### PR TITLE
Drop `wagtail` from version `5.0.2` -> `5.0.1` due to bug with trying to locate new static file `wagtailadmin/js/vendor/jquery.autosize.js`

### DIFF
--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -96,7 +96,7 @@ typing_extensions==4.4.0
 uritemplate==4.1.1
 urllib3==1.26.15
 virtualenv==20.16.5
-wagtail==5.0.2
+wagtail==5.0.1
 webencodings==0.5.1
 Willow==1.5.0
 zipp==3.13.0


### PR DESCRIPTION
# Description

This PR drops the version of wagtail by 1 patch version.

There was a gnarly bug:

```
  File "/Users/afaanashiq/projects/ukhsa/winter-pressures-api/venv/lib/python3.11/site-packages/django/contrib/staticfiles/storage.py", line 182, in _url
    hashed_name = hashed_name_func(*args)
                  ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/afaanashiq/projects/ukhsa/winter-pressures-api/venv/lib/python3.11/site-packages/django/contrib/staticfiles/storage.py", line 513, in stored_name
    raise ValueError(
ValueError: Missing staticfiles manifest entry for 'wagtailadmin/js/vendor/jquery.autosize.js'
```

Which only happened when `DEBUG=False`

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

