### PR TITLE
Chmod entrypoint file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ WORKDIR /code
 
 EXPOSE 8000
 
-# runs the production server
-ENTRYPOINT ["python", "manage.py"]
-CMD ["migrate", "--noinput", "&&", "python", "manage.py", "runserver", "0.0.0.0:80"]
+# Adds execution permission for the entrypoint shell script
+RUN chmod +x entrypoint.sh
+
+# Runs the production server
+ENTRYPOINT ./entrypoint.sh

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+function set_up_django() {
+    echo "Migrating tables"
+    python manage.py migrate --noinput
+
+    echo "Starting server"
+    python manage.py runserver 0.0.0.0:80
+}
+
+set_up_django


### PR DESCRIPTION
For now chmod the entrypoint shell script and pass to the entrypoint.
I think another way of doing this might be something like:

```
COPY entrypoint.sh /code
ENTRYPOINT ["docker-entrypoint.sh"]
```

Instead of chmoding, but I just wanna get this in so that we can draw a line in the sand for a working deployment which connects successfully to the db and migrates tables etc