### PR TITLE
Remove `date_posted` field from `Topic` page responses

### DIFF
--- a/cms/dashboard/templates/cms_starting_pages/coronavirus.json
+++ b/cms/dashboard/templates/cms_starting_pages/coronavirus.json
@@ -21,7 +21,6 @@
         }
     },
     "title": "Coronavirus",
-    "date_posted": "2023-05-04",
     "body": [
         {
             "type": "section",

--- a/cms/topic/models.py
+++ b/cms/topic/models.py
@@ -50,7 +50,6 @@ class TopicPage(Page):
 
     # Sets which fields to expose on the API
     api_fields = [
-        APIField("date_posted"),
         APIField("body"),
         APIField("symptoms"),
         APIField("transmission"),


### PR DESCRIPTION
# Description

Removes `date_posted` field from `Topic` page responses.
Will follow up with a PR soon for wrapping our CMS pages endpoints in tests

Fixes #CDD-675

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

