### PR TITLE
Use `Arial` font across all charts which display text elements

### DIFF
--- a/metrics/domain/charts/bar/generation.py
+++ b/metrics/domain/charts/bar/generation.py
@@ -6,7 +6,7 @@ import plotly.graph_objects
 from metrics.domain.charts.bar import colour_scheme, type_hints
 
 TICK_FONT = type_hints.AXIS_ARGS = {
-    "family": '"GDS Transport", Arial, sans-serif',
+    "family": "Arial",
     "color": colour_scheme.RGBAColours.DARK_BLUE_GREY.stringified,
 }
 

--- a/metrics/domain/charts/line_multi_coloured/generation.py
+++ b/metrics/domain/charts/line_multi_coloured/generation.py
@@ -16,7 +16,7 @@ X_AXIS_ARGS = {
     "dtick": "M1",
     "tickformat": "%b %Y",
     "tickfont": {
-        "family": '"GDS Transport", Arial, sans-serif',
+        "family": "Arial",
         "color": colour_scheme.RGBAColours.BLACK.stringified,
     },
 }

--- a/metrics/domain/charts/line_with_shaded_section/generation.py
+++ b/metrics/domain/charts/line_with_shaded_section/generation.py
@@ -16,7 +16,7 @@ X_AXIS_ARGS: type_hints.AXIS_ARGS = {
     "dtick": "M1",
     "tickformat": "%b %Y",
     "tickfont": {
-        "family": '"GDS Transport", Arial, sans-serif',
+        "family": "Arial",
         "color": colour_scheme.RGBAColours.DARK_BLUE_GREY.stringified,
     },
 }


### PR DESCRIPTION
# Description

I couldn’t get plotly to load the custom GDS font annoyingly.
So this PR sets the font to Arial. 
I’ve written up a tech debt ticket to tackle this properly and use the custom GDS font.

Fixes #CDD-778

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

