### PR TITLE
Set `x_axis` and `y_axis` on plots before filtering for timeseries

### DIFF
--- a/metrics/interfaces/plots/access.py
+++ b/metrics/interfaces/plots/access.py
@@ -127,13 +127,13 @@ class PlotsInterface:
                 for a particular plot.
 
         """
-        timeseries_queryset = self.get_timeseries_for_plot_parameters(
-            plot_parameters=plot_parameters
-        )
-
         # Set each plot with the selected chart-level x and y-axis choices
         plot_parameters.x_axis = self.plots_collection.x_axis
         plot_parameters.y_axis = self.plots_collection.y_axis
+
+        timeseries_queryset = self.get_timeseries_for_plot_parameters(
+            plot_parameters=plot_parameters
+        )
 
         try:
             x_axis_values, y_axis_values = get_x_and_y_values(


### PR DESCRIPTION
# Description

Fixes #CDD-971

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [x] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

