### PR TITLE
Remove redundant private API endpoints

### DIFF
--- a/metrics/api/urls_construction.py
+++ b/metrics/api/urls_construction.py
@@ -56,14 +56,6 @@ private_api_urlpatterns = [
     re_path(f"^{API_PREFIX}tables/v2", TablesView.as_view()),
     re_path(f"^{API_PREFIX}trends/v2", TrendsView.as_view()),
     re_path(f"^{API_PREFIX}suggestions/v1", SuggestionsView.as_view()),
-    # Endpoints to be migrated away from
-    re_path(r"^upload/$", FileUploadView.as_view()),
-    re_path(r"^charts/v2", ChartsView.as_view()),
-    re_path(r"^charts/v3", EncodedChartsView.as_view()),
-    re_path(r"^downloads/v2", DownloadsView.as_view()),
-    re_path(r"^headlines/v2", HeadlinesView.as_view()),
-    re_path(r"^tables/v2", TablesView.as_view()),
-    re_path(r"^trends/v2", TrendsView.as_view()),
 ]
 
 docs_urlspatterns = [

--- a/tests/integration/metrics/api/views/test_charts.py
+++ b/tests/integration/metrics/api/views/test_charts.py
@@ -21,24 +21,23 @@ class TestChartsView:
             ],
         }
 
-    @pytest.mark.parametrize("path", ["/charts/v2", "/api/charts/v2"])
     @pytest.mark.django_db
     def test_hitting_endpoint_without_appended_forward_slash_redirects_correctly(
         self,
-        path: str,
         authenticated_api_client: APIClient,
         core_timeseries_example: list[CoreTimeSeries],
     ):
         """
         Given a valid payload to create a chart
         And an authenticated APIClient
-        When the `POST /charts/v2` endpoint is hit i.e. without the trailing `/`
+        When the `POST /api/charts/v2` endpoint is hit i.e. without the trailing `/`
         Then the response is still a valid HTTP 200 OK
         """
         # Given
         valid_payload = self._build_valid_payload_for_existing_timeseries(
             core_timeseries=core_timeseries_example[0]
         )
+        path = "/api/charts/v2"
 
         # When
         response: Response = authenticated_api_client.post(
@@ -49,24 +48,23 @@ class TestChartsView:
 
         assert response.status_code == HTTPStatus.OK
 
-    @pytest.mark.parametrize("path", ["/charts/v2/", "/api/charts/v2/"])
     @pytest.mark.django_db
     def test_returns_correct_response(
         self,
-        path: str,
         authenticated_api_client: APIClient,
         core_timeseries_example: list[CoreTimeSeries],
     ):
         """
         Given a valid payload to create a chart
         And an authenticated APIClient
-        When the `POST /charts/v2/` endpoint is hit
+        When the `POST /api/charts/v2/` endpoint is hit
         Then the response is not an HTTP 401 UNAUTHORIZED
         """
         # Given
         valid_payload = self._build_valid_payload_for_existing_timeseries(
             core_timeseries=core_timeseries_example[0]
         )
+        path = "/api/charts/v2/"
 
         # When
         response: Response = authenticated_api_client.post(
@@ -82,16 +80,16 @@ class TestChartsView:
         # Check that the headers on the response indicate an `svg` image being returned
         assert response.headers["Content-Type"] == "image/svg+xml"
 
-    @pytest.mark.parametrize("path", ["/charts/v2/", "/api/charts/v2/"])
     @pytest.mark.django_db
-    def test_post_request_without_api_key_is_unauthorized(self, path: str):
+    def test_post_request_without_api_key_is_unauthorized(self):
         """
         Given an APIClient which is not authenticated
-        When the `GET /charts/v2/` endpoint is hit
+        When the `POST /api/charts/v2/` endpoint is hit
         Then an HTTP 401 UNAUTHORIZED response is returned
         """
         # Given
         client = APIClient()
+        path = "/api/charts/v2/"
 
         # When
         response: Response = client.post(path=path, data={})
@@ -99,24 +97,23 @@ class TestChartsView:
         # Then
         assert response.status_code == HTTPStatus.UNAUTHORIZED
 
-    @pytest.mark.parametrize("path", ["/charts/v3", "/api/charts/v3"])
     @pytest.mark.django_db
     def test_hitting_endpoint_without_appended_forward_slash_redirects_correctly(
         self,
-        path: str,
         authenticated_api_client: APIClient,
         core_timeseries_example: list[CoreTimeSeries],
     ):
         """
         Given a valid payload to create a chart
         And an authenticated APIClient
-        When the `POST /charts/v3` endpoint is hit i.e. without the trailing `/`
+        When the `POST /api/charts/v3` endpoint is hit i.e. without the trailing `/`
         Then the response is still a valid HTTP 200 OK
         """
         # Given
         valid_payload = self._build_valid_payload_for_existing_timeseries(
             core_timeseries=core_timeseries_example[0]
         )
+        path = "/api/charts/v3"
 
         # When
         response: Response = authenticated_api_client.post(
@@ -127,24 +124,23 @@ class TestChartsView:
 
         assert response.status_code == HTTPStatus.OK
 
-    @pytest.mark.parametrize("path", ["/charts/v3/", "/api/charts/v3/"])
     @pytest.mark.django_db
     def test_returns_correct_response(
         self,
-        path: str,
         authenticated_api_client: APIClient,
         core_timeseries_example: list[CoreTimeSeries],
     ):
         """
         Given a valid payload to create a chart
         And an authenticated APIClient
-        When the `POST /charts/v3/` endpoint is hit
+        When the `POST /api/charts/v3/` endpoint is hit
         Then the response is not an HTTP 401 UNAUTHORIZED
         """
         # Given
         valid_payload = self._build_valid_payload_for_existing_timeseries(
             core_timeseries=core_timeseries_example[0]
         )
+        path = "/api/charts/v3/"
 
         # When
         response: Response = authenticated_api_client.post(
@@ -160,16 +156,16 @@ class TestChartsView:
         # Check that the headers on the response indicate a json response is being returned
         assert response.headers["Content-Type"] == "application/json"
 
-    @pytest.mark.parametrize("path", ["/charts/v3/", "/api/charts/v3/"])
     @pytest.mark.django_db
-    def test_post_request_without_api_key_is_unauthorized(self, path: str):
+    def test_post_request_without_api_key_is_unauthorized(self):
         """
         Given an APIClient which is not authenticated
-        When the `GET /charts/v3/` endpoint is hit
+        When the `POST /api/charts/v3/` endpoint is hit
         Then an HTTP 401 UNAUTHORIZED response is returned
         """
         # Given
         client = APIClient()
+        path = "/api/charts/v3/"
 
         # When
         response: Response = client.post(path=path, data={})

--- a/tests/integration/metrics/api/views/test_downloads.py
+++ b/tests/integration/metrics/api/views/test_downloads.py
@@ -61,19 +61,17 @@ class TestDownloadsView:
             metric_value=metric_value,
         )
 
-    @pytest.mark.parametrize("path", ["/downloads/v2", "/api/downloads/v2"])
     @pytest.mark.django_db
     def test_hitting_endpoint_without_appended_forward_slash_redirects_correctly(
-        self, path: str, authenticated_api_client: APIClient
+        self, authenticated_api_client: APIClient
     ):
         """
         Given a valid payload to request a download
         And an authenticated APIClient
-        When the `POST /downloads/v2` endpoint is hit i.e. without the trailing `/`
+        When the `POST /api/downloads/v2` endpoint is hit i.e. without the trailing `/`
         Then the response is still a valid HTTP 200 OK
         """
         # Given
-        path_without_trailing_forward_slash: str = path
         self._setup_api_time_series(**self.api_timeseries_data)
         valid_payload = {
             "file_format": "json",
@@ -84,6 +82,7 @@ class TestDownloadsView:
                 }
             ],
         }
+        path_without_trailing_forward_slash = "/api/downloads/v2"
 
         # When
         response: Response = authenticated_api_client.post(
@@ -95,15 +94,14 @@ class TestDownloadsView:
         # Then
         assert response.status_code == HTTPStatus.OK
 
-    @pytest.mark.parametrize("path", ["/downloads/v2/", "/api/downloads/v2/"])
     @pytest.mark.django_db
     def test_json_download_returns_correct_response(
-        self, path: str, authenticated_api_client: APIClient
+        self, authenticated_api_client: APIClient
     ):
         """
         Given a valid payload to request a download
         And an authenticated APIClient
-        When the `POST /downloads/v2/` endpoint is hit
+        When the `POST /api/downloads/v2/` endpoint is hit
         Then the response contains the expected output in json format
         """
         # Given
@@ -117,6 +115,7 @@ class TestDownloadsView:
                 }
             ],
         }
+        path = "/api/downloads/v2/"
 
         # When
         response: Response = authenticated_api_client.post(
@@ -137,15 +136,14 @@ class TestDownloadsView:
         # Check the output itself is as expected
         assert response.data[0] == self.api_timeseries_data
 
-    @pytest.mark.parametrize("path", ["/downloads/v2/", "/api/downloads/v2/"])
     @pytest.mark.django_db
     def test_csv_download_returns_correct_response(
-        self, path: str, authenticated_api_client: APIClient
+        self, authenticated_api_client: APIClient
     ):
         """
         Given a valid payload to request a download
         And an authenticated APIClient
-        When the `POST /downloads/v2/` endpoint is hit
+        When the `POST /api/downloads/v2/` endpoint is hit
         Then the response contains the expected output in csv format
         """
         # Given
@@ -159,35 +157,7 @@ class TestDownloadsView:
                 }
             ],
         }
-
-        expected_csv_heading = [
-            "theme",
-            "sub_theme",
-            "topic",
-            "geography_type",
-            "geography",
-            "metric",
-            "stratum",
-            "sex",
-            "year",
-            "dt",
-            "metric_value",
-        ]
-        expected_csv_content = [
-            [
-                "infectious_disease",
-                "respiratory",
-                "COVID-19",
-                "Nation",
-                "England",
-                "new_deaths_7day_avg",
-                "default",
-                "M",
-                "2023",
-                "2023-01-15",
-                "123.45",
-            ]
-        ]
+        path = "/api/downloads/v2/"
 
         # When
         response: Response = authenticated_api_client.post(
@@ -207,19 +177,48 @@ class TestDownloadsView:
         csv_output = list(csv_file)
         csv_header = csv_output.pop(0)
 
-        assert csv_header == expected_csv_heading
+        expected_csv_headings = [
+            "theme",
+            "sub_theme",
+            "topic",
+            "geography_type",
+            "geography",
+            "metric",
+            "stratum",
+            "sex",
+            "year",
+            "dt",
+            "metric_value",
+        ]
+        assert csv_header == expected_csv_headings
+
+        expected_csv_content = [
+            [
+                "infectious_disease",
+                "respiratory",
+                "COVID-19",
+                "Nation",
+                "England",
+                "new_deaths_7day_avg",
+                "default",
+                "M",
+                "2023",
+                "2023-01-15",
+                "123.45",
+            ]
+        ]
         assert csv_output == expected_csv_content
 
-    @pytest.mark.parametrize("path", ["/downloads/v2/", "/api/downloads/v2/"])
     @pytest.mark.django_db
-    def test_post_request_without_api_key_is_unauthorized(self, path: str):
+    def test_post_request_without_api_key_is_unauthorized(self):
         """
         Given an APIClient which is not authenticated
-        When the `GET /downloads/v2/` endpoint is hit
+        When the `POST /api/downloads/v2/` endpoint is hit
         Then an HTTP 401 UNAUTHORIZED response is returned
         """
         # Given
         client = APIClient()
+        path = "/api/downloads/v2/"
 
         # When
         response: Response = client.post(path=path, data={})

--- a/tests/integration/metrics/api/views/test_file_upload.py
+++ b/tests/integration/metrics/api/views/test_file_upload.py
@@ -8,17 +8,15 @@ from rest_framework.test import APIClient
 
 class TestFileUploadView:
     @pytest.mark.django_db
-    @pytest.mark.parametrize("path", ["/upload/", "/api/upload/"])
     @mock.patch("metrics.api.views.file_upload.load_core_data")
     def test_get_returns_correct_response(
         self,
         mocked_load_core_data: mock.MagicMock,
-        path: str,
         authenticated_api_client: APIClient,
     ):
         """
         Given an authenticated APIClient
-        When the `PUT /upload/` endpoint is hit
+        When the `PUT /api/upload/` endpoint is hit
         Then the response is not an HTTP 401 UNAUTHORIZED
 
         Patches:
@@ -26,24 +24,27 @@ class TestFileUploadView:
                 effect of uploading the data from the file
 
         """
-        # Given / When
+        # Given
+        path = "/api/upload/"
+
+        # When
         response: Response = authenticated_api_client.put(path=path)
 
         # Then
         assert response.status_code != HTTPStatus.UNAUTHORIZED
 
-    @pytest.mark.parametrize("path", ["/upload/", "/api/upload/"])
     @pytest.mark.django_db
     def test_get_request_without_api_key_is_unauthorized(
-        self, path: str, authenticated_api_client: APIClient
+        self, authenticated_api_client: APIClient
     ):
         """
         Given an APIClient which is not authenticated
-        When the `PUT /upload/` endpoint is hit
+        When the `PUT /api/upload/` endpoint is hit
         Then an HTTP 401 UNAUTHORIZED response is returned
         """
         # Given
         client = APIClient()
+        path = "/api/upload/"
 
         # When
         response: Response = client.put(path=path)

--- a/tests/integration/metrics/api/views/test_headlines.py
+++ b/tests/integration/metrics/api/views/test_headlines.py
@@ -12,23 +12,22 @@ class TestHeadlinesView:
     def path(self) -> str:
         return "/headlines/v2/"
 
-    @pytest.mark.parametrize("path", ["/headlines/v2/", "/api/headlines/v2/"])
     @pytest.mark.django_db
     def test_get_returns_correct_response(
         self,
-        path: str,
         authenticated_api_client: APIClient,
         core_headline_example: CoreTimeSeries,
     ):
         """
         Given the names of a `metric` and `topic`
         And an authenticated APIClient
-        When the `GET /headlines/v2/` endpoint is hit
+        When the `GET /api/headlines/v2/` endpoint is hit
         Then an HTTP 200 OK response is returned with the associated metric_value
         """
         # Given
         topic_name: str = core_headline_example.metric.metric_group.topic.name
         metric_name: str = core_headline_example.metric.name
+        path = "/api/headlines/v2/"
 
         # When
         response: Response = authenticated_api_client.get(
@@ -39,24 +38,23 @@ class TestHeadlinesView:
         assert response.status_code == HTTPStatus.OK
         assert response.data == {"value": core_headline_example.metric_value}
 
-    @pytest.mark.parametrize("path", ["/headlines/v2/", "/api/headlines/v2/"])
     @pytest.mark.django_db
     def test_get_returns_error_message_for_timeseries_type_metric(
         self,
-        path: str,
         authenticated_api_client: APIClient,
         core_timeseries_example: list[CoreTimeSeries],
     ):
         """
         Given a `topic` and a `metric` which has more than 1 record and is a timeseries type metric
         And an authenticated APIClient
-        When the `GET /headlines/v2/` endpoint is hit
+        When the `GET /api/headlines/v2/` endpoint is hit
         Then an HTTP 400 BAD REQUEST response is returned with the expected error message
         """
         # Given
         core_timeseries: CoreTimeSeries = core_timeseries_example[0]
         topic_name: str = core_timeseries.metric.metric_group.topic.name
         metric_name: str = core_timeseries.metric.name
+        path = "/api/headlines/v2/"
 
         # When
         response: Response = authenticated_api_client.get(
@@ -69,19 +67,19 @@ class TestHeadlinesView:
         expected_error_message = f"`{metric_name}` is a timeseries-type metric. This should be a headline-type metric"
         assert response.data == {"error_message": expected_error_message}
 
-    @pytest.mark.parametrize("path", ["/headlines/v2/", "/api/headlines/v2/"])
     @pytest.mark.django_db
-    def test_get_request_without_api_key_is_unauthorized(self, path: str):
+    def test_get_request_without_api_key_is_unauthorized(self):
         """
         Given the names of a `metric` and `topic`
         And an APIClient which is not authenticated
-        When the `GET /headlines/v2/` endpoint is hit
+        When the `GET /api/headlines/v2/` endpoint is hit
         Then an HTTP 401 UNAUTHORIZED response is returned
         """
         # Given
         metric_name = "COVID-19_headline_ONSdeaths_7daytotals"
         topic_name = "COVID-19"
         client = APIClient()
+        path = "/api/headlines/v2/"
 
         # When
         response: Response = client.get(

--- a/tests/integration/metrics/api/views/test_tables.py
+++ b/tests/integration/metrics/api/views/test_tables.py
@@ -8,26 +8,19 @@ from metrics.data.models.core_models import CoreTimeSeries
 
 
 class TestTablesView:
-    @property
-    def path(self) -> str:
-        return "/tables/v2/"
-
-    @pytest.mark.parametrize("path", ["/tables/v2", "/api/tables/v2"])
     @pytest.mark.django_db
     def test_hitting_endpoint_without_appended_forward_slash_redirects_correctly(
         self,
-        path: str,
         authenticated_api_client: APIClient,
         core_timeseries_example: list[CoreTimeSeries],
     ):
         """
         Given a valid payload to create a chart
         And an authenticated APIClient
-        When the `POST /tables/v2` endpoint is hit i.e. without the trailing `/`
+        When the `POST /api/tables/v2` endpoint is hit i.e. without the trailing `/`
         Then the response is still a valid HTTP 200 OK
         """
         # Given
-        path_without_trailing_forward_slash: str = path
         core_timeseries: CoreTimeSeries = core_timeseries_example[0]
         topic_name: str = core_timeseries.metric.metric_group.topic.name
         metric_name: str = core_timeseries.metric.name
@@ -44,28 +37,27 @@ class TestTablesView:
                 }
             ],
         }
+        path = "/api/tables/v2"
 
         # When
         response: Response = authenticated_api_client.post(
-            path=path_without_trailing_forward_slash,
+            path=path,
             data=valid_payload,
             format="json",
         )
 
         assert response.status_code == HTTPStatus.OK
 
-    @pytest.mark.parametrize("path", ["/tables/v2/", "/api/tables/v2/"])
     @pytest.mark.django_db
     def test_returns_correct_response_type(
         self,
-        path: str,
         authenticated_api_client: APIClient,
         core_timeseries_example: list[CoreTimeSeries],
     ):
         """
         Given a valid payload to create a chart
         And an authenticated APIClient
-        When the `POST /tables/v2/` endpoint is hit
+        When the `POST /api/tables/v2/` endpoint is hit
         Then the response is not an HTTP 401 UNAUTHORIZED
         """
         # Given
@@ -84,6 +76,7 @@ class TestTablesView:
                 }
             ],
         }
+        path = "/api/tables/v2/"
 
         # When
         response: Response = authenticated_api_client.post(
@@ -97,16 +90,16 @@ class TestTablesView:
         # Check that the headers on the response indicate a json-type reponse is being returned
         assert response.headers["Content-Type"] == "application/json"
 
-    @pytest.mark.parametrize("path", ["/tables/v2/", "/api/tables/v2/"])
     @pytest.mark.django_db
-    def test_post_request_without_api_key_is_unauthorized(self, path: str):
+    def test_post_request_without_api_key_is_unauthorized(self):
         """
         Given an APIClient which is not authenticated
-        When the `GET /tables/v2/` endpoint is hit
+        When the `GET /api/tables/v2/` endpoint is hit
         Then an HTTP 401 UNAUTHORIZED response is returned
         """
         # Given
         client = APIClient()
+        path = "/api/tables/v2/"
 
         # When
         response: Response = client.post(path=path, data={})
@@ -114,18 +107,16 @@ class TestTablesView:
         # Then
         assert response.status_code == HTTPStatus.UNAUTHORIZED
 
-    @pytest.mark.parametrize("path", ["/tables/v2/", "/api/tables/v2/"])
     @pytest.mark.django_db
     def test_single_plot_output_is_as_expected(
         self,
-        path: str,
         authenticated_api_client: APIClient,
         core_timeseries_example: list[CoreTimeSeries],
     ):
         """
         Given a valid payload to create a chart
         And an authenticated APIClient
-        When the `POST /tables/v2/` endpoint is hit with a single plot
+        When the `POST /api/tables/v2/` endpoint is hit with a single plot
         Then the response is of the correct format
         """
         # Given
@@ -144,7 +135,14 @@ class TestTablesView:
                 }
             ],
         }
+        path = "/api/tables/v2/"
 
+        # When
+        response: Response = authenticated_api_client.post(
+            path=path, data=valid_payload, format="json"
+        )
+
+        # Then
         expected_response = [
             {
                 "date": "2023-01-31",
@@ -156,27 +154,18 @@ class TestTablesView:
                 ],
             }
         ]
-
-        # When
-        response: Response = authenticated_api_client.post(
-            path=path, data=valid_payload, format="json"
-        )
-
-        # Then
         assert response.data == expected_response
 
-    @pytest.mark.parametrize("path", ["/tables/v2/", "/api/tables/v2/"])
     @pytest.mark.django_db
     def test_multiple_plot_output_is_as_expected(
         self,
-        path: str,
         authenticated_api_client: APIClient,
         core_timeseries_example: list[CoreTimeSeries],
     ):
         """
         Given a valid payload to create a chart
         And an authenticated APIClient
-        When the `POST /tables/v2/` endpoint is hit with multiple plots
+        When the `POST /api/tables/v2/` endpoint is hit with multiple plots
         Then the response is of the correct format
         """
         # Given
@@ -199,7 +188,14 @@ class TestTablesView:
                 },
             ],
         }
+        path = "/api/tables/v2/"
 
+        # When
+        response: Response = authenticated_api_client.post(
+            path=path, data=valid_payload, format="json"
+        )
+
+        # Then
         expected_response = [
             {
                 "date": "2023-01-31",
@@ -209,11 +205,4 @@ class TestTablesView:
                 ],
             }
         ]
-
-        # When
-        response: Response = authenticated_api_client.post(
-            path=path, data=valid_payload, format="json"
-        )
-
-        # Then
         assert response.data == expected_response

--- a/tests/integration/metrics/api/views/test_trends.py
+++ b/tests/integration/metrics/api/views/test_trends.py
@@ -8,11 +8,9 @@ from metrics.data.models.core_models import CoreTimeSeries, Topic
 
 
 class TestTrendsView:
-    @pytest.mark.parametrize("path", ["/trends/v2/", "/api/trends/v2/"])
     @pytest.mark.django_db
     def test_get_returns_correct_response(
         self,
-        path: str,
         authenticated_api_client: APIClient,
         core_trend_percentage_example: list[CoreTimeSeries],
         core_headline_example: CoreTimeSeries,
@@ -20,7 +18,7 @@ class TestTrendsView:
         """
         Given the names of a `topic`, `metric` and `percentage_metric`
         And an authenticated APIClient
-        When the `GET /trends/v2/` endpoint is hit
+        When the `GET /api/trends/v2/` endpoint is hit
         Then an HTTP 200 OK response is returned with the correct trend data
         """
         # Given
@@ -28,6 +26,7 @@ class TestTrendsView:
         topic_name = main_record.metric.metric_group.topic.name
         metric_name = main_record.metric.name
         percentage_metric_name = percentage_record.metric.name
+        path = "/api/trends/v2/"
 
         # When
         response: Response = authenticated_api_client.get(
@@ -51,18 +50,16 @@ class TestTrendsView:
         }
         assert response.data == expected_response_data
 
-    @pytest.mark.parametrize("path", ["/trends/v2/", "/api/trends/v2/"])
     @pytest.mark.django_db
     def test_get_returns_error_message_for_timeseries_type_metric(
         self,
-        path: str,
         authenticated_api_client: APIClient,
         core_trend_percentage_example: list[CoreTimeSeries],
     ):
         """
         Given the names of a `metric`, `percentage_metric` as well as an incorrect `topic`
         And an authenticated APIClient
-        When the `GET /trends/v2/` endpoint is hit
+        When the `GET /api/trends/v2/` endpoint is hit
         Then an HTTP 400 BAD REQUEST response is returned with the expected error message
         """
         # Given
@@ -74,6 +71,7 @@ class TestTrendsView:
         # Or else the serializer will invalidate the field choice first
         incorrect_topic_name = "Influenza"
         Topic.objects.create(name=incorrect_topic_name)
+        path = "/api/trends/v2/"
 
         # When
         response: Response = authenticated_api_client.get(
@@ -92,19 +90,19 @@ class TestTrendsView:
         )
         assert response.data == {"error_message": expected_error_message}
 
-    @pytest.mark.parametrize("path", ["/trends/v2/", "/api/trends/v2/"])
     @pytest.mark.django_db
-    def test_get_request_without_api_key_is_unauthorized(self, path: str):
+    def test_get_request_without_api_key_is_unauthorized(self):
         """
         Given the names of a `topic`, `metric` and `percentage_metric`
         And an APIClient which is not authenticated
-        When the `GET /trends/v2/` endpoint is hit
+        When the `GET /api/trends/v2/` endpoint is hit
         Then an HTTP 401 UNAUTHORIZED response is returned
         """
         topic_name = "COVID-19"
         metric_name = "new_deaths_7days_change"
         percentage_metric_name = "new_deaths_7days_change_percentage"
         client = APIClient()
+        path = "/api/trends/v2/"
 
         # When
         response: Response = client.get(


### PR DESCRIPTION
# Description

This PR removes the private API endpoints which were not prefixed by `/api/`

Fixes #CDD-988

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

