### PR TITLE
Move `_setup_core_time_series` type test methods into centralised fixtures

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,6 +1,11 @@
+import datetime
+from typing import List
+
 import pytest
 from rest_framework.test import APIClient
 from rest_framework_api_key.models import APIKey
+
+from metrics.data.models.core_models import CoreTimeSeries, Metric, Topic
 
 
 @pytest.fixture
@@ -11,3 +16,65 @@ def authenticated_api_client() -> APIClient:
     api_client.credentials(HTTP_AUTHORIZATION=key)
 
     return api_client
+
+
+@pytest.fixture
+def core_headline_example() -> CoreTimeSeries:
+    topic = Topic.objects.create(name="COVID-19")
+    metric = Metric.objects.create(
+        name="COVID-19_headline_newtests_7daycounttotal", topic=topic
+    )
+    year = 2023
+    return CoreTimeSeries.objects.create(
+        metric_value=123,
+        metric=metric,
+        year=year,
+        epiweek=1,
+        dt=datetime.date(year=year, month=1, day=1),
+    )
+
+
+@pytest.fixture
+def core_trend_percentage_example() -> List[CoreTimeSeries]:
+    topic = Topic.objects.create(name="COVID-19")
+    metric = Metric.objects.create(
+        name="COVID-19_headline_ONSdeaths_7daychange", topic=topic
+    )
+    percentage_metric = Metric.objects.create(
+        name="COVID-19_headline_ONSdeaths_7daypercentchange", topic=topic
+    )
+
+    year = 2023
+
+    main_timeseries: CoreTimeSeries = CoreTimeSeries.objects.create(
+        metric_value=123,
+        metric=metric,
+        year=year,
+        epiweek=1,
+        dt=datetime.date(year=year, month=1, day=1),
+    )
+    percentage_timeseries: CoreTimeSeries = CoreTimeSeries.objects.create(
+        metric_value=3,
+        metric=percentage_metric,
+        year=year,
+        epiweek=1,
+        dt=datetime.date(year=year, month=1, day=1),
+    )
+    return [main_timeseries, percentage_timeseries]
+
+
+@pytest.fixture
+def core_timeseries_example() -> List[CoreTimeSeries]:
+    topic = Topic.objects.create(name="COVID-19")
+    metric = Metric.objects.create(name="COVID-19_deaths_ONSByDay", topic=topic)
+    year = 2023
+    return [
+        CoreTimeSeries.objects.create(
+            metric_value=123,
+            metric=metric,
+            year=year,
+            epiweek=1,
+            dt=datetime.date(year=year, month=1, day=i + 1),
+        )
+        for i in range(2)
+    ]

--- a/tests/integration/metrics/api/views/test_charts.py
+++ b/tests/integration/metrics/api/views/test_charts.py
@@ -1,42 +1,26 @@
-import datetime
 from http import HTTPStatus
+from typing import List
 
 import pytest
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
-from metrics.data.models.core_models import CoreTimeSeries, Metric, Topic
+from metrics.data.models.core_models import CoreTimeSeries
 
 
 class TestChartsView:
-    metric_name = "vaccinations_percentage_uptake_spring22"
-    topic_name = "COVID-19"
-
-    valid_payload = {
-        "file_format": "svg",
-        "plots": [
-            {
-                "topic": topic_name,
-                "metric": metric_name,
-                "chart_type": "waffle",
-            }
-        ],
-    }
-
     @staticmethod
-    def _setup_core_time_series(
-        topic_name: str, metric_name: str, metric_value: float
-    ) -> CoreTimeSeries:
-        topic = Topic.objects.create(name=topic_name)
-        metric = Metric.objects.create(name=metric_name, topic=topic)
-        year = 2023
-        return CoreTimeSeries.objects.create(
-            metric_value=metric_value,
-            metric=metric,
-            year=year,
-            epiweek=1,
-            dt=datetime.date(year=year, month=1, day=1),
-        )
+    def _build_valid_payload_for_existing_timeseries(core_timeseries: CoreTimeSeries):
+        return {
+            "file_format": "svg",
+            "plots": [
+                {
+                    "topic": core_timeseries.metric.topic.name,
+                    "metric": core_timeseries.metric.name,
+                    "chart_type": "waffle",
+                }
+            ],
+        }
 
     @pytest.mark.parametrize("path", ["/charts/v2", "/api/charts/v2"])
     @pytest.mark.django_db
@@ -44,6 +28,7 @@ class TestChartsView:
         self,
         path: str,
         authenticated_api_client: APIClient,
+        core_timeseries_example: List[CoreTimeSeries],
     ):
         """
         Given a valid payload to create a chart
@@ -52,14 +37,14 @@ class TestChartsView:
         Then the response is still a valid HTTP 200 OK
         """
         # Given
-        self._setup_core_time_series(
-            metric_name=self.metric_name, metric_value=13, topic_name=self.topic_name
+        valid_payload = self._build_valid_payload_for_existing_timeseries(
+            core_timeseries=core_timeseries_example[0]
         )
 
         # When
         response: Response = authenticated_api_client.post(
             path=path,
-            data=self.valid_payload,
+            data=valid_payload,
             format="json",
         )
 
@@ -68,7 +53,10 @@ class TestChartsView:
     @pytest.mark.parametrize("path", ["/charts/v2/", "/api/charts/v2/"])
     @pytest.mark.django_db
     def test_returns_correct_response(
-        self, path: str, authenticated_api_client: APIClient
+        self,
+        path: str,
+        authenticated_api_client: APIClient,
+        core_timeseries_example: List[CoreTimeSeries],
     ):
         """
         Given a valid payload to create a chart
@@ -77,14 +65,14 @@ class TestChartsView:
         Then the response is not an HTTP 401 UNAUTHORIZED
         """
         # Given
-        self._setup_core_time_series(
-            metric_name=self.metric_name, metric_value=13, topic_name=self.topic_name
+        valid_payload = self._build_valid_payload_for_existing_timeseries(
+            core_timeseries=core_timeseries_example[0]
         )
 
         # When
         response: Response = authenticated_api_client.post(
             path=path,
-            data=self.valid_payload,
+            data=valid_payload,
             format="json",
         )
 
@@ -118,6 +106,7 @@ class TestChartsView:
         self,
         path: str,
         authenticated_api_client: APIClient,
+        core_timeseries_example: List[CoreTimeSeries],
     ):
         """
         Given a valid payload to create a chart
@@ -126,14 +115,14 @@ class TestChartsView:
         Then the response is still a valid HTTP 200 OK
         """
         # Given
-        self._setup_core_time_series(
-            metric_name=self.metric_name, metric_value=13, topic_name=self.topic_name
+        valid_payload = self._build_valid_payload_for_existing_timeseries(
+            core_timeseries=core_timeseries_example[0]
         )
 
         # When
         response: Response = authenticated_api_client.post(
             path=path,
-            data=self.valid_payload,
+            data=valid_payload,
             format="json",
         )
 
@@ -142,7 +131,10 @@ class TestChartsView:
     @pytest.mark.parametrize("path", ["/charts/v3/", "/api/charts/v3/"])
     @pytest.mark.django_db
     def test_returns_correct_response(
-        self, path: str, authenticated_api_client: APIClient
+        self,
+        path: str,
+        authenticated_api_client: APIClient,
+        core_timeseries_example: List[CoreTimeSeries],
     ):
         """
         Given a valid payload to create a chart
@@ -151,14 +143,14 @@ class TestChartsView:
         Then the response is not an HTTP 401 UNAUTHORIZED
         """
         # Given
-        self._setup_core_time_series(
-            metric_name=self.metric_name, metric_value=13, topic_name=self.topic_name
+        valid_payload = self._build_valid_payload_for_existing_timeseries(
+            core_timeseries=core_timeseries_example[0]
         )
 
         # When
         response: Response = authenticated_api_client.post(
             path=path,
-            data=self.valid_payload,
+            data=valid_payload,
             format="json",
         )
 

--- a/tests/integration/metrics/api/views/test_headlines.py
+++ b/tests/integration/metrics/api/views/test_headlines.py
@@ -1,29 +1,14 @@
-import datetime
 from http import HTTPStatus
+from typing import List
 
 import pytest
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
-from metrics.data.models.core_models import CoreTimeSeries, Metric, Topic
+from metrics.data.models.core_models import CoreTimeSeries
 
 
 class TestHeadlinesView:
-    @staticmethod
-    def _setup_core_time_series(
-        topic_name: str, metric_name: str, metric_value: float
-    ) -> CoreTimeSeries:
-        topic = Topic.objects.create(name=topic_name)
-        metric = Metric.objects.create(name=metric_name, topic=topic)
-        year = 2023
-        return CoreTimeSeries.objects.create(
-            metric_value=metric_value,
-            metric=metric,
-            year=year,
-            epiweek=1,
-            dt=datetime.date(year=year, month=1, day=1),
-        )
-
     @property
     def path(self) -> str:
         return "/headlines/v2/"
@@ -31,7 +16,10 @@ class TestHeadlinesView:
     @pytest.mark.parametrize("path", ["/headlines/v2/", "/api/headlines/v2/"])
     @pytest.mark.django_db
     def test_get_returns_correct_response(
-        self, path: str, authenticated_api_client: APIClient
+        self,
+        path: str,
+        authenticated_api_client: APIClient,
+        core_headline_example: CoreTimeSeries,
     ):
         """
         Given the names of a `metric` and `topic`
@@ -40,12 +28,8 @@ class TestHeadlinesView:
         Then an HTTP 200 OK response is returned with the associated metric_value
         """
         # Given
-        metric_name = "new_cases_7days_sum"
-        topic_name = "COVID-19"
-        metric_value = 123
-        self._setup_core_time_series(
-            topic_name=topic_name, metric_name=metric_name, metric_value=metric_value
-        )
+        topic_name: str = core_headline_example.metric.topic.name
+        metric_name: str = core_headline_example.metric.name
 
         # When
         response: Response = authenticated_api_client.get(
@@ -54,12 +38,15 @@ class TestHeadlinesView:
 
         # Then
         assert response.status_code == HTTPStatus.OK
-        assert response.data == {"value": metric_value}
+        assert response.data == {"value": core_headline_example.metric_value}
 
     @pytest.mark.parametrize("path", ["/headlines/v2/", "/api/headlines/v2/"])
     @pytest.mark.django_db
     def test_get_returns_error_message_for_timeseries_type_metric(
-        self, path: str, authenticated_api_client: APIClient
+        self,
+        path: str,
+        authenticated_api_client: APIClient,
+        core_timeseries_example: List[CoreTimeSeries],
     ):
         """
         Given a `topic` and a `metric` which has more than 1 record and is a timeseries type metric
@@ -68,27 +55,19 @@ class TestHeadlinesView:
         Then an HTTP 400 BAD REQUEST response is returned with the expected error message
         """
         # Given
-        incorrect_metric_name = "new_cases_daily"
-        topic_name = "COVID-19"
-        metric_value = 123
-
-        # Create multiple records to emulate time-series type data
-        for _ in range(2):
-            self._setup_core_time_series(
-                topic_name=topic_name,
-                metric_name=incorrect_metric_name,
-                metric_value=metric_value,
-            )
+        core_timeseries: CoreTimeSeries = core_timeseries_example[0]
+        topic_name: str = core_timeseries.metric.topic.name
+        metric_name: str = core_timeseries.metric.name
 
         # When
         response: Response = authenticated_api_client.get(
             path=path,
-            data={"topic": topic_name, "metric": incorrect_metric_name},
+            data={"topic": topic_name, "metric": metric_name},
         )
 
         # Then
         assert response.status_code == HTTPStatus.BAD_REQUEST
-        expected_error_message = f"`{incorrect_metric_name}` is a timeseries-type metric. This should be a headline-type metric"
+        expected_error_message = f"`{metric_name}` is a timeseries-type metric. This should be a headline-type metric"
         assert response.data == {"error_message": expected_error_message}
 
     @pytest.mark.parametrize("path", ["/headlines/v2/", "/api/headlines/v2/"])

--- a/tests/integration/metrics/api/views/test_trends.py
+++ b/tests/integration/metrics/api/views/test_trends.py
@@ -1,50 +1,22 @@
-import datetime
 from http import HTTPStatus
+from typing import List
 
 import pytest
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
-from metrics.data.models.core_models import CoreTimeSeries, Metric, Topic
+from metrics.data.models.core_models import CoreTimeSeries, Topic
 
 
 class TestTrendsView:
-    @staticmethod
-    def _setup_core_time_series(
-        topic_name: str,
-        metric_name: str,
-        metric_value: float,
-        percentage_metric_name: str,
-        percentage_metric_value: float,
-    ) -> CoreTimeSeries:
-        year = 2023
-        date = datetime.date(year=year, month=1, day=1)
-
-        topic = Topic.objects.create(name=topic_name)
-        metric = Metric.objects.create(name=metric_name, topic=topic)
-        percentage_metric = Metric.objects.create(
-            name=percentage_metric_name, topic=topic
-        )
-
-        CoreTimeSeries.objects.create(
-            metric_value=metric_value,
-            metric=metric,
-            year=year,
-            epiweek=1,
-            dt=date,
-        )
-        CoreTimeSeries.objects.create(
-            metric_value=percentage_metric_value,
-            metric=percentage_metric,
-            year=year,
-            epiweek=1,
-            dt=date,
-        )
-
     @pytest.mark.parametrize("path", ["/trends/v2/", "/api/trends/v2/"])
     @pytest.mark.django_db
     def test_get_returns_correct_response(
-        self, path: str, authenticated_api_client: APIClient
+        self,
+        path: str,
+        authenticated_api_client: APIClient,
+        core_trend_percentage_example: List[CoreTimeSeries],
+        core_headline_example: CoreTimeSeries,
     ):
         """
         Given the names of a `topic`, `metric` and `percentage_metric`
@@ -53,29 +25,10 @@ class TestTrendsView:
         Then an HTTP 200 OK response is returned with the correct trend data
         """
         # Given
-        topic_name = "COVID-19"
-        metric_name = "new_deaths_7days_change"
-        metric_value = 123
-        percentage_metric_name = "new_deaths_7days_change_percentage"
-        percentage_metric_value = 1.3
-
-        # Create the records for the data which is expected to be returned
-        self._setup_core_time_series(
-            topic_name=topic_name,
-            metric_name=metric_name,
-            metric_value=metric_value,
-            percentage_metric_name=percentage_metric_name,
-            percentage_metric_value=percentage_metric_value,
-        )
-
-        # Create records for data which should be filtered out and not returned
-        self._setup_core_time_series(
-            topic_name="Influenza",
-            metric_name="weekly_positivity_change",
-            metric_value=-100,
-            percentage_metric_name="weekly_percent_change_positivity",
-            percentage_metric_value=-3.22,
-        )
+        main_record, percentage_record = core_trend_percentage_example
+        topic_name = main_record.metric.topic.name
+        metric_name = main_record.metric.name
+        percentage_metric_name = percentage_record.metric.name
 
         # When
         response: Response = authenticated_api_client.get(
@@ -93,16 +46,19 @@ class TestTrendsView:
             "colour": "red",
             "direction": "up",
             "metric_name": metric_name,
-            "metric_value": metric_value,
+            "metric_value": main_record.metric_value,
             "percentage_metric_name": percentage_metric_name,
-            "percentage_metric_value": percentage_metric_value,
+            "percentage_metric_value": percentage_record.metric_value,
         }
         assert response.data == expected_response_data
 
     @pytest.mark.parametrize("path", ["/trends/v2/", "/api/trends/v2/"])
     @pytest.mark.django_db
     def test_get_returns_error_message_for_timeseries_type_metric(
-        self, path: str, authenticated_api_client: APIClient
+        self,
+        path: str,
+        authenticated_api_client: APIClient,
+        core_trend_percentage_example: List[CoreTimeSeries],
     ):
         """
         Given the names of a `metric`, `percentage_metric` as well as an incorrect `topic`
@@ -111,16 +67,10 @@ class TestTrendsView:
         Then an HTTP 400 BAD REQUEST response is returned with the expected error message
         """
         # Given
-        topic_name = "COVID-19"
-        metric_name = "new_deaths_7days_change"
-        percentage_metric_name = "new_deaths_7days_change_percentage"
-        self._setup_core_time_series(
-            topic_name=topic_name,
-            metric_name=metric_name,
-            metric_value=123,
-            percentage_metric_name=percentage_metric_name,
-            percentage_metric_value=1.3,
-        )
+        main_record, percentage_record = core_trend_percentage_example
+        topic_name = main_record.metric.topic.name
+        metric_name = main_record.metric.name
+        percentage_metric_name = percentage_record.metric.name
 
         # The `Topic` record needs to be available
         # Or else the serializer will invalidate the field choice first


### PR DESCRIPTION
# Description

This PR is the start of the prep work needed for the big data migration work stream.
This PR removes all the setup time series type methods on the various test classes and replaces them with a couple of centralised re-useale fixtures.

The idea being when I come to switch over to the new schema I can isolate the changes that I'll need to make

Fixes #CDD-970

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit and integration tests at the right level to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

