### PR TITLE
Update example home page response with new `Heading` block

### DIFF
--- a/cms/dashboard/templates/cms_starting_pages/respiratory_viruses.json
+++ b/cms/dashboard/templates/cms_starting_pages/respiratory_viruses.json
@@ -1,4 +1,25 @@
 {
+    "id": 6,
+    "meta": {
+        "type": "home.HomePage",
+        "detail_url": "http://localhost/api/pages/6/",
+        "html_url": null,
+        "slug": "respiratory-viruses",
+        "show_in_menus": false,
+        "seo_title": "",
+        "search_description": "",
+        "first_published_at": "2023-04-26T11:39:38.064114Z",
+        "alias_of": null,
+        "parent": {
+            "id": 2,
+            "meta": {
+                "type": "wagtailcore.Page",
+                "detail_url": "http://localhost/api/pages/2/",
+                "html_url": null
+            },
+            "title": "Welcome to your new Wagtail site!"
+        }
+    },
     "title": "Respiratory viruses",
     "body": [
         {
@@ -9,9 +30,14 @@
             "id": "cc2d5c0c-97a3-45a0-83cc-d21b1ba7e06c"
         },
         {
+            "type": "heading",
+            "value": {"body": "Coronavirus"},
+            "id": "d4deebbc-fb31-4051-baba-0b3c3b5be46c"
+        },
+        {
             "type": "text",
             "value": {
-                "body": "<h2 data-block-key=\"cl294\">Coronavirus</h2><p data-block-key=\"bf348\">The UKHSA dashboard for data and insights on coronavirus.</p>"
+                "body": "<p data-block-key=\"cl294\">The UKHSA dashboard for data and insights on coronavirus.</p>"
             },
             "id": "b1f3d7ab-3c43-492c-8dab-c65a76a7a867"
         },
@@ -197,9 +223,14 @@
             "id": "b3bebde7-538d-4ba1-a568-c28ac1c33a63"
         },
         {
+            "type": "heading",
+            "value": {"body": "Influenza"},
+            "id": "45c82cac-1f13-4730-bdfe-6e5baac48564"
+        },
+        {
             "type": "text",
             "value": {
-                "body": "<h2 data-block-key=\"aie95\">Influenza</h2><p data-block-key=\"19u5\">The UKHSA dashboard for data and insights on influenza.</p>"
+                "body": "<p data-block-key=\"aie95\">The UKHSA dashboard for data and insights on influenza.</p>"
             },
             "id": "34e6806e-eb04-49e9-8db2-0733b8203397"
         },
@@ -313,5 +344,5 @@
         }
     ],
     "related_links": [],
-    "last_published_at": "2023-04-24T09:37:35.021114Z"
+    "last_published_at": "2023-04-28T08:11:30.295417Z"
 }


### PR DESCRIPTION
# Description

This PR updates the example home page response to reflect the current design with the new `Heading` block.
Note that `Text` blocks will no longer support `h2` or `h3`, just bold, italic, lists and links.
This PR is just for the example response, the actual change will be implemented by https://github.com/UKHSA-Internal/winter-pressures-api/pull/90

Fixes #CDD-675

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

