### PR TITLE
Add tags to cms and public API endpoints to group them seperately in API docs

### DIFF
--- a/cms/dashboard/viewsets.py
+++ b/cms/dashboard/viewsets.py
@@ -1,6 +1,8 @@
+from drf_spectacular.utils import extend_schema
 from rest_framework_api_key.permissions import HasAPIKey
 from wagtail.api.v2.views import PagesAPIViewSet
 
 
+@extend_schema(tags=["cms"])
 class CMSPagesAPIViewSet(PagesAPIViewSet):
     permission_classes = [HasAPIKey]

--- a/metrics/public_api/views.py
+++ b/metrics/public_api/views.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from django.views.decorators.http import require_http_methods
+from drf_spectacular.utils import extend_schema
 from rest_framework import generics
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
@@ -19,6 +20,8 @@ from metrics.public_api.serializers.linked_serializers import (
     ThemeListSerializer,
 )
 
+PUBLIC_API_TAG = "public-api"
+
 
 class BaseNestedAPITimeSeriesView(generics.GenericAPIView):
     queryset = APITimeSeries.objects.all()
@@ -35,6 +38,7 @@ class BaseNestedAPITimeSeriesView(generics.GenericAPIView):
         serializer_context = {"request": request, "lookup_field": self.lookup_field}
         return APITimeSeriesRequestSerializer(context=serializer_context)
 
+    @extend_schema(tags=[PUBLIC_API_TAG])
     def get(self, request, *args, **kwargs) -> Response:
         serializer: APITimeSeriesRequestSerializer = self._build_request_serializer(
             request=request
@@ -99,6 +103,7 @@ class SubThemeDetailView(BaseNestedAPITimeSeriesView):
     serializer_class = SubThemeDetailSerializer
 
 
+@extend_schema(tags=[PUBLIC_API_TAG])
 @api_view(["GET"])
 @require_http_methods(["GET"])
 def public_api_root(request, format=None):


### PR DESCRIPTION
# Description

Add tags to cms and public API endpoints to group them seperately in API docs

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

