### PR TITLE
Update example home page response with nested `chart_row_card` -> `chart_card` or `chart_with_headline_and_trend_card` types

### DIFF
--- a/cms/dashboard/templates/cms_starting_pages/respiratory_viruses.json
+++ b/cms/dashboard/templates/cms_starting_pages/respiratory_viruses.json
@@ -126,94 +126,102 @@
                         "id": "e285caf4-ae79-4c76-bcb7-426d6e66cb8a"
                     },
                     {
-                        "type": "chart_with_headline_and_trend_card",
+                        "type": "chart_row_card",
                         "value": {
-                            "title": "Cases",
-                            "body": "Positive tests reported in England",
-                            "chart": [
+                            "columns": [
                                 {
-                                    "type": "plot",
+                                    "type": "chart_with_headline_and_trend_card",
                                     "value": {
-                                        "topic": "COVID-19",
-                                        "metric": "new_cases_daily",
-                                        "chart_type": "line_with_shaded_section",
-                                        "date_from": null,
-                                        "date_to": null,
-                                        "stratum": "",
-                                        "geography": "",
-                                        "geography_type": ""
+                                        "title": "Cases",
+                                        "body": "Positive tests reported in England",
+                                        "chart": [
+                                            {
+                                                "type": "plot",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "new_cases_daily",
+                                                    "chart_type": "line_with_shaded_section",
+                                                    "date_from": null,
+                                                    "date_to": null,
+                                                    "stratum": "",
+                                                    "geography": "",
+                                                    "geography_type": ""
+                                                },
+                                                "id": "b0ead98b-4102-48f6-b94e-ff7bcffe1dc4"
+                                            }
+                                        ],
+                                        "headline_number_columns": [
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "new_cases_7days_sum",
+                                                    "body": "Last 7 days"
+                                                },
+                                                "id": "95b24a05-a015-42ed-b258-51c7ccaedbcd"
+                                            },
+                                            {
+                                                "type": "trend_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "new_deaths_7days_change",
+                                                    "body": "",
+                                                    "percentage_metric": "new_cases_7days_change_percentage"
+                                                },
+                                                "id": "8c42a86e-f675-41d0-a65a-633c20ac98e3"
+                                            }
+                                        ]
                                     },
-                                    "id": "43d5015f-e21e-4367-93af-7f236fa07bd1"
-                                }
-                            ],
-                            "headline_number_columns": [
-                                {
-                                    "type": "headline_number",
-                                    "value": {
-                                        "topic": "COVID-19",
-                                        "metric": "new_cases_7days_sum",
-                                        "body": "Last 7 days"
-                                    },
-                                    "id": "70494f3c-13bf-4daa-9ae3-199198776edf"
+                                    "id": "d9b86415-9734-46be-952a-56182f0c40be"
                                 },
                                 {
-                                    "type": "trend_number",
+                                    "type": "chart_with_headline_and_trend_card",
                                     "value": {
-                                        "topic": "COVID-19",
-                                        "metric": "new_cases_7days_change",
-                                        "body": "",
-                                        "percentage_metric": "new_cases_7days_change_percentage"
+                                        "title": "Deaths",
+                                        "body": "Deaths with COVID-19 on the death certificate in England",
+                                        "chart": [
+                                            {
+                                                "type": "plot",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "new_deaths_daily",
+                                                    "chart_type": "line_with_shaded_section",
+                                                    "date_from": null,
+                                                    "date_to": null,
+                                                    "stratum": "",
+                                                    "geography": "",
+                                                    "geography_type": ""
+                                                },
+                                                "id": "d3b521d8-a6bb-4960-9db9-864c3d362976"
+                                            }
+                                        ],
+                                        "headline_number_columns": [
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "new_deaths_7days_sum",
+                                                    "body": "Last 7 days"
+                                                },
+                                                "id": "10c92d4c-bdb1-4bcc-a8a5-d0063dcee095"
+                                            },
+                                            {
+                                                "type": "trend_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "new_deaths_7days_change",
+                                                    "body": "",
+                                                    "percentage_metric": "new_deaths_7days_change_percentage"
+                                                },
+                                                "id": "41ce6c59-99fe-486a-8225-341a306cc395"
+                                            }
+                                        ]
                                     },
-                                    "id": "c720f9fb-6ec6-4038-84f3-8b5dae7979dc"
+                                    "id": "c18703a1-9b01-417f-8fd8-3e4db35865e5"
                                 }
                             ]
                         },
-                        "id": "d8514c8c-eb79-4c53-9b39-f7eaa02c3f81"
-                    },
-                    {
-                        "type": "chart_with_headline_and_trend_card",
-                        "value": {
-                            "title": "Deaths",
-                            "body": "Deaths with COVID-19 on the death certificate in England",
-                            "chart": [
-                                {
-                                    "type": "plot",
-                                    "value": {
-                                        "topic": "COVID-19",
-                                        "metric": "new_deaths_daily",
-                                        "chart_type": "line_with_shaded_section",
-                                        "date_from": null,
-                                        "date_to": null,
-                                        "stratum": "",
-                                        "geography": "",
-                                        "geography_type": ""
-                                    },
-                                    "id": "9133f732-52a7-4df7-a2e1-6973f0e8c5d7"
-                                }
-                            ],
-                            "headline_number_columns": [
-                                {
-                                    "type": "headline_number",
-                                    "value": {
-                                        "topic": "COVID-19",
-                                        "metric": "new_deaths_7days_sum",
-                                        "body": "Last 7 days"
-                                    },
-                                    "id": "9906538f-1d5b-437b-a987-e9e2084c2f51"
-                                },
-                                {
-                                    "type": "trend_number",
-                                    "value": {
-                                        "topic": "COVID-19",
-                                        "metric": "new_deaths_7days_change",
-                                        "body": "",
-                                        "percentage_metric": "new_deaths_7days_change_percentage"
-                                    },
-                                    "id": "f7f843f8-0812-4feb-99a6-fdc081db70b9"
-                                }
-                            ]
-                        },
-                        "id": "ee8e12ea-1f13-420e-b2d8-18fa4fb15a4d"
+                        "id": "a5acbd6c-f9b7-4d36-86f4-005c2d46debc"
                     }
                 ]
             },
@@ -270,74 +278,82 @@
                         "id": "06e1f087-dc2c-42ea-873f-0b1fb1f1b12e"
                     },
                     {
-                        "type": "chart_with_headline_and_trend_card",
+                        "type": "chart_row_card",
                         "value": {
-                            "title": "Healthcare",
-                            "body": "Weekly hospital admission rates for Influenza",
-                            "chart": [
+                            "columns": [
                                 {
-                                    "type": "plot",
+                                    "type": "chart_with_headline_and_trend_card",
                                     "value": {
-                                        "topic": "Influenza",
-                                        "metric": "weekly_hospital_admissions_rate",
-                                        "chart_type": "line_with_shaded_section",
-                                        "date_from": null,
-                                        "date_to": null,
-                                        "stratum": "",
-                                        "geography": "",
-                                        "geography_type": ""
+                                        "title": "Healthcare",
+                                        "body": "Weekly hospital admission rates for Influenza",
+                                        "chart": [
+                                            {
+                                                "type": "plot",
+                                                "value": {
+                                                    "topic": "Influenza",
+                                                    "metric": "weekly_hospital_admissions_rate",
+                                                    "chart_type": "bar",
+                                                    "date_from": null,
+                                                    "date_to": null,
+                                                    "stratum": "",
+                                                    "geography": "",
+                                                    "geography_type": ""
+                                                },
+                                                "id": "c7340640-85c6-4b2e-b3b3-2695576f0355"
+                                            }
+                                        ],
+                                        "headline_number_columns": [
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "Influenza",
+                                                    "metric": "weekly_hospital_admissions_rate_latest",
+                                                    "body": "Last 7 days"
+                                                },
+                                                "id": "a93d4317-3814-41ab-b6f6-a6f0769770a7"
+                                            },
+                                            {
+                                                "type": "trend_number",
+                                                "value": {
+                                                    "topic": "Influenza",
+                                                    "metric": "weekly_hospital_admissions_rate_change",
+                                                    "body": "",
+                                                    "percentage_metric": "weekly_hospital_admissions_rate_change_percentage"
+                                                },
+                                                "id": "7b860dc9-26d1-4d95-924a-c23f866a7eae"
+                                            }
+                                        ]
                                     },
-                                    "id": "224ff3b0-e94e-4562-9277-5b9ade924e8c"
-                                }
-                            ],
-                            "headline_number_columns": [
-                                {
-                                    "type": "headline_number",
-                                    "value": {
-                                        "topic": "Influenza",
-                                        "metric": "weekly_positivity_latest",
-                                        "body": "Last 7 days"
-                                    },
-                                    "id": "f317523e-cbf0-4515-ae48-f126385e088a"
+                                    "id": "60984a8a-9c76-4e86-94bc-b2a2234b6d53"
                                 },
                                 {
-                                    "type": "trend_number",
+                                    "type": "chart_with_headline_and_trend_card",
                                     "value": {
-                                        "topic": "Influenza",
-                                        "metric": "weekly_hospital_admissions_rate_change",
-                                        "body": "",
-                                        "percentage_metric": "weekly_hospital_admissions_rate_change_percentage"
+                                        "title": "Testing",
+                                        "body": "Weekly positivity",
+                                        "chart": [
+                                            {
+                                                "type": "plot",
+                                                "value": {
+                                                    "topic": "Influenza",
+                                                    "metric": "weekly_positivity_latest",
+                                                    "chart_type": "bar",
+                                                    "date_from": null,
+                                                    "date_to": null,
+                                                    "stratum": "",
+                                                    "geography": "",
+                                                    "geography_type": ""
+                                                },
+                                                "id": "f1a643ba-ff7e-4118-a0a8-366288468cb0"
+                                            }
+                                        ],
+                                        "headline_number_columns": []
                                     },
-                                    "id": "06e66df0-d9e6-43dd-ace7-41c4a0037c04"
+                                    "id": "809fc976-3332-4e6c-b902-20a5d39a7f99"
                                 }
                             ]
                         },
-                        "id": "9d29b644-3508-447e-b573-fdc835bcc41e"
-                    },
-                    {
-                        "type": "chart_with_headline_and_trend_card",
-                        "value": {
-                            "title": "Testing",
-                            "body": "Weekly positivity",
-                            "chart": [
-                                {
-                                    "type": "plot",
-                                    "value": {
-                                        "topic": "Influenza",
-                                        "metric": "weekly_positivity",
-                                        "chart_type": "line_with_shaded_section",
-                                        "date_from": null,
-                                        "date_to": null,
-                                        "stratum": "",
-                                        "geography": "",
-                                        "geography_type": ""
-                                    },
-                                    "id": "2dbd538c-e57a-4274-b6a9-262ceccd0b1f"
-                                }
-                            ],
-                            "headline_number_columns": []
-                        },
-                        "id": "0464ceb7-59df-457b-8f96-8a4de924e97c"
+                        "id": "b921e063-5b9e-4fd1-9cf3-764b24a8ae2b"
                     }
                 ]
             },
@@ -345,5 +361,5 @@
         }
     ],
     "related_links": [],
-    "last_published_at": "2023-04-28T16:18:41.910082Z"
+    "last_published_at": "2023-05-02T11:49:06.927124Z"
 }


### PR DESCRIPTION
# Description

This PR updates the example home page response to reflect the current design with the nested chart row card implemented.

This PR is just for the example response, the actual change will be implemented by https://github.com/UKHSA-Internal/winter-pressures-api/pull/90

Fixes #CDD-675

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

