### PR TITLE
Add API key in front of endpoints temporarily

### DIFF
--- a/metrics/public_api/views.py
+++ b/metrics/public_api/views.py
@@ -5,6 +5,7 @@ from rest_framework import generics
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
+from rest_framework_api_key.permissions import HasAPIKey
 
 from metrics.data.models.api_models import APITimeSeries
 from metrics.public_api.serializers.api_time_series_request_serializer import (
@@ -53,6 +54,7 @@ class ThemeListView(BaseNestedAPITimeSeriesView):
     A `theme` is the largest topical subgroup e.g. **infectious_disease**.
     """
 
+    permission_classes = [HasAPIKey]
     lookup_field = "theme"
     serializer_class = ThemeListSerializer
 
@@ -65,6 +67,7 @@ class ThemeDetailView(BaseNestedAPITimeSeriesView):
     In this case, the next step in the data hierarchy is **sub_themes**.
     """
 
+    permission_classes = [HasAPIKey]
     lookup_field = "theme"
     serializer_class = ThemeDetailSerializer
 
@@ -78,6 +81,7 @@ class SubThemeListView(BaseNestedAPITimeSeriesView):
     A `sub_theme` is a topical subgroup  e.g. **respiratory**
     """
 
+    permission_classes = [HasAPIKey]
     lookup_field = "sub_theme"
     serializer_class = SubThemeListSerializer
 
@@ -90,6 +94,7 @@ class SubThemeDetailView(BaseNestedAPITimeSeriesView):
     In this case, the next step in the data hierarchy is **topics**.
     """
 
+    permission_classes = [HasAPIKey]
     lookup_field = "sub_theme"
     serializer_class = SubThemeDetailSerializer
 

--- a/tests/integration/metrics/public_api/views/test_api.py
+++ b/tests/integration/metrics/public_api/views/test_api.py
@@ -30,7 +30,9 @@ class TestPublicAPINestedLinkViews:
         )
 
     @pytest.mark.django_db
-    def test_returns_correct_response_for_theme_list_view(self, client: APIClient):
+    def test_returns_correct_response_for_theme_list_view(
+        self, authenticated_api_client: APIClient
+    ):
         """
         Given a valid request
         When the `GET /api/public/timeseries/themes/` endpoint is hit
@@ -42,7 +44,7 @@ class TestPublicAPINestedLinkViews:
         self._setup_api_time_series(theme=theme_value)
 
         # When
-        response: Response = client.get(path=self.path, format="json")
+        response: Response = authenticated_api_client.get(path=self.path, format="json")
 
         # Then
         assert response.status_code == HTTPStatus.OK
@@ -54,7 +56,9 @@ class TestPublicAPINestedLinkViews:
         assert response_data[0]["link"] == expected_theme_link
 
     @pytest.mark.django_db
-    def test_returns_correct_response_for_theme_detail_view(self, client: APIClient):
+    def test_returns_correct_response_for_theme_detail_view(
+        self, authenticated_api_client: APIClient
+    ):
         """
         Given a valid request
         When the `GET /api/public/timeseries/themes/{theme}` endpoint is hit
@@ -67,7 +71,7 @@ class TestPublicAPINestedLinkViews:
         self._setup_api_time_series(theme=theme_value)
 
         # When
-        response: Response = client.get(path=path, format="json")
+        response: Response = authenticated_api_client.get(path=path, format="json")
 
         # Then
         assert response.status_code == HTTPStatus.OK
@@ -81,7 +85,9 @@ class TestPublicAPINestedLinkViews:
         assert response_data[0]["sub_themes"] == expected_sub_themes_link
 
     @pytest.mark.django_db
-    def test_returns_correct_response_for_sub_theme_list_view(self, client: APIClient):
+    def test_returns_correct_response_for_sub_theme_list_view(
+        self, authenticated_api_client: APIClient
+    ):
         """
         Given a valid request
         When the `GET /api/public/timeseries/themes/{theme}/sub_themes` endpoint is hit
@@ -95,7 +101,7 @@ class TestPublicAPINestedLinkViews:
         path = f"{self.path}{theme_value}/sub_themes/"
 
         # When
-        response: Response = client.get(path=path, format="json")
+        response: Response = authenticated_api_client.get(path=path, format="json")
 
         # Then
         assert response.status_code == HTTPStatus.OK


### PR DESCRIPTION
# Description

Adds an API key temporarily in front of the public API whilst it's still in development

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

