### PR TITLE
Remove 2nd plot on `new_cases_rolling_rate` chart

### DIFF
--- a/cms/dashboard/templates/cms_starting_pages/coronavirus.json
+++ b/cms/dashboard/templates/cms_starting_pages/coronavirus.json
@@ -323,8 +323,8 @@
                                                     "geography": "",
                                                     "geography_type": "",
                                                     "label": "",
-                                                    "line_colour": "",
-                                                    "line_type": ""
+                                                    "line_colour": "BLUE",
+                                                    "line_type": "SOLID"
                                                 },
                                                 "id": "e5830390-1928-4097-9894-b8c5621cfab7"
                                             }


### PR DESCRIPTION
# Description

Remove 2nd plot on `new_cases_rolling_rate` chart on the covid-page

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

