### PR TITLE
Add `seo_title` and `search_description` SEO metadata to start template pages

### DIFF
--- a/cms/dashboard/templates/cms_starting_pages/about.json
+++ b/cms/dashboard/templates/cms_starting_pages/about.json
@@ -6,8 +6,8 @@
         "html_url": null,
         "slug": "about",
         "show_in_menus": false,
-        "seo_title": "",
-        "search_description": "",
+        "seo_title": "About | UKHA data dashboard",
+        "search_description": "The UKHSA data dashboard provides presents a wide range of public health data in an easily accessible format.",
         "first_published_at": "2023-05-16T11:18:41.084933+01:00",
         "alias_of": null,
         "parent": {

--- a/cms/dashboard/templates/cms_starting_pages/coronavirus.json
+++ b/cms/dashboard/templates/cms_starting_pages/coronavirus.json
@@ -6,8 +6,8 @@
         "html_url": null,
         "slug": "coronavirus",
         "show_in_menus": false,
-        "seo_title": "",
-        "search_description": "",
+        "seo_title": "Coronavirus | UKHA data dashboard",
+        "search_description": "Overall summary of Coronavirus in circulation within the UK",
         "first_published_at": "2023-05-15T17:23:02.306556+01:00",
         "alias_of": null,
         "parent": {

--- a/cms/dashboard/templates/cms_starting_pages/how_to_use_this_data.json
+++ b/cms/dashboard/templates/cms_starting_pages/how_to_use_this_data.json
@@ -6,8 +6,8 @@
         "html_url": null,
         "slug": "how-to-use-this-data",
         "show_in_menus": false,
-        "seo_title": "",
-        "search_description": "",
+        "seo_title": "How to use this data | UKHA data dashboard",
+        "search_description": "A guide on how to use the data provided across the UKHSA data dashboard.",
         "first_published_at": "2023-05-12T16:51:07.555450+01:00",
         "alias_of": null,
         "parent": {

--- a/cms/dashboard/templates/cms_starting_pages/influenza.json
+++ b/cms/dashboard/templates/cms_starting_pages/influenza.json
@@ -6,8 +6,8 @@
         "html_url": null,
         "slug": "influenza",
         "show_in_menus": false,
-        "seo_title": "",
-        "search_description": "",
+        "seo_title": "Influenza | UKHA data dashboard",
+        "search_description": "Detailed summary of Influenza in circulation within the UK",
         "first_published_at": "2023-05-16T14:06:43.187457+01:00",
         "alias_of": null,
         "parent": {

--- a/cms/dashboard/templates/cms_starting_pages/maps.json
+++ b/cms/dashboard/templates/cms_starting_pages/maps.json
@@ -6,8 +6,8 @@
         "html_url": null,
         "slug": "maps",
         "show_in_menus": false,
-        "seo_title": "",
-        "search_description": "",
+        "seo_title": "Maps | UKHSA data dashboard",
+        "search_description": "Geographical illustration of the various topics provided across the UKHSA data dashboard",
         "first_published_at": "2023-05-12T16:33:40.460981+01:00",
         "alias_of": null,
         "parent": {

--- a/cms/dashboard/templates/cms_starting_pages/other_respiratory_viruses.json
+++ b/cms/dashboard/templates/cms_starting_pages/other_respiratory_viruses.json
@@ -6,8 +6,8 @@
         "html_url": null,
         "slug": "other-respiratory-viruses",
         "show_in_menus": false,
-        "seo_title": "",
-        "search_description": "",
+        "seo_title": "Other Respiratory Viruses | UKHA data dashboard",
+        "search_description": "Overall summary of other respiratory viruses in circulation within the UK",
         "first_published_at": "2023-05-12T16:58:42.332020+01:00",
         "alias_of": null,
         "parent": {

--- a/cms/dashboard/templates/cms_starting_pages/respiratory_viruses.json
+++ b/cms/dashboard/templates/cms_starting_pages/respiratory_viruses.json
@@ -6,8 +6,8 @@
         "html_url": null,
         "slug": "respiratory-viruses",
         "show_in_menus": false,
-        "seo_title": "",
-        "search_description": "",
+        "seo_title": "Respiratory Viruses | UKHA data dashboard",
+        "search_description": "Overall summary of the respiratory viruses in circulation within the UK",
         "first_published_at": "2023-04-26T12:39:38.064114+01:00",
         "alias_of": null,
         "parent": {

--- a/cms/dashboard/templates/cms_starting_pages/whats_new.json
+++ b/cms/dashboard/templates/cms_starting_pages/whats_new.json
@@ -6,8 +6,8 @@
         "html_url": null,
         "slug": "whats-new",
         "show_in_menus": false,
-        "seo_title": "",
-        "search_description": "",
+        "seo_title": "What's New | UKHA data dashboard",
+        "search_description": "A list of all the new features and key pieces of data which have been added to the UKHSA data dashboard",
         "first_published_at": "2023-05-16T11:46:07.719758+01:00",
         "alias_of": null,
         "parent": {


### PR DESCRIPTION
# Description

Adds `seo_title` and the `search_description` fields to the template page responses. 
Note that this is purely dummy data and has not been provided by a content manager from the UKHSA.
Once that does happen, the contents of these fields will likely be replaced.

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

