### PR TITLE
Feat/test linting builds ci/cdd 568

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,6 +20,7 @@ jobs:
   ###############################################################################
 
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -49,8 +50,8 @@ jobs:
 
   unit-tests:
     name: Unit tests
-    runs-on: ubuntu-latest
     needs: [ build ]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Restore virtual environment


### PR DESCRIPTION
This PR adds a unit test build step to the CI pipeline
Also caches the venv so the CI agent does not have to recreate the project dependencies between each job.

Will follow up with a PR for the linting job