### PR TITLE
Re-order question-answer pairs on feedback email to match feedback form

### DIFF
--- a/feedback/email_template.py
+++ b/feedback/email_template.py
@@ -22,9 +22,9 @@ def build_body_for_email(suggestions: dict[str, str]) -> str:
 
 class FeedbackQuestion(Enum):
     reason = "What was your reason for visiting the dashboard today?"
+    did_you_find_everything = "Did you find everything you were looking for?"
     improve_experience = "How could we improve your experience with the dashboard?"
     like_to_see = "What would you like to see on the dashboard in the future?"
-    did_you_find_everything = "Did you find everything you were looking for?"
 
 
 def _enrich_suggestions_with_long_form_questions(

--- a/tests/unit/feedback/test_email_template.py
+++ b/tests/unit/feedback/test_email_template.py
@@ -106,9 +106,9 @@ class TestBuildBodyForEmail:
         # Given
         suggestions = {
             FeedbackQuestion.reason.name: REASON_ANSWER,
+            FeedbackQuestion.did_you_find_everything.name: DID_YOU_FIND_EVERYTHING_ANSWER,
             FeedbackQuestion.improve_experience.name: IMPROVE_EXPERIENCE_ANSWER,
             FeedbackQuestion.like_to_see.name: LIKE_TO_SEE_ANSWER,
-            FeedbackQuestion.did_you_find_everything.name: DID_YOU_FIND_EVERYTHING_ANSWER,
         }
 
         # When


### PR DESCRIPTION
# Description

As request by @amita-nhs this PR re-orders the question answer pairs in the suggestions email so that they match the feedback form 

Fixes #CDD-958

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added unit and integration tests at the right level to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

