### PR TITLE
Reset `DEBUG` to True whilst static file bug is being resolved

### DIFF
--- a/metrics/api/settings.py
+++ b/metrics/api/settings.py
@@ -24,7 +24,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "django-insecure-c*9tu36z0@z70&x9+(phl(h@5u1epyogm!4%6j-aj+gi3a5-1y"
 
-DEBUG = False
+DEBUG = True
 
 ALLOWED_HOSTS = ["*"]
 


### PR DESCRIPTION
# Description

This was super weird. Django can't collect the wagtail admin static files when `DEBUG=False`.
When `DEBUG=True` this was not a problem.
Obviously, Django collects those static files when `DEBUG=False` because it needs them to display fallback pages instead of Django's debug failure page.

Looks like a similar issue to https://github.com/wagtail/wagtail/issues/5717

For now, this PR sets `DEBUG=True` so we can unblock the dev environment.

Fixes #CDD-787

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

