### PR TITLE
Task/rename cms app mode env var to cms admin/cdd 1005

### DIFF
--- a/metrics/api/urls_construction.py
+++ b/metrics/api/urls_construction.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from django.contrib import admin
 from django.urls import include, path, re_path, resolvers
 from django.views.static import serve
@@ -90,6 +92,12 @@ django_admin_urlpatterns = [
 ]
 
 
+class AppMode(Enum):
+    CMS_ADMIN = "CMS_ADMIN"
+    PRIVATE_API = "PRIVATE_API"
+    PUBLIC_API = "PUBLIC_API"
+
+
 def construct_urlpatterns(
     app_mode: str | None,
 ) -> list[resolvers.URLResolver, resolvers.URLPattern]:
@@ -117,12 +125,12 @@ def construct_urlpatterns(
         docs_urlspatterns + static_urlpatterns + common_urlpatterns
     )
 
-    if app_mode == "CMS_ADMIN":
+    if app_mode == AppMode.CMS_ADMIN.value:
         constructed_url_patterns += cms_admin_urlpatterns
         constructed_url_patterns += django_admin_urlpatterns
-    elif app_mode == "PUBLIC_API":
+    elif app_mode == AppMode.PUBLIC_API.value:
         constructed_url_patterns += public_api_urlpatterns
-    elif app_mode == "PRIVATE_API":
+    elif app_mode == AppMode.PRIVATE_API.value:
         constructed_url_patterns += private_api_urlpatterns
     else:
         constructed_url_patterns += cms_admin_urlpatterns

--- a/tests/unit/metrics/api/test_urls_construction.py
+++ b/tests/unit/metrics/api/test_urls_construction.py
@@ -1,7 +1,7 @@
 import pytest
 from django.urls.resolvers import URLResolver
 
-from metrics.api.urls_construction import construct_urlpatterns
+from metrics.api.urls_construction import AppMode, construct_urlpatterns
 from public_api.urls import PUBLIC_API_PREFIX
 
 HEADLESS_CMS_API_ENDPOINT_PATHS = ["drafts", "pages"]
@@ -43,7 +43,7 @@ class TestConstructUrlpatterns:
         Then the urlpatterns returned contain the private API endpoints
         """
         # Given
-        app_mode = "PRIVATE_API"
+        app_mode = AppMode.PRIVATE_API.value
 
         # When
         urlpatterns = construct_urlpatterns(app_mode=app_mode)
@@ -65,7 +65,7 @@ class TestConstructUrlpatterns:
         Then the urlpatterns returned contain the headless CMS pages endpoints
         """
         # Given
-        app_mode = "PRIVATE_API"
+        app_mode = AppMode.PRIVATE_API.value
 
         # When
         private_api_urlpatterns = construct_urlpatterns(app_mode=app_mode)
@@ -91,7 +91,7 @@ class TestConstructUrlpatterns:
         Then the urlpatterns returned do not contain URLs for the other APIs
         """
         # Given
-        app_mode = "PRIVATE_API"
+        app_mode = AppMode.PRIVATE_API.value
 
         # When
         urlpatterns = construct_urlpatterns(app_mode=app_mode)
@@ -113,7 +113,7 @@ class TestConstructUrlpatterns:
         Then the urlpatterns returned contain the public API endpoints
         """
         # Given
-        app_mode = "PUBLIC_API"
+        app_mode = AppMode.PUBLIC_API.value
 
         # When
         urlpatterns = construct_urlpatterns(app_mode=app_mode)
@@ -135,7 +135,7 @@ class TestConstructUrlpatterns:
         Then the urlpatterns returned do not contain URLs for the other APIs
         """
         # Given
-        app_mode = "PUBLIC_API"
+        app_mode = AppMode.PUBLIC_API.value
 
         # When
         urlpatterns = construct_urlpatterns(app_mode=app_mode)
@@ -155,7 +155,7 @@ class TestConstructUrlpatterns:
         Then the urlpatterns returned contain the CMS admin endpoints
         """
         # Given
-        app_mode = "CMS_ADMIN"
+        app_mode = AppMode.CMS_ADMIN.value
 
         # When
         urlpatterns = construct_urlpatterns(app_mode=app_mode)
@@ -177,7 +177,7 @@ class TestConstructUrlpatterns:
         Then the urlpatterns returned do not contain URLs for the other APIs
         """
         # Given
-        app_mode = "CMS_ADMIN"
+        app_mode = AppMode.CMS_ADMIN.value
 
         # When
         urlpatterns = construct_urlpatterns(app_mode=app_mode)
@@ -213,9 +213,9 @@ class TestConstructUrlpatterns:
     @pytest.mark.parametrize(
         "app_mode",
         [
-            "CMS_ADMIN",
-            "PUBLIC_API",
-            "PRIVATE_API",
+            AppMode.CMS_ADMIN.value,
+            AppMode.PUBLIC_API.value,
+            AppMode.PRIVATE_API.value,
             None,
             "",
             "COMPLETE_APP",


### PR DESCRIPTION
# Description

This PR renames the expected `APP_MODE` env var value from `CMS` to instead be `CMS_ADMIN`. 
This PR also implements an `AppMode` enum class that can be shipped around instead of the brittle hard-coding I was doing before

Fixes #CDD-1005

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit and integration tests at the right level to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

