### PR TITLE
Add rough clean up to remove the image file from disk

### DIFF
--- a/metrics/api/views.py
+++ b/metrics/api/views.py
@@ -1,3 +1,4 @@
+import os
 from http import HTTPStatus
 
 from django.http import FileResponse
@@ -70,8 +71,16 @@ class ChartView(APIView):
         except ChartNotSupportedError:
             return Response(status=HTTPStatus.NOT_FOUND)
 
+        return self._return_image(filename=filename)
+
+    @staticmethod
+    def _return_image(filename: str) -> FileResponse:
         image = open(filename, "rb")
-        return FileResponse(image)
+        response = FileResponse(image)
+
+        os.remove(filename)
+
+        return response
 
 
 class FileUploadView(APIView):


### PR DESCRIPTION
Cleans the filesystem of the rendered image before responding so the filesystem isn't left a cluttered mess.
Ideally we should be passing the file around in a file stream but I couldn't quite get it to play ball with plotly so I'm gonna move on for now and write a follow up ticket to do this properly