### PR TITLE
CDD-752---Increase-font-size-of-ticks-along-axis-on-charts

### DIFF
--- a/metrics/domain/charts/bar/generation.py
+++ b/metrics/domain/charts/bar/generation.py
@@ -7,7 +7,6 @@ from metrics.domain.charts.bar import colour_scheme, type_hints
 
 TICK_FONT = type_hints.AXIS_ARGS = {
     "family": '"GDS Transport", Arial, sans-serif',
-    "size": 10,
     "color": colour_scheme.RGBAColours.DARK_BLUE_GREY.stringified,
 }
 
@@ -19,6 +18,7 @@ X_AXIS_ARGS: type_hints.AXIS_ARGS = {
     "ticks": "outside",
     "tickson": "boundaries",
     "type": "date",
+    "dtick": "M1",
     "tickformat": "%b %Y",
     "tickfont": TICK_FONT,
 }

--- a/metrics/domain/charts/line_with_shaded_section/generation.py
+++ b/metrics/domain/charts/line_with_shaded_section/generation.py
@@ -17,7 +17,6 @@ X_AXIS_ARGS: type_hints.AXIS_ARGS = {
     "tickformat": "%b %Y",
     "tickfont": {
         "family": '"GDS Transport", Arial, sans-serif',
-        "size": 10,
         "color": colour_scheme.RGBAColours.DARK_BLUE_GREY.stringified,
     },
 }

--- a/tests/integration/metrics/domain/charts/bar/test_generation.py
+++ b/tests/integration/metrics/domain/charts/bar/test_generation.py
@@ -90,6 +90,10 @@ class TestBarCharts:
         assert x_axis.ticks == "outside"
         assert x_axis.tickson == "boundaries"
 
+        # The `M1` dtick setting ensures x values within the same month do not show repeated months:
+        # ___Sep___Oct___Nov___  as opposed to _Sep_Sep_Oct_Oct_Oct_Nov_Nov_
+        assert x_axis.dtick == "M1"
+
         # The x-axis ticks should be formatted as shorthand Months only i.e Sep not September
         assert x_axis.type == "date"
         assert x_axis.tickformat == "%b %Y"


### PR DESCRIPTION
# Description

The tick label font size on a couple of the charts was too small. Also changed the bar chart so it displayed a tick value for each month. Previously we let Plotly decide what to do

Fixes #[CDD-752](https://digitaltools.phe.org.uk/browse/CDD-752)

## Type of change

Please select the options that are relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added unit and integration tests at the right level to prove my change is effective
- [X] New and existing unit tests pass locally with my changes
- [X] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [X] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

