### PR TITLE
Feat/add ukhsa branding to browsable api/cdd 850

### DIFF
--- a/metrics/templates/rest_framework/api.html
+++ b/metrics/templates/rest_framework/api.html
@@ -3,15 +3,9 @@
 {% load i18n %}
 {% load rest_framework %}
 
-{# Insert the UKHSA favicon #}
+
 {% block style %}
 {{ block.super }}
-<link rel="shortcut icon" type="image/png" href="/static/ukhsa_icon.png" />
-{% endblock %}
-
-{# Append the UKHSA title #}
-{% block title %}{% if name %}{{ name }} – {% endif %}UKHSA Data Dashboard API{% endblock %}
-
 {# Apply Bootstrap style sheet #}
 {% block bootstrap_theme %}
     <link rel="stylesheet"
@@ -20,6 +14,12 @@
           crossorigin="anonymous"
     >
 {% endblock %}
+{# Insert the UKHSA favicon #}
+<link rel="shortcut icon" type="image/png" href="/static/ukhsa_icon.png" />
+{% endblock %}
+
+{# Append the UKHSA title #}
+{% block title %}{% if name %}{{ name }} – {% endif %}UKHSA Data Dashboard API{% endblock %}
 
 {# Add custom stylings and branding applied to Navbar #}
 {% block navbar %}


### PR DESCRIPTION
# Description

Adds some custom UKHSA branding for the browsable API

- Adds the logo in the navbar
- Makes the navabr black
- Applies bootstrap theme
- Hides the login link when the endpoint is part of the public API
- Overrides the breadcrumbs so that the current link is greyed with no href
- Links also uses the gov.uk colour pallete 

Fixes #CDD-850

<img width="1408" alt="Screenshot 2023-05-25 at 10 01 37" src="https://github.com/UKHSA-Internal/winter-pressures-api/assets/47219506/7958170e-1653-4e8d-bdde-772ca51ab722">


## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [x] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

