### PR TITLE
Feat/deprecate existing stats endpoint/cdd 692

### DIFF
--- a/metrics/api/viewsets.py
+++ b/metrics/api/viewsets.py
@@ -83,4 +83,4 @@ class DashboardViewSet(viewsets.GenericViewSet):
     @extend_schema(deprecated=True)
     def retrieve(self, request, *args, **kwargs):
         data = self.get_queryset()
-        return response.Response(data)
+        return response.Response(data, headers=DEPRECATION_HEADERS_STATS)


### PR DESCRIPTION
# Description

Deprecates the existing stats endpoint ahead of migration to headlines/v2 & trends/v2.
Note that this PR does not remove the exist stats endpoint

Fixes #CDD-692

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

