### PR TITLE
Replace class method call `_build_example_metric` in favour of delegating call to `FakeMetricFactory`

### DIFF
--- a/tests/fakes/factories/metrics/core_time_series_factory.py
+++ b/tests/fakes/factories/metrics/core_time_series_factory.py
@@ -85,7 +85,9 @@ class FakeCoreTimeSeriesFactory(factory.Factory):
     ) -> List[FakeCoreTimeSeries]:
         time_series_records = []
 
-        metric: FakeMetric = FakeMetricFactory.build_example_metric(metric_name=metric_name)
+        metric: FakeMetric = FakeMetricFactory.build_example_metric(
+            metric_name=metric_name
+        )
         metric_value: int = cls._pick_random_positive_metric_value()
 
         percentage_metric: FakeMetric = FakeMetricFactory.build_example_metric(


### PR DESCRIPTION
# Description

Yet another schema prep PR

Fixes #CDD-970

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

