### PR TITLE
Add `show_in_menus` to template starter pages

### DIFF
--- a/cms/dashboard/management/commands/build_cms_site.py
+++ b/cms/dashboard/management/commands/build_cms_site.py
@@ -68,6 +68,7 @@ def _build_respiratory_viruses_page(parent_page: Page) -> HomePage:
         slug=data["meta"]["slug"],
         seo_title=data["meta"]["seo_title"],
         search_description=data["meta"]["search_description"],
+        show_in_menus=data["meta"]["show_in_menus"],
     )
     _add_page_to_parent(page=page, parent_page=parent_page)
 
@@ -96,6 +97,7 @@ def _build_topic_page(name: str, parent_page: Page) -> TopicPage:
         surveillance_and_reporting=data["surveillance_and_reporting"],
         seo_title=data["meta"]["seo_title"],
         search_description=data["meta"]["search_description"],
+        show_in_menus=data["meta"]["show_in_menus"],
     )
     _add_page_to_parent(page=page, parent_page=parent_page)
 
@@ -118,6 +120,7 @@ def _build_common_page(name: str, parent_page: Page) -> TopicPage:
         date_posted=data["meta"]["first_published_at"].split("T")[0],
         seo_title=data["meta"]["seo_title"],
         search_description=data["meta"]["search_description"],
+        show_in_menus=data["meta"]["show_in_menus"],
     )
     _add_page_to_parent(page=page, parent_page=parent_page)
 

--- a/cms/dashboard/templates/cms_starting_pages/about.json
+++ b/cms/dashboard/templates/cms_starting_pages/about.json
@@ -5,7 +5,7 @@
         "detail_url": "http://localhost/api/pages/115/",
         "html_url": null,
         "slug": "about",
-        "show_in_menus": false,
+        "show_in_menus": true,
         "seo_title": "About | UKHSA data dashboard",
         "search_description": "The UKHSA data dashboard provides presents a wide range of public health data in an easily accessible format.",
         "first_published_at": "2023-05-16T11:18:41.084933+01:00",

--- a/cms/dashboard/templates/cms_starting_pages/covid_19.json
+++ b/cms/dashboard/templates/cms_starting_pages/covid_19.json
@@ -5,7 +5,7 @@
         "detail_url": "http://localhost/api/pages/8/",
         "html_url": null,
         "slug": "covid-19",
-        "show_in_menus": false,
+        "show_in_menus": true,
         "seo_title": "COVID-19 | UKHSA data dashboard",
         "search_description": "Overall summary of COVID-19 in circulation within the UK",
         "first_published_at": "2023-05-15T17:23:02.306556+01:00",

--- a/cms/dashboard/templates/cms_starting_pages/influenza.json
+++ b/cms/dashboard/templates/cms_starting_pages/influenza.json
@@ -5,7 +5,7 @@
         "detail_url": "http://localhost/api/pages/111/",
         "html_url": null,
         "slug": "influenza",
-        "show_in_menus": false,
+        "show_in_menus": true,
         "seo_title": "Influenza | UKHSA data dashboard",
         "search_description": "Detailed summary of Influenza in circulation within the UK",
         "first_published_at": "2023-05-16T14:06:43.187457+01:00",

--- a/cms/dashboard/templates/cms_starting_pages/other_respiratory_viruses.json
+++ b/cms/dashboard/templates/cms_starting_pages/other_respiratory_viruses.json
@@ -5,7 +5,7 @@
         "detail_url": "http://localhost/api/pages/10/",
         "html_url": null,
         "slug": "other-respiratory-viruses",
-        "show_in_menus": false,
+        "show_in_menus": true,
         "seo_title": "Other Respiratory Viruses | UKHSA data dashboard",
         "search_description": "Overall summary of other respiratory viruses in circulation within the UK",
         "first_published_at": "2023-05-12T16:58:42.332020+01:00",

--- a/cms/dashboard/templates/cms_starting_pages/respiratory_viruses.json
+++ b/cms/dashboard/templates/cms_starting_pages/respiratory_viruses.json
@@ -5,7 +5,7 @@
         "detail_url": "http://localhost/api/pages/243/",
         "html_url": null,
         "slug": "respiratory-viruses",
-        "show_in_menus": false,
+        "show_in_menus": true,
         "seo_title": "Respiratory Viruses | UKHSA data dashboard",
         "search_description": "Overall summary of the respiratory viruses in circulation within the UK",
         "first_published_at": "2023-04-26T12:39:38.064114+01:00",

--- a/cms/dashboard/templates/cms_starting_pages/whats_new.json
+++ b/cms/dashboard/templates/cms_starting_pages/whats_new.json
@@ -5,7 +5,7 @@
         "detail_url": "http://localhost/api/pages/134/",
         "html_url": null,
         "slug": "whats-new",
-        "show_in_menus": false,
+        "show_in_menus": true,
         "seo_title": "What's new | UKHSA data dashboard",
         "search_description": "A list of all the new features and key pieces of data which have been added to the UKHSA data dashboard",
         "first_published_at": "2023-05-16T11:46:07.719758+01:00",

--- a/tests/integration/cms/dashboard/management/commands/test_build_cms_site.py
+++ b/tests/integration/cms/dashboard/management/commands/test_build_cms_site.py
@@ -91,6 +91,10 @@ class TestBuildCMSSite:
             response_data["meta"]["search_description"]
             == home_page_response_template["meta"]["search_description"]
         )
+        assert (
+            response_data["meta"]["show_in_menus"]
+            == home_page_response_template["meta"]["show_in_menus"]
+        )
 
         # Check that the related links have been populated correctly
         related_links_from_response = response_data["related_links"]
@@ -145,6 +149,10 @@ class TestBuildCMSSite:
             response_data["meta"]["search_description"]
             == topic_page_response_template["meta"]["search_description"]
         )
+        assert (
+            response_data["meta"]["show_in_menus"]
+            == topic_page_response_template["meta"]["show_in_menus"]
+        )
 
         # Check that the related links have been populated correctly
         related_links_from_response = response_data["related_links"]
@@ -190,6 +198,10 @@ class TestBuildCMSSite:
             response_data["meta"]["search_description"]
             == about_page_template["meta"]["search_description"]
         )
+        assert (
+            response_data["meta"]["show_in_menus"]
+            == about_page_template["meta"]["show_in_menus"]
+        )
 
         # Check that the related links have been populated correctly
         related_links_from_response = response_data["related_links"]
@@ -234,6 +246,10 @@ class TestBuildCMSSite:
         assert (
             response_data["meta"]["search_description"]
             == whats_new_page_template["meta"]["search_description"]
+        )
+        assert (
+            response_data["meta"]["show_in_menus"]
+            == whats_new_page_template["meta"]["show_in_menus"]
         )
 
         # Check that the related links have been populated correctly


### PR DESCRIPTION
# Description

This PR adds the `show_in_menus` to the template CMS starter pages.
By default the following pages will have `show_in_menus: true`:
- about
- what's new
- covid-19
- influenza
- respiratory-viruses
- other-respiratory-viruses

The following pages will have `show_in_menus: false`:
- how_to_use_this_data
- maps

Fixes #CDD-1017

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit and integration tests at the right level to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

