### PR TITLE
Set old `tabular/` endpoint to be deprecated

### DIFF
--- a/metrics/api/views/tables.py
+++ b/metrics/api/views/tables.py
@@ -18,6 +18,7 @@ from metrics.interfaces.tables import access
 class OldTabularView(APIView):
     permission_classes = [HasAPIKey]
 
+    @extend_schema(deprecated=True)
     def get(self, request, *args, **kwargs):
         """This endpoint can be used to generate a summary of the chart data but in tabular format
         There are 2 mandatory URL parameters:


### PR DESCRIPTION
# Description

![Screenshot 2023-05-30 at 13 08 13](https://github.com/UKHSA-Internal/winter-pressures-api/assets/47219506/91b522b9-ef87-43d4-973f-be468797d8bd)

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

