### PR TITLE
Implement `get_line_multi_coloured_chart_config()`

### DIFF
--- a/metrics/domain/charts/bar/generation.py
+++ b/metrics/domain/charts/bar/generation.py
@@ -53,12 +53,7 @@ def generate_chart_figure(
 
     # Set x axis tick type depending on what sort of data we are showing
     if type(x_axis_values[0]) is date:
-        figure.update_xaxes(**settings._get_x_axis_date_type())
-
-        # Give the chart the best chance of displaying all the tick labels
-        min_date, max_date = chart_settings.get_x_axis_range(figure=figure)
-
-        figure.update_xaxes(range=[min_date, max_date])
+        figure.update_xaxes(**settings._get_x_axis_date_type(figure=figure))
         figure.update_layout(**settings._get_margin_for_charts_with_dates())
     else:
         figure.update_xaxes(**settings._get_x_axis_text_type())

--- a/metrics/domain/charts/chart_settings.py
+++ b/metrics/domain/charts/chart_settings.py
@@ -118,12 +118,16 @@ class ChartSettings:
         )
         return {**chart_config, **self._get_legend_top_centre_config()}
 
-    def _get_x_axis_date_type(self) -> DICT_OF_STR_ONLY:
+    def _get_x_axis_date_type(
+        self, figure: plotly.graph_objs.Figure
+    ) -> DICT_OF_STR_ONLY:
         tick_format = "%b %Y" if self.width > self.narrow_chart_width else "%b<br>%Y"
+        min_date, max_date = get_x_axis_range(figure=figure)
         return {
             "type": "date",
             "dtick": "M1",
             "tickformat": tick_format,
+            "range": [min_date, max_date],
         }
 
     @staticmethod

--- a/metrics/domain/charts/line_multi_coloured/generation.py
+++ b/metrics/domain/charts/line_multi_coloured/generation.py
@@ -66,12 +66,7 @@ def create_multi_coloured_line_chart(
 
     # Set x axis tick type depending on what sort of data we are showing
     if type(chart_plots_data[0].x_axis_values[0]) is date:
-        figure.update_xaxes(**settings._get_x_axis_date_type())
-
-        # Give the chart the best chance of displaying all the tick labels
-        min_date, max_date = chart_settings.get_x_axis_range(figure=figure)
-
-        figure.update_xaxes(range=[min_date, max_date])
+        figure.update_xaxes(**settings._get_x_axis_date_type(figure=figure))
         figure.update_layout(**settings._get_margin_for_charts_with_dates())
     else:
         figure.update_xaxes(**settings._get_x_axis_text_type())

--- a/metrics/domain/charts/line_with_shaded_section/generation.py
+++ b/metrics/domain/charts/line_with_shaded_section/generation.py
@@ -84,12 +84,7 @@ def create_line_chart_with_shaded_section(
 
     # Set x axis tick type depending on what sort of data we are showing
     if type(x_axis_values[0]) is date:
-        figure.update_xaxes(**settings._get_x_axis_date_type())
-
-        # Give the chart the best chance of displaying all the tick labels
-        min_date, max_date = chart_settings.get_x_axis_range(figure=figure)
-
-        figure.update_xaxes(range=[min_date, max_date])
+        figure.update_xaxes(**settings._get_x_axis_date_type(figure=figure))
         figure.update_layout(**settings._get_margin_for_charts_with_dates())
     else:
         figure.update_xaxes(**settings._get_x_axis_text_type())


### PR DESCRIPTION
# Description

Next step, more clean up work. Implement chart settings for line multi coloured module.

Fixes #CDD-874

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit and integration tests at the right level to prove my change is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

