### PR TITLE
Rename `coronavirus` page slug -> `covid-19`

### DIFF
--- a/cms/dashboard/management/commands/build_cms_site.py
+++ b/cms/dashboard/management/commands/build_cms_site.py
@@ -161,7 +161,7 @@ class Command(BaseCommand):
         respiratory_viruses_page: HomePage = _build_respiratory_viruses_page(
             parent_page=root_page
         )
-        _build_topic_page(name="coronavirus", parent_page=respiratory_viruses_page)
+        _build_topic_page(name="covid_19", parent_page=respiratory_viruses_page)
         _build_topic_page(name="influenza", parent_page=respiratory_viruses_page)
         _build_topic_page(
             name="other_respiratory_viruses", parent_page=respiratory_viruses_page

--- a/cms/dashboard/templates/cms_starting_pages/covid_19.json
+++ b/cms/dashboard/templates/cms_starting_pages/covid_19.json
@@ -4,7 +4,7 @@
         "type": "topic.TopicPage",
         "detail_url": "http://localhost/api/pages/8/",
         "html_url": null,
-        "slug": "coronavirus",
+        "slug": "covid-19",
         "show_in_menus": false,
         "seo_title": "COVID-19 | UKHSA data dashboard",
         "search_description": "Overall summary of COVID-19 in circulation within the UK",

--- a/tests/fakes/factories/cms/topic_page_factory.py
+++ b/tests/fakes/factories/cms/topic_page_factory.py
@@ -23,8 +23,8 @@ class FakeTopicPageFactory(factory.Factory):
         )
 
     @classmethod
-    def build_coronavirus_page_from_template(cls) -> FakeTopicPage:
-        return cls._build_page(page_name="coronavirus")
+    def build_covid_19_page_from_template(cls) -> FakeTopicPage:
+        return cls._build_page(page_name="covid_19")
 
     @classmethod
     def build_other_respiratory_viruses_page_from_template(cls) -> FakeTopicPage:

--- a/tests/integration/cms/dashboard/management/commands/test_build_cms_site.py
+++ b/tests/integration/cms/dashboard/management/commands/test_build_cms_site.py
@@ -31,7 +31,7 @@ class TestBuildCMSSite:
 
         expected_slugs = [
             "respiratory-viruses",
-            "coronavirus",
+            "covid-19",
             "influenza",
             "how-to-use-this-data",
             "maps",
@@ -105,7 +105,7 @@ class TestBuildCMSSite:
 
     @pytest.mark.django_db
     @pytest.mark.parametrize(
-        "slug", ["coronavirus", "influenza", "other-respiratory-viruses"]
+        "slug", ["covid-19", "influenza", "other-respiratory-viruses"]
     )
     def test_command_builds_site_with_correct_topic_pages(
         self,

--- a/tests/unit/cms/home/test_models.py
+++ b/tests/unit/cms/home/test_models.py
@@ -114,7 +114,7 @@ class TestTemplateHomePage:
         assert len(body) == 2
         covid_section, influenza_section = body
 
-        # Check that the first item is a `section` type for `Coronavirus`
+        # Check that the first item is a `section` type for `COVID-19`
         assert covid_section.block_type == "section"
         assert covid_section.value["heading"] == "COVID-19"
 
@@ -122,7 +122,7 @@ class TestTemplateHomePage:
         assert influenza_section.block_type == "section"
         assert influenza_section.value["heading"] == "Influenza"
 
-    def test_coronavirus_section_text_card(self):
+    def test_covid_19_section_text_card(self):
         """
         Given a `HomePage` created with a template for the `respiratory-viruses` page
         When the `body` is taken from the page
@@ -146,7 +146,7 @@ class TestTemplateHomePage:
             in text_card.value["body"].source
         )
 
-    def test_coronavirus_section_headline_number_row_card(self):
+    def test_covid_19_section_headline_number_row_card(self):
         """
         Given a `HomePage` created with a template for the `respiratory-viruses` page
         When the `body` is taken from the page
@@ -170,7 +170,7 @@ class TestTemplateHomePage:
         headline_number_row_columns = headline_numbers_row_card.value["columns"]
         assert len(headline_number_row_columns) == 5
 
-    def test_coronavirus_section_headline_number_row_headline_and_trend_column(self):
+    def test_covid_19_section_headline_number_row_headline_and_trend_column(self):
         """
         Given a `HomePage` created with a template for the `respiratory-viruses` page
         When the `body` is taken from the page
@@ -213,7 +213,7 @@ class TestTemplateHomePage:
             == self.expected_trend_number_block_body
         )
 
-    def test_coronavirus_section_headline_number_row_headline_and_percentage_blocks(
+    def test_covid_19_section_headline_number_row_headline_and_percentage_blocks(
         self,
     ):
         """
@@ -256,7 +256,7 @@ class TestTemplateHomePage:
         )
         assert fourth_column_percentage_block_value["body"] == "Percentage uptake"
 
-    def test_coronavirus_section_headline_number_row_single_headline_column_with_percentage_block(
+    def test_covid_19_section_headline_number_row_single_headline_column_with_percentage_block(
         self,
     ):
         """
@@ -289,7 +289,7 @@ class TestTemplateHomePage:
         )
         assert fifth_column_percentage_block_value["body"] == "Virus tests positivity"
 
-    def test_coronavirus_section_chart_row_card(self):
+    def test_covid_19_section_chart_row_card(self):
         """
         Given a `HomePage` created with a template for the `respiratory-viruses` page
         When the `body` is taken from the page
@@ -312,7 +312,7 @@ class TestTemplateHomePage:
 
         assert len(chart_card_columns) == 2
 
-    def test_coronavirus_section_chart_card_plot(self):
+    def test_covid_19_section_chart_card_plot(self):
         """
         Given a `HomePage` created with a template for the `respiratory-viruses` page
         When the `body` is taken from the page
@@ -346,7 +346,7 @@ class TestTemplateHomePage:
             chart_plot_value["chart_type"] == ChartTypes.line_with_shaded_section.value
         )
 
-    def test_coronavirus_section_chart_card_headline_and_trend_number(self):
+    def test_covid_19_section_chart_card_headline_and_trend_number(self):
         """
         Given a `HomePage` created with a template for the `respiratory-viruses` page
         When the `body` is taken from the page

--- a/tests/unit/cms/topic/test_models.py
+++ b/tests/unit/cms/topic/test_models.py
@@ -4,24 +4,24 @@ from metrics.domain.utils import ChartTypes
 from tests.fakes.factories.cms.topic_page_factory import FakeTopicPageFactory
 
 
-class TestTemplateCoronavirusPage:
+class TestTemplateCOVID19Page:
     @property
     def covid_19(self) -> str:
         return "COVID-19"
 
     def test_sections_in_body_are_correct_order(self):
         """
-        Given a `TopicPage` created with a template for the `coronavirus` page
+        Given a `TopicPage` created with a template for the `covid-19` page
         When the `body` is taken from the page
         Then the correct sections are in place
         """
         # Given
-        template_coronavirus_page = (
-            FakeTopicPageFactory.build_coronavirus_page_from_template()
+        template_covid_19_page = (
+            FakeTopicPageFactory.build_covid_19_page_from_template()
         )
 
         # When
-        body = template_coronavirus_page.body
+        body = template_covid_19_page.body
 
         # Then
         assert len(body) == 5
@@ -53,17 +53,17 @@ class TestTemplateCoronavirusPage:
 
     def test_cases_section_chart_card(self):
         """
-        Given a `TopicPage` created with a template for the `coronavirus` page
+        Given a `TopicPage` created with a template for the `covid-19` page
         When the `body` is taken from the page
         Then the correct chart card is in place
         """
         # Given
-        template_coronavirus_page = (
-            FakeTopicPageFactory.build_coronavirus_page_from_template()
+        template_covid_19_page = (
+            FakeTopicPageFactory.build_covid_19_page_from_template()
         )
 
         # When
-        body = template_coronavirus_page.body
+        body = template_covid_19_page.body
 
         # Then
         cases_section = body[0]
@@ -88,17 +88,17 @@ class TestTemplateCoronavirusPage:
 
     def test_is_previewable_returns_false(self):
         """
-        Given a `TopicPage` created with a template for the `coronavirus` page
+        Given a `TopicPage` created with a template for the `covid-19` page
         When `is_previewable()` is called
         Then False is returned
         """
         # Given
-        template_covid_topic_page = (
-            FakeTopicPageFactory.build_coronavirus_page_from_template()
+        template_covid_19_page = (
+            FakeTopicPageFactory.build_covid_19_page_from_template()
         )
 
         # When
-        page_is_previewable: bool = template_covid_topic_page.is_previewable()
+        page_is_previewable: bool = template_covid_19_page.is_previewable()
 
         # Then
         assert not page_is_previewable


### PR DESCRIPTION
# Description

This PR renames instances of `Coronavirus` -> `covid-19` in page slugs & tests in line with the latest GDS guidance

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

