### PR TITLE
Add architectural contracts for `feedback` module

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -103,9 +103,7 @@ source_modules=
     feedback
 forbidden_modules=
     cms
-    metrics.api
-    metrics.data
-    metrics.domain
+    metrics
     public_api
 
 [importlinter:contract:Feedback module not used by codebase]
@@ -113,9 +111,7 @@ name = The rest of the codebase does not depend on the feedback module except fo
 type = forbidden
 source_modules=
     cms
-    metrics.api
-    metrics.data
-    metrics.domain
+    metrics
     public_api
 forbidden_modules=
     feedback


### PR DESCRIPTION
# Description

This PR adds architectural contracts for the `feeback` module which should remain independent of the rest of the codebase. The only exception being the wiring of the endpoint into the URLs on the main django app

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

