### PR TITLE
Add `PUBLIC_API_TAG` to final timeseries slice of public API

### DIFF
--- a/metrics/public_api/views/timeseries_viewset.py
+++ b/metrics/public_api/views/timeseries_viewset.py
@@ -1,4 +1,5 @@
 from django_filters.rest_framework import DjangoFilterBackend
+from drf_spectacular.utils import extend_schema
 from rest_framework import pagination, viewsets
 from rest_framework_api_key.permissions import HasAPIKey
 
@@ -6,6 +7,7 @@ from metrics.public_api.metrics_interface.interface import MetricsPublicAPIInter
 from metrics.public_api.serializers.timeseries_serializers import (
     APITimeSeriesListSerializer,
 )
+from metrics.public_api.views.base import PUBLIC_API_TAG
 
 DEFAULT_API_TIMESERIES_RESPONSE_PAGE_SIZE: int = 5
 MAXIMUM_API_TIMESERIES_RESPONSE_PAGE_SIZE: int = 52
@@ -16,6 +18,7 @@ class APITimeSeriesPagination(pagination.PageNumberPagination):
     max_page_size = MAXIMUM_API_TIMESERIES_RESPONSE_PAGE_SIZE
 
 
+@extend_schema(tags=[PUBLIC_API_TAG])
 class APITimeSeriesViewSet(viewsets.ReadOnlyModelViewSet):
     """
     This endpoint will provide the full timeseries of a slice of data.


### PR DESCRIPTION
# Description

Adds the `public-api` tag to the final timeseries slice view of the public API

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

