### PR TITLE
Order `geography`, `geography_type`, `metric` & `stratum` get name type methods in descending order

### DIFF
--- a/metrics/data/managers/core_models/geography.py
+++ b/metrics/data/managers/core_models/geography.py
@@ -14,12 +14,13 @@ class GeographyQuerySet(models.QuerySet):
         """Gets all available geography names as a flat list queryset.
 
         Returns:
-            QuerySet: A queryset of the individual geography names:
+            QuerySet: A queryset of the individual geography names
+                ordered in descending ordering starting from A -> Z:
                 Examples:
                     `<GeographyQuerySet ['England', 'London']>`
 
         """
-        return self.all().values_list("name", flat=True)
+        return self.all().values_list("name", flat=True).order_by("name")
 
 
 class GeographyManager(models.Manager):
@@ -32,7 +33,8 @@ class GeographyManager(models.Manager):
         """Gets all available geography names as a flat list queryset.
 
         Returns:
-            QuerySet: A queryset of the individual geography names:
+            QuerySet: A queryset of the individual geography names
+                ordered in descending ordering starting from A -> Z:
                 Examples:
                     `<GeographyQuerySet ['England', 'London']>`
 

--- a/metrics/data/managers/core_models/geography_type.py
+++ b/metrics/data/managers/core_models/geography_type.py
@@ -14,12 +14,13 @@ class GeographyTypeQuerySet(models.QuerySet):
         """Gets all available geography_type names as a flat list queryset.
 
         Returns:
-            QuerySet: A queryset of the individual geography_type names:
+            QuerySet: A queryset of the individual geography_type names
+                ordered in descending ordering starting from A -> Z:
                 Examples:
                     `<GeographyTypeQuerySet ['Nation', 'UKHSA_Region']>`
 
         """
-        return self.all().values_list("name", flat=True)
+        return self.all().values_list("name", flat=True).order_by("name")
 
 
 class GeographyTypeManager(models.Manager):

--- a/metrics/data/managers/core_models/metric.py
+++ b/metrics/data/managers/core_models/metric.py
@@ -14,12 +14,13 @@ class MetricQuerySet(models.QuerySet):
         """Gets all available metric names as a flat list queryset.
 
         Returns:
-            QuerySet: A queryset of the individual metric names:
+            QuerySet: A queryset of the individual metric names
+                ordered in descending ordering starting from A -> Z:
                 Examples:
                     `<MetricQuerySet ['new_cases_daily', 'new_deaths_daily']>`
 
         """
-        return self.all().values_list("name", flat=True)
+        return self.all().values_list("name", flat=True).order_by("name")
 
     def is_metric_available_for_topic(self, metric_name: str, topic_name: str) -> bool:
         """Checks whether there are any metrics available for the given `metric_name` and `topic_name`
@@ -34,11 +35,12 @@ class MetricQuerySet(models.QuerySet):
         """Gets all unique metric names as a flat list queryset.
 
         Returns:
-            QuerySet: A queryset of the individual metric names without repetition:
+            QuerySet: A queryset of the individual metric names without repetition
+                ordered in descending ordering starting from A -> Z:
                 Examples:
                     `<MetricQuerySet ['new_cases_daily', 'new_deaths_daily']>`
         """
-        return self.all().values_list("name", flat=True).distinct()
+        return self.all().values_list("name", flat=True).distinct().order_by("name")
 
     def get_all_unique_change_type_names(self) -> models.QuerySet:
         """Gets all unique metric names as a flat list queryset, which contain the word `change`
@@ -72,7 +74,8 @@ class MetricManager(models.Manager):
         """Gets all available metric names as a flat list queryset.
 
         Returns:
-            QuerySet: A queryset of the individual metric names:
+            QuerySet: A queryset of the individual metric names
+                ordered in descending ordering starting from A -> Z:
                 Examples:
                     `<MetricQuerySet ['new_cases_daily', 'new_deaths_daily']>`
 
@@ -94,7 +97,8 @@ class MetricManager(models.Manager):
         """Gets all unique metric names as a flat list queryset.
 
         Returns:
-            QuerySet: A queryset of the individual metric names without repetition:
+            QuerySet: A queryset of the individual metric names without repetition
+                ordered in descending ordering starting from A -> Z:
                 Examples:
                     `<MetricQuerySet ['new_cases_daily', 'new_deaths_daily']>`
 

--- a/metrics/data/managers/core_models/stratum.py
+++ b/metrics/data/managers/core_models/stratum.py
@@ -14,12 +14,13 @@ class StratumQuerySet(models.QuerySet):
         """Gets all available stratum names as a flat list queryset.
 
         Returns:
-            QuerySet: A queryset of the individual stratum names:
+            QuerySet: A queryset of the individual stratum names
+                ordered in descending ordering starting from A -> Z:
                 Examples:
-                    `<StratumQuerySet ['default', '0_4']>`
+                    `<StratumQuerySet ['0_4', '0_5']>`
 
         """
-        return self.all().values_list("name", flat=True)
+        return self.all().values_list("name", flat=True).order_by("name")
 
 
 class StratumManager(models.Manager):
@@ -32,9 +33,10 @@ class StratumManager(models.Manager):
         """Gets all available stratum names as a flat list queryset.
 
         Returns:
-            QuerySet: A queryset of the individual stratum names:
+            QuerySet: A queryset of the individual stratum names
+                ordered in descending ordering starting from A -> Z:
                 Examples:
-                    `<StratumQuerySet ['default', '0_4']>`
+                    `<StratumQuerySet ['0_4', '0_5']>`
 
         """
         return self.get_queryset().get_all_names()


### PR DESCRIPTION
# Description

Sets an order on the returned names so that when the user clicks on the dropdown choice field

Fixes #CDD-675

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

