### PR TITLE
Implement `get_x_and_y_values` to encapsulate decision logic around `sort_by_stratum` or `unzip_values`

### DIFF
--- a/metrics/interfaces/plots/access.py
+++ b/metrics/interfaces/plots/access.py
@@ -126,14 +126,9 @@ class PlotsInterface:
         )
 
         try:
-            # Stratum needs special treatment because a regular sort does not yield the required result
-            if plot_parameters.x_axis == ChartAxisFields.stratum.name:
-                x_axis_values, y_axis_values = sort_by_stratum(
-                    queryset=timeseries_queryset
-                )
-
-            else:
-                x_axis_values, y_axis_values = unzip_values(values=timeseries_queryset)
+            x_axis_values, y_axis_values = get_x_and_y_values(
+                plot_parameters=plot_parameters, queryset=timeseries_queryset
+            )
         except ValueError as error:
             raise DataNotFoundError from error
 
@@ -171,6 +166,27 @@ class PlotsInterface:
             plots_data.append(plot_data)
 
         return plots_data
+
+
+def get_x_and_y_values(
+    plot_parameters: PlotParameters, queryset: QuerySet
+) -> Tuple[List, List]:
+    """Gets the X and Y values for a given `queryset` based on the `plot_parameters`
+
+    Args:
+        plot_parameters: A `PlotParameters` model containing
+            the requested info
+        queryset:
+
+    Returns:
+
+    """
+
+    # Stratum needs special treatment because a regular sort does not yield the required result
+    if plot_parameters.x_axis == ChartAxisFields.stratum.name:
+        return sort_by_stratum(queryset=queryset)
+
+    return unzip_values(values=queryset)
 
 
 def sort_by_stratum(queryset: QuerySet) -> Tuple[List, List]:

--- a/tests/unit/metrics/interfaces/plots/test_access.py
+++ b/tests/unit/metrics/interfaces/plots/test_access.py
@@ -9,6 +9,7 @@ from metrics.domain.utils import ChartAxisFields
 from metrics.interfaces.plots.access import (
     DataNotFoundError,
     PlotsInterface,
+    get_x_and_y_values,
     sort_by_stratum,
     unzip_values,
 )
@@ -177,99 +178,45 @@ class TestPlotsInterface:
         )
 
     @mock.patch.object(PlotsInterface, "get_timeseries_for_plot_parameters")
-    @mock.patch(f"{MODULE_PATH}.sort_by_stratum")
-    def test_build_plot_data_from_parameters_calls_sort_by_stratum(
+    @mock.patch(f"{MODULE_PATH}.get_x_and_y_values")
+    def test_build_plot_data_from_parameters_calls_get_x_and_y_values(
         self,
-        spy_sort_by_stratum: mock.MagicMock,
+        spy_get_x_and_y_values: mock.MagicMock,
         mocked_get_timeseries_for_plot_parameters: mock.MagicMock,
         fake_chart_plot_parameters: PlotParameters,
     ):
         """
-        Given a `PlotParameters` model requesting a plot for existing `CoreTimeSeries`
-        When `build_plot_data_from_parameters()` is called from an instance of the `PlotsInterface`
-        And the x_axis is `stratum`
-        Then `sort_by_stratum` is called
+        Given a set of `ChartParameters` and fake X and Y axis values
+        When `build_plot_data_from_parameters()` is called from an instance of `PlotsInterface`
+        Then the call is delegated to `get_x_and_y_values()` to fetch the values
+        And those values are set on the `x_axis` and `y_axis` on returned model
         """
         # Given
-        fake_plots_collection = PlotsCollection(
-            plots=[fake_chart_plot_parameters],
-            file_format="png",
-            chart_width=123,
-            chart_height=456,
-        )
-        fake_core_time_series_for_plot: List[
-            FakeCoreTimeSeries
-        ] = self._setup_fake_time_series_for_plot(
-            plot_parameters=fake_chart_plot_parameters
-        )
-        fake_core_time_series_manager = FakeCoreTimeSeriesManager(
-            time_series=fake_core_time_series_for_plot
-        )
-
+        fake_x_axis_values = [1, 2, 3]
+        fake_y_axis_values = ["a", "b", "c"]
+        spy_get_x_and_y_values.return_value = fake_x_axis_values, fake_y_axis_values
         plots_interface = PlotsInterface(
-            plots_collection=fake_plots_collection,
-            core_time_series_manager=fake_core_time_series_manager,
+            plots_collection=mock.Mock(),
+            core_time_series_manager=mock.Mock(),
         )
-        # Change the x_axis to be `stratum`
-        fake_chart_plot_parameters.x_axis = ChartAxisFields.stratum.name
-        spy_sort_by_stratum.return_value = ("x_values", "y_values")
 
         # When
-        plots_interface.build_plot_data_from_parameters(
-            plot_parameters=fake_chart_plot_parameters
+        plot_data_from_parameters: PlotsData = (
+            plots_interface.build_plot_data_from_parameters(
+                plot_parameters=fake_chart_plot_parameters
+            )
         )
 
         # Then
-        spy_sort_by_stratum.assert_called_once_with(
-            queryset=mocked_get_timeseries_for_plot_parameters.return_value
+        spy_get_x_and_y_values.assert_called_once_with(
+            plot_parameters=fake_chart_plot_parameters,
+            queryset=mocked_get_timeseries_for_plot_parameters.return_value,
         )
 
-    @mock.patch.object(PlotsInterface, "get_timeseries_for_plot_parameters")
-    @mock.patch(f"{MODULE_PATH}.unzip_values")
-    def test_build_plot_data_from_parameters_calls_unzip_values(
-        self,
-        spy_unzip_values: mock.MagicMock,
-        mocked_get_timeseries_for_plot_parameters: mock.MagicMock,
-        fake_chart_plot_parameters: PlotParameters,
-    ):
-        """
-        Given a `PlotParameters` model requesting a plot for existing `CoreTimeSeries`
-        When `build_plot_data_from_parameters()` is called from an instance of the `PlotsInterface`
-        And the x_axis is something other than `stratum`
-        Then `sort_by_stratum` is called
-        """
-        # Given
-        fake_plots_collection = PlotsCollection(
-            plots=[fake_chart_plot_parameters],
-            file_format="png",
-            chart_width=123,
-            chart_height=456,
-        )
-        fake_core_time_series_for_plot: List[
-            FakeCoreTimeSeries
-        ] = self._setup_fake_time_series_for_plot(
-            plot_parameters=fake_chart_plot_parameters
-        )
-        fake_core_time_series_manager = FakeCoreTimeSeriesManager(
-            time_series=fake_core_time_series_for_plot
-        )
-
-        plots_interface = PlotsInterface(
-            plots_collection=fake_plots_collection,
-            core_time_series_manager=fake_core_time_series_manager,
-        )
-
-        spy_unzip_values.return_value = ("x_values", "y_values")
-
-        # When
-        plots_interface.build_plot_data_from_parameters(
-            plot_parameters=fake_chart_plot_parameters
-        )
-
-        # Then
-        spy_unzip_values.assert_called_once_with(
-            values=mocked_get_timeseries_for_plot_parameters.return_value
-        )
+        # Check that the enriched `PlotsData` model has been set
+        # with the correct values via the `get_x_any_y_values` function
+        assert plot_data_from_parameters.x_axis_values == fake_x_axis_values
+        assert plot_data_from_parameters.y_axis_values == fake_y_axis_values
 
     def test_build_plot_data_from_parameters_raises_error_when_no_data_found(
         self, fake_chart_plot_parameters: PlotParameters
@@ -383,6 +330,65 @@ class TestPlotsInterface:
         mocked_get_timeseries.assert_called_once_with(
             **fake_chart_plot_parameters.to_dict_for_query(),
         )
+
+
+class TestGetXAndYValues:
+    @mock.patch(f"{MODULE_PATH}.sort_by_stratum")
+    def test_can_delegate_call_to_sort_by_stratum(
+        self,
+        spy_sort_by_stratum: mock.MagicMock,
+        fake_chart_plot_parameters: PlotParameters,
+    ):
+        """
+        Given a `PlotParameters` model which requests `stratum` along the X-axis
+        When `get_x_and_y_values()` is called
+        Then the call is delegated to `sort_by_stratum()`
+        """
+        # Given
+        fake_chart_plot_parameters.x_axis = ChartAxisFields.stratum.name
+        mocked_queryset = mock.Mock()
+
+        # When
+        x_and_y_values = get_x_and_y_values(
+            plot_parameters=fake_chart_plot_parameters, queryset=mocked_queryset
+        )
+
+        # Then
+        assert x_and_y_values == spy_sort_by_stratum.return_value
+        spy_sort_by_stratum.assert_called_once_with(queryset=mocked_queryset)
+
+    @pytest.mark.parametrize(
+        "x_axis",
+        [
+            ChartAxisFields.date.name,
+            ChartAxisFields.metric.name,
+            ChartAxisFields.geography.name,
+        ],
+    )
+    @mock.patch(f"{MODULE_PATH}.unzip_values")
+    def test_delegates_call_to_unzip_values(
+        self,
+        spy_unzip_values: mock.MagicMock,
+        x_axis: str,
+        fake_chart_plot_parameters: PlotParameters,
+    ):
+        """
+        Given a `PlotParameters` model which does not request `stratum` along the X-axis
+        When `get_x_and_y_values()` is called
+        Then the call is delegated to `unzip_values()`
+        """
+        # Given
+        mocked_queryset = mock.Mock()
+        fake_chart_plot_parameters.x_axis = x_axis
+
+        # When
+        x_and_y_values = get_x_and_y_values(
+            plot_parameters=fake_chart_plot_parameters, queryset=mocked_queryset
+        )
+
+        # Then
+        assert x_and_y_values == spy_unzip_values.return_value
+        spy_unzip_values.assert_called_once_with(values=mocked_queryset)
 
 
 class TestSortByStratum:


### PR DESCRIPTION
# Description

This PR refactors the `build_plot_data_from_parameters()` method on the `PlotsInterface` class by wrapping the decision on whether to call out to `sort_by_stratum()` or `unzip_values()` within one function -> `get_x_and_y_values()` 

Fixes #CDD-906

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit and integration tests at the right level to prove my change is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added screenshots or screen grabs where appropriate to demonstrate e2e testing
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

