### PR TITLE
Add help text for `stratum`, `geography` & `geography_type` fields on `ChartPlotElement`

### DIFF
--- a/cms/dynamic_content/blocks.py
+++ b/cms/dynamic_content/blocks.py
@@ -12,14 +12,10 @@ MAXIMUM_ROWS_NUMBER_BLOCK_COUNT: int = 2
 
 
 class HeadlineNumberBlockTypes(blocks.StreamBlock):
-    headline_number = HeadlineNumberComponent(
-        help_text=help_texts.HEADLINE_BLOCK_FIELD_HELP_TEXT
-    )
-    trend_number = TrendNumberComponent(
-        help_text=help_texts.TREND_BLOCK_FIELD_HELP_TEXT
-    )
+    headline_number = HeadlineNumberComponent(help_text=help_texts.HEADLINE_BLOCK_FIELD)
+    trend_number = TrendNumberComponent(help_text=help_texts.TREND_BLOCK_FIELD)
     percentage_number = PercentageNumberComponent(
-        help_text=help_texts.PERCENTAGE_BLOCK_FIELD_HELP_TEXT
+        help_text=help_texts.PERCENTAGE_BLOCK_FIELD
     )
 
     class Meta:
@@ -27,14 +23,12 @@ class HeadlineNumberBlockTypes(blocks.StreamBlock):
 
 
 class MetricNumberBlockTypes(blocks.StructBlock):
-    title = blocks.TextBlock(required=True, help_text=help_texts.TITLE_FIELD_HELP_TEXT)
+    title = blocks.TextBlock(required=True, help_text=help_texts.TITLE_FIELD)
     rows = HeadlineNumberBlockTypes(
         required=True,
         min_num=MINIMUM_ROWS_NUMBER_BLOCK_COUNT,
         max_num=MAXIMUM_ROWS_NUMBER_BLOCK_COUNT,
-        help_text=help_texts.NUMBERS_ROW_FIELD_HELP_TEXT.format(
-            MAXIMUM_ROWS_NUMBER_BLOCK_COUNT
-        ),
+        help_text=help_texts.NUMBERS_ROW_FIELD.format(MAXIMUM_ROWS_NUMBER_BLOCK_COUNT),
     )
 
     class Meta:

--- a/cms/dynamic_content/cards.py
+++ b/cms/dynamic_content/cards.py
@@ -9,7 +9,7 @@ from cms.metrics_interface.field_choices_callables import get_possible_axis_choi
 
 class TextCard(blocks.StructBlock):
     body = blocks.RichTextBlock(
-        features=AVAILABLE_RICH_TEXT_FEATURES, help_text=help_texts.TEXT_CARD_HELP_TEXT
+        features=AVAILABLE_RICH_TEXT_FEATURES, help_text=help_texts.TEXT_CARD
     )
 
     class Meta:
@@ -30,7 +30,7 @@ class HeadlineNumbersRowCard(blocks.StructBlock):
     columns = MetricNumberBlock(
         min_num=MINIMUM_HEADLINE_COLUMNS_COUNT,
         max_num=MAXIMUM_HEADLINE_COLUMNS_COUNT,
-        help_text=help_texts.HEADLINE_COLUMNS_FIELD_HELP_TEXT.format(
+        help_text=help_texts.HEADLINE_COLUMNS_FIELD.format(
             MAXIMUM_HEADLINE_COLUMNS_COUNT
         ),
     )
@@ -40,26 +40,24 @@ class HeadlineNumbersRowCard(blocks.StructBlock):
 
 
 class ChartWithHeadlineAndTrendCard(blocks.StructBlock):
-    title = blocks.TextBlock(required=True, help_text=help_texts.TITLE_FIELD_HELP_TEXT)
-    body = blocks.TextBlock(
-        required=False, help_text=help_texts.OPTIONAL_BODY_FIELD_HELP_TEXT
-    )
+    title = blocks.TextBlock(required=True, help_text=help_texts.TITLE_FIELD)
+    body = blocks.TextBlock(required=False, help_text=help_texts.OPTIONAL_BODY_FIELD)
     x_axis = blocks.ChoiceBlock(
         required=False,
         choices=get_possible_axis_choices,
-        help_text=help_texts.X_AXIS_HELP_TEXT,
+        help_text=help_texts.CHART_X_AXIS,
     )
     y_axis = blocks.ChoiceBlock(
         required=False,
         choices=get_possible_axis_choices,
-        help_text=help_texts.Y_AXIS_HELP_TEXT,
+        help_text=help_texts.CHART_Y_AXIS,
     )
-    chart = ChartComponent(help_text=help_texts.CHART_BLOCK_FIELD_HELP_TEXT)
+    chart = ChartComponent(help_text=help_texts.CHART_BLOCK_FIELD)
     headline_number_columns = HeadlineNumberBlockTypes(
         required=False,
         min_num=MINIMUM_HEADLINES_IN_CHART_CARD_COLUMN_COUNT,
         max_num=MAXIMUM_HEADLINES_IN_CHART_CARD_COLUMN_COUNT,
-        help_text=help_texts.HEADLINE_COLUMNS_IN_CHART_CARD_HELP_TEXT.format(
+        help_text=help_texts.HEADLINE_COLUMNS_IN_CHART_CARD.format(
             MAXIMUM_HEADLINES_IN_CHART_CARD_COLUMN_COUNT
         ),
     )
@@ -69,21 +67,19 @@ class ChartWithHeadlineAndTrendCard(blocks.StructBlock):
 
 
 class ChartCard(blocks.StructBlock):
-    title = blocks.TextBlock(required=True, help_text=help_texts.TITLE_FIELD_HELP_TEXT)
-    body = blocks.TextBlock(
-        required=False, help_text=help_texts.OPTIONAL_BODY_FIELD_HELP_TEXT
-    )
+    title = blocks.TextBlock(required=True, help_text=help_texts.TITLE_FIELD)
+    body = blocks.TextBlock(required=False, help_text=help_texts.OPTIONAL_BODY_FIELD)
     x_axis = blocks.ChoiceBlock(
         required=False,
         choices=get_possible_axis_choices,
-        help_text=help_texts.X_AXIS_HELP_TEXT,
+        help_text=help_texts.CHART_X_AXIS,
     )
     y_axis = blocks.ChoiceBlock(
         required=False,
         choices=get_possible_axis_choices,
-        help_text=help_texts.Y_AXIS_HELP_TEXT,
+        help_text=help_texts.CHART_Y_AXIS,
     )
-    chart = ChartComponent(help_text=help_texts.CHART_BLOCK_FIELD_HELP_TEXT)
+    chart = ChartComponent(help_text=help_texts.CHART_BLOCK_FIELD)
 
     class Meta:
         icon = "standalone_chart"
@@ -98,7 +94,7 @@ class ChartRowCard(blocks.StructBlock):
     columns = ChartRowBlockTypes(
         min_num=MINIMUM_COLUMNS_CHART_COLUMNS_COUNT,
         max_num=MAXIMUM_COLUMNS_CHART_COLUMNS_COUNT,
-        help_text=help_texts.CHART_CARD_ROW_HELP_TEXT,
+        help_text=help_texts.CHART_CARD_ROW,
     )
 
     class Meta:

--- a/cms/dynamic_content/components.py
+++ b/cms/dynamic_content/components.py
@@ -15,27 +15,23 @@ class ChartComponent(blocks.StreamBlock):
 
 
 class HeadlineNumberComponent(elements.BaseMetricsElement):
-    body = blocks.TextBlock(
-        required=False, help_text=help_texts.OPTIONAL_BODY_FIELD_HELP_TEXT
-    )
+    body = blocks.TextBlock(required=False, help_text=help_texts.OPTIONAL_BODY_FIELD)
 
     class Meta:
         icon = "bold"
 
 
 class TrendNumberComponent(elements.BaseMetricsElement):
-    body = blocks.TextBlock(
-        required=False, help_text=help_texts.OPTIONAL_BODY_FIELD_HELP_TEXT
-    )
+    body = blocks.TextBlock(required=False, help_text=help_texts.OPTIONAL_BODY_FIELD)
     metric = blocks.ChoiceBlock(
         required=True,
         choices=get_all_unique_change_type_metric_names,
-        help_text=help_texts.TREND_METRIC_FIELD_HELP_TEXT,
+        help_text=help_texts.TREND_METRIC_FIELD,
     )
     percentage_metric = blocks.ChoiceBlock(
         required=True,
         choices=get_all_unique_percent_change_type_names,
-        help_text=help_texts.TREND_PERCENTAGE_METRIC_FIELD_HELP_TEXT,
+        help_text=help_texts.TREND_PERCENTAGE_METRIC_FIELD,
     )
 
     class Meta:

--- a/cms/dynamic_content/elements.py
+++ b/cms/dynamic_content/elements.py
@@ -18,12 +18,12 @@ class BaseMetricsElement(blocks.StructBlock):
     topic = blocks.ChoiceBlock(
         required=True,
         choices=get_all_topic_names,
-        help_text=help_texts.TOPIC_FIELD_HELP_TEXT,
+        help_text=help_texts.TOPIC_FIELD,
     )
     metric = blocks.ChoiceBlock(
         required=True,
         choices=get_all_unique_metric_names,
-        help_text=help_texts.METRIC_FIELD_HELP_TEXT,
+        help_text=help_texts.METRIC_FIELD,
     )
 
 
@@ -31,15 +31,15 @@ class ChartPlotElement(BaseMetricsElement):
     chart_type = blocks.ChoiceBlock(
         required=True,
         choices=get_chart_types,
-        help_text=help_texts.CHART_TYPE_FIELD_HELP_TEXT,
+        help_text=help_texts.CHART_TYPE_FIELD,
     )
     date_from = blocks.DateBlock(
         required=False,
-        help_text=help_texts.DATE_FROM_FIELD_HELP_TEXT,
+        help_text=help_texts.DATE_FROM_FIELD,
     )
     date_to = blocks.DateBlock(
         required=False,
-        help_text=help_texts.DATE_TO_FIELD_HELP_TEXT,
+        help_text=help_texts.DATE_TO_FIELD,
     )
     stratum = blocks.ChoiceBlock(
         required=False,

--- a/cms/dynamic_content/help_texts.py
+++ b/cms/dynamic_content/help_texts.py
@@ -1,19 +1,19 @@
-HEADLINE_COLUMNS_FIELD_HELP_TEXT: str = """
+HEADLINE_COLUMNS_FIELD: str = """
 Add up to {} number column components within this row. 
 The columns are ordered from left to right, top to bottom respectively. 
 So by moving 1 column component above the other, that component will be rendered in the column left of the other. 
 """
 
-HEADLINE_COLUMNS_IN_CHART_CARD_HELP_TEXT: str = """
+HEADLINE_COLUMNS_IN_CHART_CARD: str = """
 Add up to {} headline or trend number column components within this space.
 Note that these figures will be displayed within the card, and above the chart itself.
 """
-CHART_CARD_ROW_HELP_TEXT: str = """
+CHART_CARD_ROW: str = """
 Here you can add 1 or 2 columns to contain a particular chart card.
 If you add the 1 column, then the chart card will spread across the available width.
 If you add 2 columns, then the cards will be split across 2 columns within the available width.
 """
-NUMBERS_ROW_FIELD_HELP_TEXT: str = """
+NUMBERS_ROW_FIELD: str = """
 Here you can add up to {} rows within this column component.
 Each row can be used to add a number block. 
 This can be a headline number, a trend number or a percentage number.
@@ -21,71 +21,71 @@ If you only add 1 row, then that block will be rendered on the upper half of the
 And the bottom row of the column will remain empty.
 """
 
-CHART_BLOCK_FIELD_HELP_TEXT: str = """
+CHART_BLOCK_FIELD: str = """
 Add the plots required for your chart. 
 Within each plot, you will be required to add a set of fields which will be used to fetch the supporting data 
 for that plot.
 """
 
-HEADLINE_BLOCK_FIELD_HELP_TEXT: str = """
+HEADLINE_BLOCK_FIELD: str = """
 This component will display a key headline number type metric.
 You can also optionally add a body of text to accompany that headline number.
 E.g. "Patients admitted"
 """
-TREND_BLOCK_FIELD_HELP_TEXT: str = """
+TREND_BLOCK_FIELD: str = """
 This component will display a trend number type metric.
 This will display an arrow pointing in the direction of the metric change 
 as well as colouring of the block to indicate the context of the change.
 You can also optionally add a body of text to accompany that headline number.
 E.g. "Last 7 days"
 """
-PERCENTAGE_BLOCK_FIELD_HELP_TEXT: str = """
+PERCENTAGE_BLOCK_FIELD: str = """
 This component will display a percentage number type metric.
 This will display the value of the metric appended with a % character.
 You can also optionally add a body of text to accompany this percentage number.
 E.g. "Virus tests positivity".
 """
 
-TOP_HEADLINE_BLOCK_FIELD_HELP_TEXT: str = """
+TOP_HEADLINE_BLOCK_FIELD: str = """
 This will display a key headline number type metric as the top half of this column component.
 """
-BOTTOM_HEADLINE_BLOCK_FIELD_HELP_TEXT: str = """
+BOTTOM_HEADLINE_BLOCK_FIELD: str = """
 This will display a key headline number type metric as the bottom half of this column component.
 """
 
-SINGLE_HEADLINE_COMPONENT_HELP_TEXT: str = """
+SINGLE_HEADLINE_COMPONENT: str = """
 This component will be displayed as a single headline number type metric on the top half of the column.
 The bottom half of this column component will be left empty.
 """
-HEADLINE_AND_TREND_COMPONENT_HELP_TEXT: str = """
+HEADLINE_AND_TREND_COMPONENT: str = """
 This component will be displayed with a headline number type metric on the top half of the column.
 And a trend type metric will be shown on the bottom half of the column component.
 """
-DUAL_HEADLINE_COMPONENT_HELP_TEXT: str = """
+DUAL_HEADLINE_COMPONENT: str = """
 This component will be displayed with a headline number type metric on the top half of the column.
 And another headline number type metric will be shown on the bottom half of the column component.
 """
 
-TEXT_CARD_HELP_TEXT: str = """
+TEXT_CARD: str = """
 This section of text will comprise this card. 
 Note that this card will span the length of the available page width if sufficient text content is provided.
 """
-BODY_FIELD_HELP_TEXT: str = "The section of text which will accommodate this block."
-BODY_FIELD_ABOVE_BLOCK_HELP_TEXT: str = f"""
-{BODY_FIELD_HELP_TEXT} Note that this text will be placed above the main content of the block.
+BODY_FIELD: str = "The section of text which will accommodate this block."
+BODY_FIELD_ABOVE_BLOCK: str = f"""
+{BODY_FIELD} Note that this text will be placed above the main content of the block.
 """
-HEADING_BLOCK_HELP_TEXT: str = """
+HEADING_BLOCK: str = """
 The text you add here will be used as the heading for this section. 
 """
 
-CONTENT_ROW_CARDS_HELP_TEXT: str = """
+CONTENT_ROW_CARDS: str = """
 Here you can add any number of content row cards for this section.
 Note that these cards will be displayed across the available width.
 """
 
 
-TOPIC_FIELD_HELP_TEXT: str = "The name of the topic to pull data e.g. COVID-19."
-METRIC_FIELD_HELP_TEXT: str = """
+TOPIC_FIELD: str = "The name of the topic to pull data e.g. COVID-19."
+METRIC_FIELD: str = """
 The name of the metric to pull data for e.g. "COVID-19_deaths_ONSByDay".
 """
 STRATUM_FIELD: str = """
@@ -102,23 +102,23 @@ The type of geographical categorisation to apply any data filtering to.
 If nothing is provided, then no filtering will be applied for this field.
 """
 
-TREND_METRIC_FIELD_HELP_TEXT: str = """
+TREND_METRIC_FIELD: str = """
 The name of the trend type metric to pull data e.g. "COVID-19_headline_ONSdeaths_7daychange". 
 Note that only 'change' type metrics are available for selection for this field type.
 """
-TREND_PERCENTAGE_METRIC_FIELD_HELP_TEXT: str = """
+TREND_PERCENTAGE_METRIC_FIELD: str = """
 The name of the accompanying percentage trend type metric to pull data 
 e.g. "COVID-19_headline_ONSdeaths_7daypercentchange". 
 Note that only 'percent' type metrics are available for selection for this field type.
 """
-CHART_TYPE_FIELD_HELP_TEXT: str = """
+CHART_TYPE_FIELD: str = """
 The name of the type of chart which you want to create e.g. waffle
 """
-DATE_FROM_FIELD_HELP_TEXT: str = """
+DATE_FROM_FIELD: str = """
 The date from which to begin the supporting plot data. 
 Note that if nothing is provided, a default of 1 year ago from the current date will be applied.
 """
-DATE_TO_FIELD_HELP_TEXT: str = """
+DATE_TO_FIELD: str = """
 The date to which to end the supporting plot data. 
 Note that if nothing is provided, a default of the current date will be applied.
 """
@@ -147,26 +147,26 @@ Note that if nothing is provided, a default of "SOLID" will be applied.
 E.g. `DASH`
 """
 
-TITLE_FIELD_HELP_TEXT: str = """
+TITLE_FIELD: str = """
 The title to display for this component. 
 Note that this will be shown in the hex colour #505A5F
 """
-OPTIONAL_BODY_FIELD_HELP_TEXT: str = """
+OPTIONAL_BODY_FIELD: str = """
 An optional body of text to accompany this block.
 """
 
-PAGE_DESCRIPTION_FIELD_HELP_TEXT: str = """
+PAGE_DESCRIPTION_FIELD: str = """
 An optional body of text which will be rendered at the top of the page. 
 This text will be displayed after the title of the page and before any of the main content.
 """
 
-X_AXIS_HELP_TEXT: str = """
+CHART_X_AXIS: str = """
 An optional choice of what to display along the x-axis of the chart.
 If nothing is provided, `dates` will be used by default.
 Dates are used by default
 """
 
-Y_AXIS_HELP_TEXT: str = """
+CHART_Y_AXIS: str = """
 An optional choice of what to display along the y-axis of the chart.
 If nothing is provided, `metric value` will be used by default.
 """

--- a/cms/dynamic_content/sections.py
+++ b/cms/dynamic_content/sections.py
@@ -10,8 +10,8 @@ class ContentCards(StreamBlock):
 
 
 class Section(StructBlock):
-    heading = TextBlock(help_text=help_texts.HEADING_BLOCK_HELP_TEXT, required=True)
-    content = ContentCards(help_text=help_texts.CONTENT_ROW_CARDS_HELP_TEXT)
+    heading = TextBlock(help_text=help_texts.HEADING_BLOCK, required=True)
+    content = ContentCards(help_text=help_texts.CONTENT_ROW_CARDS)
 
     class Meta:
         icon = "thumbtack"

--- a/cms/home/models.py
+++ b/cms/home/models.py
@@ -15,7 +15,7 @@ class HomePage(Page):
         features=AVAILABLE_RICH_TEXT_FEATURES,
         blank=True,
         null=True,
-        help_text=help_texts.PAGE_DESCRIPTION_FIELD_HELP_TEXT,
+        help_text=help_texts.PAGE_DESCRIPTION_FIELD,
     )
     body = ALLOWABLE_BODY_CONTENT
 

--- a/cms/topic/models.py
+++ b/cms/topic/models.py
@@ -16,7 +16,7 @@ class TopicPage(Page):
         features=AVAILABLE_RICH_TEXT_FEATURES,
         blank=True,
         null=True,
-        help_text=help_texts.PAGE_DESCRIPTION_FIELD_HELP_TEXT,
+        help_text=help_texts.PAGE_DESCRIPTION_FIELD,
     )
     body = ALLOWABLE_BODY_CONTENT
     date_posted = models.DateField()

--- a/metrics/api/serializers/charts.py
+++ b/metrics/api/serializers/charts.py
@@ -117,7 +117,7 @@ class ChartsSerializer(serializers.Serializer):
 
 
 class ChartsResponseSerializer(serializers.Serializer):
-    chart = serializers.FileField(help_text=help_texts.CHARTS_RESPONSE_HELP_TEXT)
+    chart = serializers.FileField(help_text=help_texts.CHARTS_RESPONSE)
 
 
 class EncodedChartsRequestSerializer(ChartsSerializer):
@@ -130,9 +130,7 @@ class EncodedChartsRequestSerializer(ChartsSerializer):
 
 class EncodedChartResponseSerializer(serializers.Serializer):
     last_updated = serializers.CharField(
-        help_text=help_texts.ENCODED_CHARTS_LAST_UPDATED_HELP_TEXT,
+        help_text=help_texts.ENCODED_CHARTS_LAST_UPDATED,
         allow_blank=True,
     )
-    chart = serializers.CharField(
-        help_text=help_texts.ENCODED_CHARTS_RESPONSE_HELP_TEXT
-    )
+    chart = serializers.CharField(help_text=help_texts.ENCODED_CHARTS_RESPONSE)

--- a/metrics/api/serializers/headlines.py
+++ b/metrics/api/serializers/headlines.py
@@ -35,6 +35,4 @@ class HeadlinesQuerySerializer(serializers.Serializer):
 
 
 class HeadlinesResponseSerializer(serializers.Serializer):
-    value = serializers.FloatField(
-        help_text=help_texts.HEADLINE_METRIC_VALUE_FIELD_HELP_TEXT
-    )
+    value = serializers.FloatField(help_text=help_texts.HEADLINE_METRIC_VALUE_FIELD)

--- a/metrics/api/serializers/help_texts.py
+++ b/metrics/api/serializers/help_texts.py
@@ -21,7 +21,7 @@ LABEL_FIELD: str = """
 The label to assign on the legend for this individual plot.
 E.g. `15 to 44 years old`
 """
-HEADLINE_METRIC_VALUE_FIELD_HELP_TEXT: str = """
+HEADLINE_METRIC_VALUE_FIELD: str = """
 The associated value of the headline metric which was queried for. E.g. `COVID-19_headline_newtests_7daycounttotal`
 """
 TREND_METRIC_NAME_FIELD: str = """
@@ -66,7 +66,7 @@ FILE_DOWNLOAD_FORMAT: str = """
 The format you want the data downloaded in. 
 This can be either `json` or `csv`
 """
-CHARTS_RESPONSE_HELP_TEXT: str = """
+CHARTS_RESPONSE: str = """
 The specified chart in the requested format e.g. svg
 """
 CHART_WIDTH: str = """
@@ -75,10 +75,10 @@ The width in pixels that you want to chart to be (default = 435 pixels)
 CHART_HEIGHT: str = """
 The height in pixels that you want to chart to be (default = 220 pixels)
 """
-TABLES_RESPONSE_DATE_HELP_TEXT: str = """
+TABLES_RESPONSE_DATE: str = """
 The dates for the specified plots in a tabular format
 """
-TABLES_RESPONSE_HELP_TEXT: str = """
+TABLES_RESPONSE: str = """
 The specified plots in a tabular format
 """
 CHART_X_AXIS: str = """
@@ -87,9 +87,9 @@ The metric to use along the X Axis of the chart
 CHART_Y_AXIS: str = """
 The metric to use along the Y Axis of the chart
 """
-ENCODED_CHARTS_RESPONSE_HELP_TEXT: str = """
+ENCODED_CHARTS_RESPONSE: str = """
 The specified chart in the requested format as a URI encoded string (default format = svg)
 """
-ENCODED_CHARTS_LAST_UPDATED_HELP_TEXT: str = """
+ENCODED_CHARTS_LAST_UPDATED: str = """
 The date that the chart data goes up to
 """

--- a/metrics/api/serializers/tables.py
+++ b/metrics/api/serializers/tables.py
@@ -71,6 +71,4 @@ class TablesSerializer(serializers.Serializer):
 
 
 class TablesResponseSerializer(serializers.Serializer):
-    tabular_output = serializers.FileField(
-        help_text=help_texts.TABLES_RESPONSE_HELP_TEXT
-    )
+    tabular_output = serializers.FileField(help_text=help_texts.TABLES_RESPONSE)


### PR DESCRIPTION
# Description

Fixes #CDD-1003

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

