### PR TITLE
CDD-925 BE: sort_by_stratum cannot handle non-number stratum values

### DIFF
--- a/metrics/interfaces/plots/access.py
+++ b/metrics/interfaces/plots/access.py
@@ -207,14 +207,15 @@ def convert_type(s: str) -> Union[int, str]:
         s: A string that may or may not be a number
 
     Returns:
-        The input as a number or the string itself (converted to lowercase so it sorts as one would expect)
+        The input as a number or the string itself.
+        This is converted to lowercase, so it sorts as one would expect
+
     """
     return int(s) if s.isdigit() else s.lower()
 
 
-def create_sort(stratum: str) -> Tuple:
-    """
-    Take a Stratum and make it sortable
+def create_sortable_stratum(stratum: str) -> Tuple[int, ...]:
+    """Take a Stratum and make it sortable
 
     Args:
         A Stratum value.
@@ -252,7 +253,7 @@ def sort_by_stratum(queryset: QuerySet) -> Tuple[List, List]:
         A properly sorted and displayable version broken into two separate lists
     """
     # Make a dictionary where the key is a tuple of the stratum values. So, 45_54 becomes (45, 54) etc
-    temp_dict = {create_sort(stratum=x[0]): x for x in queryset}
+    temp_dict = {create_sortable_stratum(stratum=x[0]): x for x in queryset}
 
     # Now sort on the tuple and return the x and y values
     # Change the Stratum so it looks nice. eg. 0_4 becomes 0-4

--- a/tests/unit/metrics/interfaces/plots/test_access.py
+++ b/tests/unit/metrics/interfaces/plots/test_access.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import List, Union
+from typing import List, Tuple, Union
 from unittest import mock
 
 import pytest
@@ -10,7 +10,7 @@ from metrics.interfaces.plots.access import (
     DataNotFoundError,
     PlotsInterface,
     convert_type,
-    create_sort,
+    create_sortable_stratum,
     get_x_and_y_values,
     sort_by_stratum,
     unzip_values,
@@ -426,27 +426,57 @@ class TestConvertType:
         assert mock_output == actual_output
 
 
-class TestCreateSort:
+class TestCreateSortableStratum:
     @pytest.mark.parametrize(
-        "mock_input, mock_output",
+        "input_stratum, expected_output",
         [
             ("0_4", (0, 4)),
+            ("5_9", (5, 9)),
+            ("5_14", (5, 14)),
+            ("10_14", (10, 14)),
             ("20_24", (20, 24)),
+            ("35_39", (35, 39)),
+            ("55_59", (55, 59)),
+            ("55_64", (55, 64)),
             ("65+", (65,)),
-            ("default", (999, 999, "default")),
+            ("65_69", (65, 69)),
+            ("70_74", (70, 74)),
+            ("75_84", (75, 84)),
+            ("85_89", (85, 89)),
+            ("90+", (90,)),
         ],
     )
-    def test_basic_operation(self, mock_input: str, mock_output: Union[int, str]):
+    def test_basic_operation(
+        self, input_stratum: str, expected_output: Tuple[Union[int, str]]
+    ):
         """
         Given a string that may or may not contain numbers
         When `create_sort()` is called
-        Then expected result is returned
+        Then the expected result is returned
         """
-        # Given/When
-        actual_output = create_sort(stratum=mock_input)
+        # Given
+        stratum = input_stratum
+
+        # When
+        actual_output = create_sortable_stratum(stratum=stratum)
 
         # Then
-        assert mock_output == actual_output
+        assert actual_output == expected_output
+
+    def test_return_max_value_when_text_is_given(self):
+        """
+        Given the string of "default"
+        When `create_sort()` is called
+        Then a tuple is returned with a max value of 999
+        """
+        # Given
+        default = "default"
+
+        # When
+        stratum_output = create_sortable_stratum(stratum=default)
+
+        # Then
+        assert stratum_output == (999, 999, default)
 
 
 class TestSortByStratum:
@@ -459,7 +489,13 @@ class TestSortByStratum:
         And in display format
         """
         # Given
-        values = [("default", 5), ("65_84", 1), ("6_17", 2), ("85+", 3), ("18_64", 4)]
+        values = [
+            ("65_84", 1),
+            ("6_17", 2),
+            ("85+", 3),
+            ("18_64", 4),
+            ("default", 5),
+        ]
 
         # When
         first_list, second_list = sort_by_stratum(values)


### PR DESCRIPTION
# Description

Bug fix for when Stratum was not numeric

Fixes #[CDD-925](https://digitaltools.phe.org.uk/browse/CDD-925)

## Type of change

Please select the options that are relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added unit and integration tests at the right level to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

