### PR TITLE
Add `generate_trend_numbers()` for the v3 trends endpoint

### DIFF
--- a/metrics/interfaces/trends/access.py
+++ b/metrics/interfaces/trends/access.py
@@ -201,3 +201,66 @@ def generate_trend_numbers(
     data: TREND_AS_DICT = trend.model_dump()
 
     return data
+
+
+def generate_trend_numbers_beta(
+    topic_name: str,
+    metric_name: str,
+    percentage_metric_name: str,
+    geography_name: str,
+    geography_type_name: str,
+    stratum_name: str,
+    sex: str,
+    age: str,
+) -> TREND_AS_DICT:
+    """Gets the trend data for the given metric names.
+
+    Args:
+        topic_name: The name of the disease being queried.
+            E.g. `COVID-19`
+        metric_name: The name of the metric being queried.
+            E.g. `COVID-19_deaths_ONSByDay`
+        percentage_metric_name: The name of the corresponding
+            percentage metric being queried.
+            E.g. `new_tests_7days_change_percentage`
+        geography_name: The name of the geography being queried.
+            E.g. `England`
+        geography_type_name: The name of the geography
+            type being queried.
+            E.g. `Nation`
+        stratum_name: The value of the stratum to apply additional filtering to.
+            E.g. `default`, which would be used to capture all strata.
+        sex: The gender to apply additional filtering to.
+            E.g. `F`, would be used to capture Females.
+            Note that options are `M`, `F`, or `ALL`.
+        age: The age range to apply additional filtering to.
+            E.g. `0_4` would be used to capture the age of 0-4 years old
+
+    Returns:
+        Dict containing the serialized trends data.
+            E.g.
+                {
+                  "metric_name": "new_cases_7days_change",
+                  "metric_value": -692,
+                  "percentage_metric_name": "new_deaths_7days_change_percentage",
+                  "percentage_metric_value": 3.1,
+                  "direction": "down",
+                  "colour": "green"
+                }
+
+    """
+    interface = TrendsInterfaceBeta(
+        topic_name=topic_name,
+        metric_name=metric_name,
+        percentage_metric_name=percentage_metric_name,
+        geography_name=geography_name,
+        geography_type_name=geography_type_name,
+        stratum_name=stratum_name,
+        sex=sex,
+        age=age,
+    )
+
+    trend: Trend = interface.get_trend()
+    data: TREND_AS_DICT = trend.model_dump()
+
+    return data

--- a/tests/unit/metrics/interfaces/trends/test_access.py
+++ b/tests/unit/metrics/interfaces/trends/test_access.py
@@ -265,3 +265,43 @@ class TestTrendNumbers:
         mocked_trend = spy_get_trend.return_value
 
         assert trend_data == mocked_trend.model_dump.return_value
+
+
+class TestGenerateTrendNumbers:
+    @mock.patch.object(access.TrendsInterfaceBeta, "get_trend")
+    def test_delegates_call_to_interface_to_get_metric_values(
+        self, spy_get_trend: mock.MagicMock
+    ):
+        """
+        Given a `topic`, `metric_name` and `percentage_metric_name`
+        When `generate_trend_numbers()` is called
+        Then the call is delegated to `get_trend()` from an instance of the `TrendsInterface`
+            which is subsequently used to call and return `model_dump()` from the `Trend` model
+        """
+        # Given
+        mocked_topic = mock.Mock()
+        mocked_metric_name = mock.Mock()
+        mocked_percentage_metric_name = mock.Mock()
+        geography_name = mock.Mock()
+        geography_type_name = mock.Mock()
+        stratum_name = mock.Mock()
+        sex = mock.Mock()
+        age = mock.Mock()
+
+        # When
+        trend_data = access.generate_trend_numbers_beta(
+            topic_name=mocked_topic,
+            metric_name=mocked_metric_name,
+            percentage_metric_name=mocked_percentage_metric_name,
+            geography_name=geography_name,
+            geography_type_name=geography_type_name,
+            stratum_name=stratum_name,
+            sex=sex,
+            age=age,
+        )
+
+        # Then
+        spy_get_trend.assert_called_once()
+        mocked_trend = spy_get_trend.return_value
+
+        assert trend_data == mocked_trend.model_dump.return_value


### PR DESCRIPTION
# Description

This PR adds the generate trend number function which will be used within the new v3 trends endpoint

Fixes #CDD-1097

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit and integration tests at the right level to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

