### PR TITLE
Set `CONN_MAX_AGE` to be a positive integer, which makes Django keep hold of connections and reuse them

### DIFF
--- a/metrics/api/settings.py
+++ b/metrics/api/settings.py
@@ -141,6 +141,10 @@ else:
         }
     }
 
+# Set the lifetime of a database connection to be 10 seconds
+# By default, the connection is closed at the end of every request
+CONN_MAX_AGE = 10
+
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
# Description

Set `CONN_MAX_AGE` to be 10 seconds, so that Django keeps hold of a db connection and reuses it instead of closing and opening a new connection

Fixes #CDD-858

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

