### PR TITLE
Implement sections layer with page description field on example home page response

### DIFF
--- a/cms/dashboard/templates/cms_starting_pages/respiratory_viruses.json
+++ b/cms/dashboard/templates/cms_starting_pages/respiratory_viruses.json
@@ -23,326 +23,282 @@
     "title": "Respiratory viruses",
     "body": [
         {
-            "type": "text",
+            "type": "section",
             "value": {
-                "body": "<p data-block-key=\"cl294\">Data and insights from the UKHSA on respiratory viruses. See the <a href=\"https://duckduckgo.com/?t=ffab&amp;q=puppies&amp;atb=v348-1&amp;iax=images&amp;ia=images\">simple summary for England (opens in new tab)</a></p>"
-            },
-            "id": "cc2d5c0c-97a3-45a0-83cc-d21b1ba7e06c"
-        },
-        {
-            "type": "heading",
-            "value": {"body": "Coronavirus"},
-            "id": "d4deebbc-fb31-4051-baba-0b3c3b5be46c"
-        },
-        {
-            "type": "text",
-            "value": {
-                "body": "<p data-block-key=\"cl294\">The UKHSA dashboard for data and insights on coronavirus.</p>"
-            },
-            "id": "b1f3d7ab-3c43-492c-8dab-c65a76a7a867"
-        },
-        {
-            "type": "headline_numbers_row_card",
-            "value": {
-                "columns": [
+                "heading": "Coronavirus",
+                "content": [
                     {
-                        "type": "headline_and_trend_component",
+                        "type": "text",
+                        "value": {
+                            "body": "<p data-block-key=\"sj74x\">The UKHSA dashboard for data and insights on coronavirus.</p>"
+                        },
+                        "id": "659d7fca-2449-4c0a-b40f-b5cd27e2be9f"
+                    },
+                    {
+                        "type": "headline_numbers_row_card",
+                        "value": {
+                            "columns": [
+                                {
+                                    "type": "headline_and_trend_component",
+                                    "value": {
+                                        "title": "Cases",
+                                        "headline_number": {
+                                            "topic": "COVID-19",
+                                            "metric": "new_cases_7days_sum",
+                                            "body": "Weekly"
+                                        },
+                                        "trend_number": {
+                                            "topic": "COVID-19",
+                                            "metric": "new_cases_7days_change",
+                                            "body": "Last 7 days",
+                                            "percentage_metric": "new_cases_7days_change_percentage"
+                                        }
+                                    },
+                                    "id": "e64cc7ea-4551-47f0-b964-941d59cae1bb"
+                                },
+                                {
+                                    "type": "headline_and_trend_component",
+                                    "value": {
+                                        "title": "Deaths",
+                                        "headline_number": {
+                                            "topic": "COVID-19",
+                                            "metric": "new_deaths_7days_sum",
+                                            "body": "Weekly"
+                                        },
+                                        "trend_number": {
+                                            "topic": "COVID-19",
+                                            "metric": "new_deaths_7days_change",
+                                            "body": "Last 7 days",
+                                            "percentage_metric": "new_deaths_7days_change_percentage"
+                                        }
+                                    },
+                                    "id": "fcfcf83f-f2a6-407c-a1f4-6c5978b472f5"
+                                },
+                                {
+                                    "type": "headline_and_trend_component",
+                                    "value": {
+                                        "title": "Healthcare",
+                                        "headline_number": {
+                                            "topic": "COVID-19",
+                                            "metric": "new_admissions_7days",
+                                            "body": "Patients admitted"
+                                        },
+                                        "trend_number": {
+                                            "topic": "COVID-19",
+                                            "metric": "new_admissions_7days_change",
+                                            "body": "Last 7 days",
+                                            "percentage_metric": "new_admissions_7days_change_percentage"
+                                        }
+                                    },
+                                    "id": "0a351331-a1ca-4c16-8c6e-5d8a0b38fd3f"
+                                },
+                                {
+                                    "type": "dual_headline_component",
+                                    "value": {
+                                        "title": "Testing",
+                                        "top_headline_number": {
+                                            "topic": "COVID-19",
+                                            "metric": "latest_total_vaccinations_autumn22",
+                                            "body": "Autumn booster"
+                                        },
+                                        "bottom_headline_number": {
+                                            "topic": "COVID-19",
+                                            "metric": "latest_vaccinations_uptake_autumn22",
+                                            "body": "Percentage uptake (%)"
+                                        }
+                                    },
+                                    "id": "bb8a9a19-ff0e-4e99-b570-b058e9cdb5a1"
+                                },
+                                {
+                                    "type": "single_headline_component",
+                                    "value": {
+                                        "title": "Testing",
+                                        "headline_number": {
+                                            "topic": "COVID-19",
+                                            "metric": "positivity_7days_latest",
+                                            "body": "Virus tests positivity (%)"
+                                        }
+                                    },
+                                    "id": "4e9d5ead-5394-42cb-b370-e0d0f028140d"
+                                }
+                            ]
+                        },
+                        "id": "e285caf4-ae79-4c76-bcb7-426d6e66cb8a"
+                    },
+                    {
+                        "type": "chart_with_headline_and_trend_card",
                         "value": {
                             "title": "Cases",
-                            "headline_number": {
-                                "topic": "COVID-19",
-                                "metric": "new_cases_7days_sum",
-                                "body": "Weekly"
-                            },
-                            "trend_number": {
-                                "topic": "COVID-19",
-                                "metric": "new_cases_7days_change",
-                                "body": "Last 7 days",
-                                "percentage_metric": "new_cases_7days_change_percentage"
-                            }
+                            "body": "Positive tests reported in England",
+                            "chart": [
+                                {
+                                    "type": "plot",
+                                    "value": {
+                                        "topic": "COVID-19",
+                                        "metric": "new_cases_daily",
+                                        "chart_type": "line_with_shaded_section",
+                                        "date_from": null,
+                                        "date_to": null,
+                                        "stratum": "",
+                                        "geography": "",
+                                        "geography_type": ""
+                                    },
+                                    "id": "43d5015f-e21e-4367-93af-7f236fa07bd1"
+                                }
+                            ],
+                            "headline_number_columns": [
+                                {
+                                    "type": "headline_number",
+                                    "value": {
+                                        "topic": "COVID-19",
+                                        "metric": "new_cases_7days_sum",
+                                        "body": "Last 7 days"
+                                    },
+                                    "id": "70494f3c-13bf-4daa-9ae3-199198776edf"
+                                },
+                                {
+                                    "type": "trend_number",
+                                    "value": {
+                                        "topic": "COVID-19",
+                                        "metric": "new_cases_7days_change",
+                                        "body": "",
+                                        "percentage_metric": "new_cases_7days_change_percentage"
+                                    },
+                                    "id": "c720f9fb-6ec6-4038-84f3-8b5dae7979dc"
+                                }
+                            ]
                         },
-                        "id": "72a1b90c-5f73-4a67-a6bc-9385b3746ce0"
-                    },
+                        "id": "d8514c8c-eb79-4c53-9b39-f7eaa02c3f81"
+                    }
+                ]
+            },
+            "id": "1f53f495-e8d1-45a3-bd34-5d27878c20fc"
+        },
+        {
+            "type": "section",
+            "value": {
+                "heading": "Influenza",
+                "content": [
                     {
-                        "type": "headline_and_trend_component",
+                        "type": "text",
                         "value": {
-                            "title": "Deaths",
-                            "headline_number": {
-                                "topic": "COVID-19",
-                                "metric": "new_deaths_7days_sum",
-                                "body": "Weekly"
-                            },
-                            "trend_number": {
-                                "topic": "COVID-19",
-                                "metric": "new_deaths_7days_change",
-                                "body": "Last 7 days",
-                                "percentage_metric": "new_deaths_7days_change_percentage"
-                            }
+                            "body": "<p data-block-key=\"1mmwg\">The UKHSA dashboard for data and insights on Influenza.</p>"
                         },
-                        "id": "19639378-5280-4c28-95d8-17390618367c"
+                        "id": "dbbafc78-be9f-4c94-8b54-fb99be093fc4"
                     },
                     {
-                        "type": "headline_and_trend_component",
+                        "type": "headline_numbers_row_card",
+                        "value": {
+                            "columns": [
+                                {
+                                    "type": "headline_and_trend_component",
+                                    "value": {
+                                        "title": "Healthcare",
+                                        "headline_number": {
+                                            "topic": "Influenza",
+                                            "metric": "weekly_hospital_admissions_rate_latest",
+                                            "body": "Hospital admission rate (per 100,000)"
+                                        },
+                                        "trend_number": {
+                                            "topic": "Influenza",
+                                            "metric": "weekly_hospital_admissions_rate_change",
+                                            "body": "Last 7 days",
+                                            "percentage_metric": "weekly_hospital_admissions_rate_change_percentage"
+                                        }
+                                    },
+                                    "id": "1eb03393-1b30-46a8-8c19-8b86aa056b34"
+                                },
+                                {
+                                    "type": "single_headline_component",
+                                    "value": {
+                                        "title": "Testing",
+                                        "headline_number": {
+                                            "topic": "Influenza",
+                                            "metric": "weekly_positivity_latest",
+                                            "body": "Virus tests positivity (%)"
+                                        }
+                                    },
+                                    "id": "8d79205b-df67-4dc1-91ae-8198dfb2155f"
+                                }
+                            ]
+                        },
+                        "id": "06e1f087-dc2c-42ea-873f-0b1fb1f1b12e"
+                    },
+                    {
+                        "type": "chart_with_headline_and_trend_card",
                         "value": {
                             "title": "Healthcare",
-                            "headline_number": {
-                                "topic": "COVID-19",
-                                "metric": "new_admissions_7days",
-                                "body": "Patients admitted"
-                            },
-                            "trend_number": {
-                                "topic": "COVID-19",
-                                "metric": "new_admissions_7days_change",
-                                "body": "Last 7 days",
-                                "percentage_metric": "new_admissions_7days_change_percentage"
-                            }
+                            "body": "Weekly hospital admission rates for Influenza",
+                            "chart": [
+                                {
+                                    "type": "plot",
+                                    "value": {
+                                        "topic": "Influenza",
+                                        "metric": "weekly_hospital_admissions_rate",
+                                        "chart_type": "line_with_shaded_section",
+                                        "date_from": null,
+                                        "date_to": null,
+                                        "stratum": "",
+                                        "geography": "",
+                                        "geography_type": ""
+                                    },
+                                    "id": "224ff3b0-e94e-4562-9277-5b9ade924e8c"
+                                }
+                            ],
+                            "headline_number_columns": [
+                                {
+                                    "type": "headline_number",
+                                    "value": {
+                                        "topic": "Influenza",
+                                        "metric": "weekly_positivity_latest",
+                                        "body": "Last 7 days"
+                                    },
+                                    "id": "f317523e-cbf0-4515-ae48-f126385e088a"
+                                },
+                                {
+                                    "type": "trend_number",
+                                    "value": {
+                                        "topic": "Influenza",
+                                        "metric": "weekly_hospital_admissions_rate_change",
+                                        "body": "",
+                                        "percentage_metric": "weekly_hospital_admissions_rate_change_percentage"
+                                    },
+                                    "id": "06e66df0-d9e6-43dd-ace7-41c4a0037c04"
+                                }
+                            ]
                         },
-                        "id": "c124e3ba-f12d-418b-8db9-066274b92fc2"
+                        "id": "9d29b644-3508-447e-b573-fdc835bcc41e"
                     },
                     {
-                        "type": "dual_headline_component",
-                        "value": {
-                            "title": "Vaccines",
-                            "top_headline_number": {
-                                "topic": "COVID-19",
-                                "metric": "latest_total_vaccinations_autumn22",
-                                "body": "Autumn booster"
-                            },
-                            "bottom_headline_number": {
-                                "topic": "COVID-19",
-                                "metric": "latest_vaccinations_uptake_autumn22",
-                                "body": "Percentage uptake (%)"
-                            }
-                        },
-                        "id": "aea30c9d-5ddd-417a-81e5-04f5048956c9"
-                    },
-                    {
-                        "type": "single_headline_component",
+                        "type": "chart_with_headline_and_trend_card",
                         "value": {
                             "title": "Testing",
-                            "headline_number": {
-                                "topic": "COVID-19",
-                                "metric": "positivity_7days_latest",
-                                "body": "Virus tests positivity (%)"
-                            }
+                            "body": "Weekly positivity",
+                            "chart": [
+                                {
+                                    "type": "plot",
+                                    "value": {
+                                        "topic": "Influenza",
+                                        "metric": "weekly_positivity",
+                                        "chart_type": "line_with_shaded_section",
+                                        "date_from": null,
+                                        "date_to": null,
+                                        "stratum": "",
+                                        "geography": "",
+                                        "geography_type": ""
+                                    },
+                                    "id": "2dbd538c-e57a-4274-b6a9-262ceccd0b1f"
+                                }
+                            ],
+                            "headline_number_columns": []
                         },
-                        "id": "d38fd53c-3513-4420-8d52-5bcd5c828443"
+                        "id": "0464ceb7-59df-457b-8f96-8a4de924e97c"
                     }
                 ]
             },
-            "id": "85218cfd-b975-40dc-bcaf-5f79d8f6f60f"
-        },
-        {
-            "type": "chart_with_headline_and_trend_card",
-            "value": {
-                "title": "Cases",
-                "body": "Positive tests reported in England",
-                "chart": [
-                    {
-                        "type": "plot",
-                        "value": {
-                            "topic": "COVID-19",
-                            "metric": "new_cases_daily",
-                            "chart_type": "line_with_shaded_section",
-                            "date_from": null,
-                            "date_to": null,
-                            "stratum": "",
-                            "geography": "",
-                            "geography_type": ""
-                        },
-                        "id": "74c93e38-e73f-4110-9a28-ef2ab8bcb52f"
-                    }
-                ],
-                "headline_number_columns": [
-                    {
-                        "type": "headline_number",
-                        "value": {
-                            "topic": "COVID-19",
-                            "metric": "new_admissions_7days",
-                            "body": "Last 7 days"
-                        },
-                        "id": "5d63adc9-f0b9-4b8b-8380-ee863daa533a"
-                    },
-                    {
-                        "type": "trend_number",
-                        "value": {
-                            "topic": "COVID-19",
-                            "metric": "new_admissions_7days_change",
-                            "body": "",
-                            "percentage_metric": "new_admissions_7days_change_percentage"
-                        },
-                        "id": "18406a2d-52fb-48a1-a9ee-5420dffb238a"
-                    }
-                ]
-            },
-            "id": "36418bc1-35fe-46e2-b38f-ebe9a9582f43"
-        },
-        {
-            "type": "chart_with_headline_and_trend_card",
-            "value": {
-                "title": "Deaths",
-                "body": "Deaths with COVID-19 on the death certificate in England",
-                "chart": [
-                    {
-                        "type": "plot",
-                        "value": {
-                            "topic": "COVID-19",
-                            "metric": "new_deaths_daily",
-                            "chart_type": "line_with_shaded_section",
-                            "date_from": null,
-                            "date_to": null,
-                            "stratum": "",
-                            "geography": "",
-                            "geography_type": ""
-                        },
-                        "id": "76482012-851e-44f0-b2f6-9af017b68968"
-                    }
-                ],
-                "headline_number_columns": [
-                    {
-                        "type": "headline_number",
-                        "value": {
-                            "topic": "COVID-19",
-                            "metric": "new_deaths_7days_sum",
-                            "body": "Last 7 days"
-                        },
-                        "id": "4f28c86d-9f72-44bb-900b-c14c5d6bc396"
-                    },
-                    {
-                        "type": "trend_number",
-                        "value": {
-                            "topic": "COVID-19",
-                            "metric": "new_deaths_7days_change",
-                            "body": "",
-                            "percentage_metric": "new_deaths_7days_change_percentage"
-                        },
-                        "id": "4a44ea30-d778-4ed4-bba0-fb506f5dc1dd"
-                    }
-                ]
-            },
-            "id": "b3bebde7-538d-4ba1-a568-c28ac1c33a63"
-        },
-        {
-            "type": "heading",
-            "value": {"body": "Influenza"},
-            "id": "45c82cac-1f13-4730-bdfe-6e5baac48564"
-        },
-        {
-            "type": "text",
-            "value": {
-                "body": "<p data-block-key=\"aie95\">The UKHSA dashboard for data and insights on influenza.</p>"
-            },
-            "id": "34e6806e-eb04-49e9-8db2-0733b8203397"
-        },
-        {
-            "type": "headline_numbers_row_card",
-            "value": {
-                "columns": [
-                    {
-                        "type": "headline_and_trend_component",
-                        "value": {
-                            "title": "Healthcare",
-                            "headline_number": {
-                                "topic": "Influenza",
-                                "metric": "weekly_hospital_admissions_rate_latest",
-                                "body": "Hospital admission rate (per 100,000)"
-                            },
-                            "trend_number": {
-                                "topic": "COVID-19",
-                                "metric": "weekly_hospital_admissions_rate_change",
-                                "body": "Last 7 days",
-                                "percentage_metric": "weekly_hospital_admissions_rate_change_percentage"
-                            }
-                        },
-                        "id": "cdde1370-9c46-4604-91b4-3dd58932bc2c"
-                    },
-                    {
-                        "type": "single_headline_component",
-                        "value": {
-                            "title": "Testing",
-                            "headline_number": {
-                                "topic": "Influenza",
-                                "metric": "weekly_positivity_latest",
-                                "body": "Virus tests positivity (%)"
-                            }
-                        },
-                        "id": "2f824c50-52a1-4827-818f-761e0ceb086c"
-                    }
-                ]
-            },
-            "id": "d90051ed-a9ad-4c33-867b-44b8447cdf3c"
-        },
-        {
-            "type": "chart_with_headline_and_trend_card",
-            "value": {
-                "title": "Healthcare",
-                "body": "Weekly hospital admission rates for Influenza",
-                "chart": [
-                    {
-                        "type": "plot",
-                        "value": {
-                            "topic": "Influenza",
-                            "metric": "weekly_hospital_admissions_rate",
-                            "chart_type": "line_with_shaded_section",
-                            "date_from": null,
-                            "date_to": null,
-                            "stratum": "",
-                            "geography": "",
-                            "geography_type": ""
-                        },
-                        "id": "dfaa61af-4e54-4d46-8d02-babedfcf4176"
-                    }
-                ],
-                "headline_number_columns": [
-                    {
-                        "type": "headline_number",
-                        "value": {
-                            "topic": "Influenza",
-                            "metric": "weekly_hospital_admissions_rate_latest",
-                            "body": "Last 7 days"
-                        },
-                        "id": "1c7e2b15-40e6-4630-9eb8-cefa5732cfc7"
-                    },
-                    {
-                        "type": "trend_number",
-                        "value": {
-                            "topic": "Influenza",
-                            "metric": "weekly_hospital_admissions_rate_change",
-                            "body": "",
-                            "percentage_metric": "weekly_hospital_admissions_rate_change_percentage"
-                        },
-                        "id": "601053ba-9dd1-4111-8e15-17a7335c6279"
-                    }
-                ]
-            },
-            "id": "4c08dee0-6a37-4602-9c54-990efe347e49"
-        },
-        {
-            "type": "chart_with_headline_and_trend_card",
-            "value": {
-                "title": "Testing",
-                "body": "Weekly positivity",
-                "chart": [
-                    {
-                        "type": "plot",
-                        "value": {
-                            "topic": "Influenza",
-                            "metric": "weekly_positivity_latest",
-                            "chart_type": "line_with_shaded_section",
-                            "date_from": null,
-                            "date_to": null,
-                            "stratum": "",
-                            "geography": "",
-                            "geography_type": ""
-                        },
-                        "id": "ad5dc74a-a6b1-48e2-bafb-f07253695cc4"
-                    }
-                ],
-                "headline_number_columns": []
-            },
-            "id": "0b7a6152-dbd3-4b77-82e1-cc98cf273ba4"
+            "id": "4c03dd17-a62b-4102-a938-557c60d38d9a"
         }
     ],
     "related_links": [],
-    "last_published_at": "2023-04-28T08:11:30.295417Z"
+    "last_published_at": "2023-04-28T11:03:59.670621Z"
 }


### PR DESCRIPTION
# Description

This PR updates the example home page response to reflect the current design with the section layers.
This PR is just for the example response, the actual change will be implemented by https://github.com/UKHSA-Internal/winter-pressures-api/pull/90

Fixes #CDD-675

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

