### PR TITLE
Implement variable number of headline/trend blocks within headline numbers row card

### DIFF
--- a/cms/dashboard/templates/cms_starting_pages/respiratory_viruses.json
+++ b/cms/dashboard/templates/cms_starting_pages/respiratory_viruses.json
@@ -17,7 +17,7 @@
                 "detail_url": "http://localhost/api/pages/2/",
                 "html_url": null
             },
-            "title": "Welcome to your new Wagtail site!"
+            "title": "UKHSA Dashboard Root"
         }
     },
     "title": "Respiratory viruses",
@@ -40,87 +40,133 @@
                         "value": {
                             "columns": [
                                 {
-                                    "type": "headline_and_trend_component",
+                                    "type": "column",
                                     "value": {
                                         "title": "Cases",
-                                        "headline_number": {
-                                            "topic": "COVID-19",
-                                            "metric": "new_cases_7days_sum",
-                                            "body": "Weekly"
-                                        },
-                                        "trend_number": {
-                                            "topic": "COVID-19",
-                                            "metric": "new_cases_7days_change",
-                                            "body": "Last 7 days",
-                                            "percentage_metric": "new_cases_7days_change_percentage"
-                                        }
+                                        "rows": [
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "new_cases_7days_sum",
+                                                    "body": "Weekly"
+                                                },
+                                                "id": "eff08341-7bfa-4a3b-b013-527e7b954ce8"
+                                            },
+                                            {
+                                                "type": "trend_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "new_cases_7days_change",
+                                                    "body": "Last 7 days",
+                                                    "percentage_metric": "new_cases_7days_change_percentage"
+                                                },
+                                                "id": "a57a4ad5-6b52-45a6-acfd-2fe208cb5617"
+                                            }
+                                        ]
                                     },
-                                    "id": "e64cc7ea-4551-47f0-b964-941d59cae1bb"
+                                    "id": "ff081d2a-e235-4bc2-9b09-220f8fe20494"
                                 },
                                 {
-                                    "type": "headline_and_trend_component",
+                                    "type": "column",
                                     "value": {
                                         "title": "Deaths",
-                                        "headline_number": {
-                                            "topic": "COVID-19",
-                                            "metric": "new_deaths_7days_sum",
-                                            "body": "Weekly"
-                                        },
-                                        "trend_number": {
-                                            "topic": "COVID-19",
-                                            "metric": "new_deaths_7days_change",
-                                            "body": "Last 7 days",
-                                            "percentage_metric": "new_deaths_7days_change_percentage"
-                                        }
+                                        "rows": [
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "new_deaths_7days_sum",
+                                                    "body": "Weekly"
+                                                },
+                                                "id": "2e403485-030c-4122-86be-5827a095f30d"
+                                            },
+                                            {
+                                                "type": "trend_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "new_deaths_7days_change",
+                                                    "body": "Last 7 days",
+                                                    "percentage_metric": "new_deaths_7days_change_percentage"
+                                                },
+                                                "id": "ea8603ca-7b4d-4ef5-a8b1-f27a565938b5"
+                                            }
+                                        ]
                                     },
-                                    "id": "fcfcf83f-f2a6-407c-a1f4-6c5978b472f5"
+                                    "id": "530cf367-092c-40d1-9129-c2274c7836b9"
                                 },
                                 {
-                                    "type": "headline_and_trend_component",
+                                    "type": "column",
                                     "value": {
                                         "title": "Healthcare",
-                                        "headline_number": {
-                                            "topic": "COVID-19",
-                                            "metric": "new_admissions_7days",
-                                            "body": "Patients admitted"
-                                        },
-                                        "trend_number": {
-                                            "topic": "COVID-19",
-                                            "metric": "new_admissions_7days_change",
-                                            "body": "Last 7 days",
-                                            "percentage_metric": "new_admissions_7days_change_percentage"
-                                        }
+                                        "rows": [
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "new_admissions_7days",
+                                                    "body": "Patients admitted"
+                                                },
+                                                "id": "2f49a215-02e7-4ded-94b1-1a0c2933708b"
+                                            },
+                                            {
+                                                "type": "trend_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "new_admissions_7days_change",
+                                                    "body": "Last 7 days",
+                                                    "percentage_metric": "new_admissions_7days_change_percentage"
+                                                },
+                                                "id": "6c09d01e-82c5-425f-aa07-1bdd22d1eaa8"
+                                            }
+                                        ]
                                     },
-                                    "id": "0a351331-a1ca-4c16-8c6e-5d8a0b38fd3f"
+                                    "id": "fad2e89a-8a65-44a8-b962-9df59169c0af"
                                 },
                                 {
-                                    "type": "dual_headline_component",
+                                    "type": "column",
                                     "value": {
                                         "title": "Vaccines",
-                                        "top_headline_number": {
-                                            "topic": "COVID-19",
-                                            "metric": "latest_total_vaccinations_autumn22",
-                                            "body": "Autumn booster"
-                                        },
-                                        "bottom_headline_number": {
-                                            "topic": "COVID-19",
-                                            "metric": "latest_vaccinations_uptake_autumn22",
-                                            "body": "Percentage uptake (%)"
-                                        }
+                                        "rows": [
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "latest_total_vaccinations_autumn22",
+                                                    "body": "Autumn booster"
+                                                },
+                                                "id": "ae3344f7-5b23-4977-bea9-2e1ccd84eb50"
+                                            },
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "latest_vaccinations_uptake_autumn22",
+                                                    "body": "Percentage uptake (%)"
+                                                },
+                                                "id": "65f00bd6-d027-4e9f-8b15-8c15e1992ba6"
+                                            }
+                                        ]
                                     },
-                                    "id": "bb8a9a19-ff0e-4e99-b570-b058e9cdb5a1"
+                                    "id": "93b6367b-fbb3-47e8-96db-f724d947fa00"
                                 },
                                 {
-                                    "type": "single_headline_component",
+                                    "type": "column",
                                     "value": {
                                         "title": "Testing",
-                                        "headline_number": {
-                                            "topic": "COVID-19",
-                                            "metric": "positivity_7days_latest",
-                                            "body": "Virus tests positivity (%)"
-                                        }
+                                        "rows": [
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "positivity_7days_latest",
+                                                    "body": "Virus tests positivity (%)"
+                                                },
+                                                "id": "7d1523f9-9732-43be-8c81-094c66efed3f"
+                                            }
+                                        ]
                                     },
-                                    "id": "4e9d5ead-5394-42cb-b370-e0d0f028140d"
+                                    "id": "1e3bf214-88e4-4cf4-9b78-3ad7eabb2eaa"
                                 }
                             ]
                         },
@@ -251,34 +297,50 @@
                         "value": {
                             "columns": [
                                 {
-                                    "type": "headline_and_trend_component",
+                                    "type": "column",
                                     "value": {
                                         "title": "Healthcare",
-                                        "headline_number": {
-                                            "topic": "Influenza",
-                                            "metric": "weekly_hospital_admissions_rate_latest",
-                                            "body": "Hospital admission rate (per 100,000)"
-                                        },
-                                        "trend_number": {
-                                            "topic": "Influenza",
-                                            "metric": "weekly_hospital_admissions_rate_change",
-                                            "body": "Last 7 days",
-                                            "percentage_metric": "weekly_hospital_admissions_rate_change_percentage"
-                                        }
+                                        "rows": [
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "Influenza",
+                                                    "metric": "weekly_hospital_admissions_rate_latest",
+                                                    "body": "Hospital admission rate (per 100,000)"
+                                                },
+                                                "id": "0520e9d6-794f-4616-b217-f5ec884a86d8"
+                                            },
+                                            {
+                                                "type": "trend_number",
+                                                "value": {
+                                                    "topic": "Influenza",
+                                                    "metric": "weekly_hospital_admissions_rate_change",
+                                                    "body": "Last 7 days",
+                                                    "percentage_metric": "weekly_hospital_admissions_rate_change_percentage"
+                                                },
+                                                "id": "3849d44d-025a-464e-a171-34b5750ca725"
+                                            }
+                                        ]
                                     },
-                                    "id": "1eb03393-1b30-46a8-8c19-8b86aa056b34"
+                                    "id": "0da002a7-d985-417c-b75c-9a4c8a77fa8e"
                                 },
                                 {
-                                    "type": "single_headline_component",
+                                    "type": "column",
                                     "value": {
                                         "title": "Testing",
-                                        "headline_number": {
-                                            "topic": "Influenza",
-                                            "metric": "weekly_positivity_latest",
-                                            "body": "Virus tests positivity (%)"
-                                        }
+                                        "rows": [
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "Influenza",
+                                                    "metric": "weekly_positivity_latest",
+                                                    "body": "Virus tests positivity (%)"
+                                                },
+                                                "id": "879a0bbd-83fd-4685-b674-37372356c4f6"
+                                            }
+                                        ]
                                     },
-                                    "id": "8d79205b-df67-4dc1-91ae-8198dfb2155f"
+                                    "id": "e57ed33f-658a-40be-bfdb-6fa12ee62512"
                                 }
                             ]
                         },

--- a/cms/dynamic_content/blocks.py
+++ b/cms/dynamic_content/blocks.py
@@ -3,53 +3,8 @@ from wagtail import blocks
 from cms.dynamic_content import help_texts
 from cms.dynamic_content.components import HeadlineNumberComponent, TrendNumberComponent
 
-
-class SingleHeadlineNumberBlock(blocks.StructBlock):
-    title = blocks.TextBlock(required=True, help_text=help_texts.TITLE_FIELD_HELP_TEXT)
-    headline_number = HeadlineNumberComponent(
-        help_text=help_texts.HEADLINE_BLOCK_FIELD_HELP_TEXT
-    )
-
-    class Meta:
-        icon = "number"
-
-
-class HeadlineAndTrendNumberBlock(blocks.StructBlock):
-    title = blocks.TextBlock(required=True, help_text=help_texts.TITLE_FIELD_HELP_TEXT)
-    headline_number = HeadlineNumberComponent(
-        help_text=help_texts.HEADLINE_BLOCK_FIELD_HELP_TEXT
-    )
-    trend_number = TrendNumberComponent(
-        help_text=help_texts.TREND_BLOCK_FIELD_HELP_TEXT
-    )
-
-    class Meta:
-        icon = "trend_down"
-
-
-class DualHeadlineNumberBlock(blocks.StructBlock):
-    title = blocks.TextBlock(required=True, help_text=help_texts.TITLE_FIELD_HELP_TEXT)
-    top_headline_number = HeadlineNumberComponent(
-        help_text=help_texts.TOP_HEADLINE_BLOCK_FIELD_HELP_TEXT
-    )
-    bottom_headline_number = HeadlineNumberComponent(
-        help_text=help_texts.BOTTOM_HEADLINE_BLOCK_FIELD_HELP_TEXT
-    )
-
-    class Meta:
-        icon = "order"
-
-
-class HeadlineNumberRowBlockTypes(blocks.StreamBlock):
-    single_headline_component = SingleHeadlineNumberBlock(
-        help_text=help_texts.SINGLE_HEADLINE_COMPONENT_HELP_TEXT
-    )
-    headline_and_trend_component = HeadlineAndTrendNumberBlock(
-        help_text=help_texts.HEADLINE_AND_TREND_COMPONENT_HELP_TEXT
-    )
-    dual_headline_component = DualHeadlineNumberBlock(
-        help_text=help_texts.DUAL_HEADLINE_COMPONENT_HELP_TEXT
-    )
+MINIMUM_ROWS_NUMBER_BLOCK_COUNT: int = 1
+MAXIMUM_ROWS_NUMBER_BLOCK_COUNT: int = 2
 
 
 class HeadlineNumberBlockTypes(blocks.StreamBlock):
@@ -59,3 +14,25 @@ class HeadlineNumberBlockTypes(blocks.StreamBlock):
     trend_number = TrendNumberComponent(
         help_text=help_texts.TREND_BLOCK_FIELD_HELP_TEXT
     )
+
+    class Meta:
+        icon = "bars"
+
+
+class MetricNumberBlockTypes(blocks.StructBlock):
+    title = blocks.TextBlock(required=True, help_text=help_texts.TITLE_FIELD_HELP_TEXT)
+    rows = HeadlineNumberBlockTypes(
+        required=True,
+        min_num=MINIMUM_ROWS_NUMBER_BLOCK_COUNT,
+        max_num=MAXIMUM_ROWS_NUMBER_BLOCK_COUNT,
+        help_text=help_texts.NUMBERS_ROW_FIELD_HELP_TEXT.format(
+            MAXIMUM_ROWS_NUMBER_BLOCK_COUNT
+        ),
+    )
+
+    class Meta:
+        icon = "table"
+
+
+class MetricNumberBlock(blocks.StreamBlock):
+    column = MetricNumberBlockTypes()

--- a/cms/dynamic_content/cards.py
+++ b/cms/dynamic_content/cards.py
@@ -2,10 +2,7 @@ from wagtail import blocks
 
 from cms.common.models import AVAILABLE_RICH_TEXT_FEATURES
 from cms.dynamic_content import help_texts
-from cms.dynamic_content.blocks import (
-    HeadlineNumberBlockTypes,
-    HeadlineNumberRowBlockTypes,
-)
+from cms.dynamic_content.blocks import HeadlineNumberBlockTypes, MetricNumberBlock
 from cms.dynamic_content.components import ChartComponent
 
 
@@ -29,7 +26,7 @@ MAXIMUM_COLUMNS_CHART_COLUMNS_COUNT: int = 2
 
 
 class HeadlineNumbersRowCard(blocks.StructBlock):
-    columns = HeadlineNumberRowBlockTypes(
+    columns = MetricNumberBlock(
         min_num=MINIMUM_HEADLINE_COLUMNS_COUNT,
         max_num=MAXIMUM_HEADLINE_COLUMNS_COUNT,
         help_text=help_texts.HEADLINE_COLUMNS_FIELD_HELP_TEXT.format(

--- a/cms/dynamic_content/help_texts.py
+++ b/cms/dynamic_content/help_texts.py
@@ -1,5 +1,5 @@
 HEADLINE_COLUMNS_FIELD_HELP_TEXT: str = """
-Add up to {} headline or trend number column components within this row. 
+Add up to {} number column components within this row. 
 The columns are ordered from left to right, top to bottom respectively. 
 So by moving 1 column component above the other, that component will be rendered in the column left of the other. 
 """
@@ -12,6 +12,13 @@ CHART_CARD_ROW_HELP_TEXT: str = """
 Here you can add 1 or 2 columns to contain a particular chart card.
 If you add the 1 column, then the chart card will spread across the available width.
 If you add 2 columns, then the cards will be split across 2 columns within the available width.
+"""
+NUMBERS_ROW_FIELD_HELP_TEXT: str = """
+Here you can add up to {} rows within this column component.
+Each row can be used to add a number block. 
+This can be a headline number, a trend number or a percentage number.
+If you only add 1 row, then that block will be rendered on the upper half of the column.
+And the bottom row of the column will remain empty.
 """
 
 CHART_BLOCK_FIELD_HELP_TEXT: str = """

--- a/tests/unit/cms/home/test_models.py
+++ b/tests/unit/cms/home/test_models.py
@@ -178,23 +178,25 @@ class TestTemplateHomePage:
         # Check that the title of the component is correct
         assert first_column_component["title"] == "Cases"
 
-        # This is a headline and trend number component
-        # So we expect 1 headline number block and 1 trend number block
+        # This column has a headline block and trend block
         # Check that the headline_number block has the correct params
-        first_column_headline_block = first_column_component["headline_number"]
-        assert first_column_headline_block["topic"] == self.covid_19
-        assert first_column_headline_block["metric"] == "new_cases_7days_sum"
-        assert first_column_headline_block["body"] == "Weekly"
+        first_column_headline_block_value = first_column_component["rows"][0].value
+        assert first_column_headline_block_value["topic"] == self.covid_19
+        assert first_column_headline_block_value["metric"] == "new_cases_7days_sum"
+        assert first_column_headline_block_value["body"] == "Weekly"
 
         # Check that the trend_number block has the correct params
-        first_column_trend_block = first_column_component["trend_number"]
-        assert first_column_trend_block["topic"] == self.covid_19
-        assert first_column_trend_block["metric"] == "new_cases_7days_change"
+        first_column_trend_block_value = first_column_component["rows"][1].value
+        assert first_column_trend_block_value["topic"] == self.covid_19
+        assert first_column_trend_block_value["metric"] == "new_cases_7days_change"
         assert (
-            first_column_trend_block["percentage_metric"]
+            first_column_trend_block_value["percentage_metric"]
             == "new_cases_7days_change_percentage"
         )
-        assert first_column_trend_block["body"] == self.expected_trend_number_block_body
+        assert (
+            first_column_trend_block_value["body"]
+            == self.expected_trend_number_block_body
+        )
 
     def test_coronavirus_section_headline_number_row_dual_headline_column(self):
         """
@@ -218,24 +220,24 @@ class TestTemplateHomePage:
         fourth_column_component = headline_number_row_columns[3].value
         assert fourth_column_component["title"] == "Vaccines"
 
-        # This is a dual headline number component
-        # So we expect 2 headline number blocks
+        # This is column component has 2 headline number blocks
         # Check that the top headline_number block has the correct params
-        fourth_column_headline_block = fourth_column_component["top_headline_number"]
-        assert fourth_column_headline_block["topic"] == self.covid_19
+        fourth_column_headline_block_value = fourth_column_component["rows"][0].value
+        assert fourth_column_headline_block_value["topic"] == self.covid_19
         assert (
-            fourth_column_headline_block["metric"]
+            fourth_column_headline_block_value["metric"]
             == "latest_total_vaccinations_autumn22"
         )
-        assert fourth_column_headline_block["body"] == "Autumn booster"
+        assert fourth_column_headline_block_value["body"] == "Autumn booster"
 
         # Check that the bottom headline_number block has the correct params
-        fourth_column_trend_block = fourth_column_component["bottom_headline_number"]
-        assert fourth_column_trend_block["topic"] == self.covid_19
+        fourth_column_trend_block_value = fourth_column_component["rows"][1].value
+        assert fourth_column_trend_block_value["topic"] == self.covid_19
         assert (
-            fourth_column_trend_block["metric"] == "latest_vaccinations_uptake_autumn22"
+            fourth_column_trend_block_value["metric"]
+            == "latest_vaccinations_uptake_autumn22"
         )
-        assert fourth_column_trend_block["body"] == "Percentage uptake (%)"
+        assert fourth_column_trend_block_value["body"] == "Percentage uptake (%)"
 
     def test_coronavirus_section_headline_number_row_single_headline_column(self):
         """
@@ -256,14 +258,14 @@ class TestTemplateHomePage:
         covid_content_section = covid_section.value["content"]
         headline_number_row_columns = covid_content_section[1].value["columns"]
 
-        # Note that this is a single headline number component
+        # Note that this column component only has the 1 headline number component
         # Check that the headline_number block has the correct params
         fifth_column_value = headline_number_row_columns[4].value
         assert fifth_column_value["title"] == "Testing"
-        fifth_column_headline_block = fifth_column_value["headline_number"]
-        assert fifth_column_headline_block["topic"] == self.covid_19
-        assert fifth_column_headline_block["metric"] == "positivity_7days_latest"
-        assert fifth_column_headline_block["body"] == "Virus tests positivity (%)"
+        fifth_column_headline_block_value = fifth_column_value["rows"][0].value
+        assert fifth_column_headline_block_value["topic"] == self.covid_19
+        assert fifth_column_headline_block_value["metric"] == "positivity_7days_latest"
+        assert fifth_column_headline_block_value["body"] == "Virus tests positivity (%)"
 
     def test_coronavirus_section_chart_row_card(self):
         """


### PR DESCRIPTION
# Description
Removes the stringent dual headline number block, single headline number block and headline and trend number blocks
in favour of a variable number of blocks (min of 1, max of 2).
This way, the user can compose each column in the headline numbers row card however they want with whatever combo of headline, trend or percentage (percentage not implemented yet).

Fixes #CDD-845

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

