### PR TITLE
Add switch to `entrypoint.sh` via the env var `DETACHED_MODE` to prevent the continuous server process from being launched

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,7 +5,12 @@ function set_up_django() {
     python manage.py migrate --noinput
 
     echo "Collecting static files"
-    python manage.py collectstatic
+    python manage.py collectstatic --noinput
+
+    if [[ "$DETACHED_MODE" == "true" ]]; then
+      # Running in detached mode means the server is not started
+      return
+    fi
 
     echo "Starting server"
     python manage.py runserver 0.0.0.0:80


### PR DESCRIPTION
# Description

Adds the env var `DETACHED_MODE` to the `entrypoint.sh` shell script.
This means that when we run the container with `DETACHED_MODE` set to `true` then the server process is **not** started. This is so that we can run commands in the container directly without also having to kill the server process first.

If the env var `DETACHED_MODE` is not set, or is any value other than `true` then the server will be started as was the case before.

Fixes #CDD-794

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

