### PR TITLE
Expose `page_description` field as content panel on topic models

### DIFF
--- a/cms/topic/models.py
+++ b/cms/topic/models.py
@@ -40,6 +40,7 @@ class TopicPage(Page):
     # Editor panels configuration
     content_panels = Page.content_panels + [
         FieldPanel("date_posted"),
+        FieldPanel("page_description"),
         FieldPanel("body"),
         FieldPanel("symptoms"),
         FieldPanel("transmission"),


### PR DESCRIPTION
# Description

Adds the `page_description` field as a content panel on the topic models

Fixes #CDD-<ISSUE_ID>

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

