### PR TITLE
Update `create_api_time_series_from_core_time_series()` to take explicit fields when creating underlying `APITimeSeries`

### DIFF
--- a/metrics/data/operations/api_models_beta.py
+++ b/metrics/data/operations/api_models_beta.py
@@ -130,7 +130,7 @@ def create_api_time_series_from_core_time_series(
         geography_type=core_time_series.geography.geography_type.name,
         geography=core_time_series.geography.name,
         geography_code=core_time_series.geography.geography_code,
-        age=core_time_series.age,
+        age=core_time_series.age.name,
         sex=core_time_series.sex,
         stratum=core_time_series.stratum.name,
         date=core_time_series.date,

--- a/tests/unit/metrics/data/operations/test_api_models_beta.py
+++ b/tests/unit/metrics/data/operations/test_api_models_beta.py
@@ -29,7 +29,7 @@ class TestCreateAPITimeSeriesFromCoreTimeSeries:
             api_time_series.geography_code
             == mocked_time_series.geography.geography_code
         )
-        assert api_time_series.age == mocked_time_series.age
+        assert api_time_series.age == mocked_time_series.age.name
         assert api_time_series.month == mocked_time_series.month
         assert (
             api_time_series.metric_group == mocked_time_series.metric.metric_group.name


### PR DESCRIPTION
# Description

This PR adds a little optimization to the way in which we create `APITimeSeries`.

Instead of just picking off all the fields from the `CoreTimeSeries` we can explicitly pass a bunch of them in.
The reason is, because the files we ingest are on a per-metric basis. Every record that we create from that file will have the same topic, metric, sub theme, theme values etc so we can just stash these in memory when we're batch-creating `APITimeSeries` and then just pass them in instead of having to pull them from each individual `CoreTimeSeries` 

Fixes #CDD-1133

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit and integration tests at the right level to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

