### PR TITLE
Increase `TIMEOUT` so connections wait longer for an overflow connection to be available

### DIFF
--- a/metrics/api/settings.py
+++ b/metrics/api/settings.py
@@ -144,8 +144,11 @@ else:
                 # Number of connections to be persisted at all times
                 "MAX_OVERFLOW": 10,
                 # Additional connections to be created at peak loads
-                "RECYCLE": 24 * 60 * 60
+                "RECYCLE": 24 * 60 * 60,
                 # Time to close and replace connections
+                "TIMEOUT": 60 * 10,
+                # Period of time to wait for a connection to become available
+                # during peak loads when all overflow slots are occupied
             },
         }
     }


### PR DESCRIPTION
# Description

Increase the `TIMEOUT` that db connections should wait for during peakloads before erroring. 
We know that right now the next.js compile step takes way too long, and we're unneccessarily letting the next.js server compile every minute. 

Consider this a bit of a sticking plaster until we've got a better solution into place. 
Most likely something like pbbouncer 

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

