### PR TITLE
Implement `reason`, `improve_experience`, `like_to_see` and `did_you_find_everything` questions on suggestions serializer

### DIFF
--- a/feedback/serializers/help_texts.py
+++ b/feedback/serializers/help_texts.py
@@ -1,6 +1,19 @@
-QUESTION_FIELD_HELP_TEXT = """
-The question which was asked on the form
+QUESTION_REASON_HELP_TEXT = """
+The answer for the *reason* question provided by the user.
+This is the answer to the question of what was the reason of the users visit to the dashboard.
 """
-ANSWER_FIELD_HELP_TEXT = """
-The answer submitted by the user for the corresponding question
+
+QUESTION_IMPROVE_EXPERIENCE_HELP_TEXT = """
+The answer for the *improve_experience* question provided by the user.
+This is the answer to the question of how we could improve the user experience of the dashboard.
+"""
+
+QUESTION_LIKE_TO_SEE_HELP_TEXT = """
+The answer for the *like_to_see* question provided by the user.
+This is the answer to the question of what the user would like to see on the dashboard in the future. 
+"""
+
+QUESTION_DID_YOU_FIND_EVERYTHING_HELP_TEXT = """
+The answer for the *did_you_find_everything* question provided by the user.
+Note that this can only be a choice of either *yes* or *no*.
 """

--- a/feedback/serializers/questions.py
+++ b/feedback/serializers/questions.py
@@ -2,23 +2,31 @@ from rest_framework import serializers
 
 from feedback.serializers import help_texts
 
-
-class QuestionAnswerSerializer(serializers.Serializer):
-    question = serializers.CharField(
-        help_text=help_texts.QUESTION_FIELD_HELP_TEXT,
-        required=True,
-        allow_blank=False,
-    )
-    answer = serializers.CharField(
-        help_text=help_texts.ANSWER_FIELD_HELP_TEXT,
-        required=True,
-        allow_blank=False,
-    )
-
-
-class QuestionAnswerListSerializer(serializers.ListSerializer):
-    child = QuestionAnswerSerializer()
+DID_YOU_FIND_EVERYTHING_CHOICES: tuple[str, str] = ("yes", "no")
 
 
 class SuggestionsSerializer(serializers.Serializer):
-    suggestions = QuestionAnswerListSerializer()
+    reason = serializers.CharField(
+        help_text=help_texts.QUESTION_REASON_HELP_TEXT,
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    improve_experience = serializers.CharField(
+        help_text=help_texts.QUESTION_IMPROVE_EXPERIENCE_HELP_TEXT,
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    like_to_see = serializers.CharField(
+        help_text=help_texts.QUESTION_LIKE_TO_SEE_HELP_TEXT,
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    did_you_find_everything = serializers.ChoiceField(
+        help_text=help_texts.QUESTION_DID_YOU_FIND_EVERYTHING_HELP_TEXT,
+        required=True,
+        allow_blank=False,
+        choices=DID_YOU_FIND_EVERYTHING_CHOICES,
+    )

--- a/tests/integration/feedback/views/test_suggestions.py
+++ b/tests/integration/feedback/views/test_suggestions.py
@@ -17,7 +17,12 @@ class TestSuggestionsView:
         """
         # Given
         path = "/api/suggestions/v1/"
-        valid_payload = {"suggestions": [{"question": "string", "answer": "string"}]}
+        valid_payload = {
+            "reason": "I wanted to find out the infection rates of Disease X in my area",
+            "improve_experience": "More context around metrics and figures",
+            "like_to_see": "I'd like to see more consistency across charts and graphs",
+            "did_you_find_everything": "yes",
+        }
 
         # When
         response: Response = authenticated_api_client.post(


### PR DESCRIPTION
# Description

This PR reconfigures the `suggestions/` endpoint so that it takes 4 question answer pairs:

- *reason* - optional string
- *improve_experience* - optional string 
- *like_to_see* - optional string
- *did_you_find_everything* - mandatory, choice of `yes` or `no`

The first 3 answers can be an empty string | null | not provided at all

![Screenshot 2023-07-11 at 11 14 58](https://github.com/UKHSA-Internal/winter-pressures-api/assets/47219506/ac858cf4-a20c-40c2-a56f-8eaf03d43600)

![Screenshot 2023-07-11 at 11 15 05](https://github.com/UKHSA-Internal/winter-pressures-api/assets/47219506/f4ce8b98-d4e3-49a1-94a1-9d3649f59f87)

Fixes #CDD-CDD-957

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit and integration tests at the right level to prove my change is effective
- [x] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

