### PR TITLE
Return `metric_value` as number type instead of string from `tabular/` endpoint

### DIFF
--- a/metrics/api/views/tabular.py
+++ b/metrics/api/views/tabular.py
@@ -15,10 +15,12 @@ class TabularView(APIView):
     def get(self, request, *args, **kwargs):
         """This endpoint can be used to generate a summary of the chart data but in tabular format
         There are 2 mandatory URL parameters:
-        - `topic` - relates to a type of disease (eg COVID-19, Influenza)
-        - `metric` - refers to the type of metric (eg, new_cases_daily, cases_age_sex)
-        """
 
+        - `topic` - relates to a type of disease (eg COVID-19, Influenza)
+
+        - `metric` - refers to the type of metric (eg, new_cases_daily, cases_age_sex)
+
+        """
         topic: str = kwargs["topic"]
         metric_name: str = kwargs["metric"]
 

--- a/metrics/data/access/core_models.py
+++ b/metrics/data/access/core_models.py
@@ -173,6 +173,6 @@ def get_month_end_timeseries_metric_values_from_date(
             .last()
         )
 
-        monthly_data.append({"date": str(dt), "value": str(metric_value)})
+        monthly_data.append({"date": str(dt), "value": metric_value})
 
     return monthly_data


### PR DESCRIPTION
# Description

Returns the `metric_value` as number type instead of string from `tabular/` endpoint.
We'll need to get the dynamic version of this endpoint up sooner rather than later. 
I'm quite concious that this endpoint doesn't have tests around it 

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

