### PR TITLE
Move `sex` field to `PlotSerializer`

### DIFF
--- a/metrics/api/serializers/plots.py
+++ b/metrics/api/serializers/plots.py
@@ -40,7 +40,13 @@ class PlotSerializer(serializers.Serializer):
         allow_null=True,
         default="",
     )
-
+    sex = serializers.CharField(
+        help_text=help_texts.SEX_FIELD,
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        default="",
+    )
     date_from = serializers.DateField(
         help_text=help_texts.DATE_FROM_FIELD,
         required=False,

--- a/tests/unit/metrics/api/serializers/test_charts.py
+++ b/tests/unit/metrics/api/serializers/test_charts.py
@@ -26,6 +26,7 @@ class TestChartPlotSerializer:
         "stratum",
         "geography",
         "geography_type",
+        "sex",
         "label",
         "line_colour",
         "line_type",

--- a/tests/unit/metrics/api/serializers/test_plots.py
+++ b/tests/unit/metrics/api/serializers/test_plots.py
@@ -9,6 +9,7 @@ class TestPlotSerializer:
         "stratum",
         "geography",
         "geography_type",
+        "sex",
     ]
 
     def test_validates_successfully_when_optional_parameters_are_none(
@@ -106,6 +107,39 @@ class TestPlotSerializer:
 
         for optional_param in self.optional_field_names:
             assert optional_param not in valid_data_payload
+
+        serializer = PlotSerializer(
+            data=valid_data_payload,
+            context={
+                "topic_manager": topic_manager,
+                "metric_manager": metric_manager,
+            },
+        )
+
+        # When
+        is_serializer_valid: bool = serializer.is_valid()
+
+        # Then
+        assert is_serializer_valid
+
+    @pytest.mark.parametrize("sex", ["ALL", "M", "F"])
+    def test_validates_successfully_with_valid_sex_field(
+        self, sex: str, plot_serializer_payload_and_model_managers
+    ):
+        """
+        Given a valid payload containing a valid `sex` field value
+            passed to a `PlotSerializer` object
+        And valid values for the `topic` and `metric`
+        When `is_valid()` is called from the serializer
+        Then True is returned
+        """
+        # Given
+        (
+            valid_data_payload,
+            metric_manager,
+            topic_manager,
+        ) = plot_serializer_payload_and_model_managers
+        valid_data_payload["sex"] = sex
 
         serializer = PlotSerializer(
             data=valid_data_payload,

--- a/tests/unit/metrics/api/serializers/test_tables.py
+++ b/tests/unit/metrics/api/serializers/test_tables.py
@@ -12,6 +12,7 @@ class TestTablePlotSerializer:
         "stratum",
         "geography",
         "geography_type",
+        "sex",
         "label",
         "x_axis",
         "y_axis",


### PR DESCRIPTION
# Description

This PR re-implements the `sex` field on the `PlotSerializer`.
As this was removed from the charts serializer on a recent PR to centralise the serializer for downloads and tables

Fixes #CDD-918

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit and integration tests at the right level to prove my change is effective
- [x] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

