### PR TITLE
Enhance `get_rolling_period_slice_for_metric()` to catch beta-schema metric names

### DIFF
--- a/metrics/interfaces/charts/calculations.py
+++ b/metrics/interfaces/charts/calculations.py
@@ -33,4 +33,4 @@ def get_rolling_period_slice_for_metric(metric_name: str) -> int:
         the rolling period of that metric.
 
     """
-    return 1 if "weekly" in metric_name else 7
+    return 1 if "week" in metric_name.lower() else 7

--- a/tests/unit/metrics/interfaces/charts/test_calculations.py
+++ b/tests/unit/metrics/interfaces/charts/test_calculations.py
@@ -98,18 +98,33 @@ class TestGetRollingPeriodSliceForEachHalf:
         # Then
         assert rolling_period_slice == 7
 
-    def test_weekly_metric_name(self):
+    @pytest.mark.parametrize(
+        "metric_name",
+        [
+            "influenza_healthcare_ICUHDUadmissionrateByWeek",
+            "COVID-19_deaths_ONSByWeek",
+            "RSV_healthcare_hospadmissionrateByWeek",
+            "RSV_testing_positivityByWeek",
+            "adenovirus_testing_positivityByWeek",
+            "hMPV_testing_positivityByWeek",
+            "influenza_testing_positivityByWeek",
+            "influenza_healthcare_ICUHDUadmissionrateByWeek",
+            "parainfluenza_testing_positivityByWeek",
+            "rhinovirus_testing_positivityByWeek",
+        ],
+    )
+    def test_weekly_metric_name(self, metric_name: str):
         """
-        Given a metric name which does not contain the word `weekly`
+        Given a metric name for weekly-centric data
         When `get_rolling_period_slice_for_metric()` is called
         Then the rolling period slice of 1 is returned
         """
         # Given
-        metric_name = "weekly_positivity"
+        metric_name_for_weekly_data = metric_name
 
         # When
         rolling_period_slice: int = calculations.get_rolling_period_slice_for_metric(
-            metric_name=metric_name
+            metric_name=metric_name_for_weekly_data
         )
 
         # Then


### PR DESCRIPTION
# Description

This PR is a temporary fix to the calculation we do to check whether the rolling period of the line with shaded section chart is 1 data point or 7 data points (i.e. weekly or daily data).
We currently do this by checking if the word `week` is in the metric name. This was always a little crude but it has been good enough.
The next iteration of this would be to instead grab the dates being passed to the charts and calculate the difference in days between 2 points and use that to instead decide how large the rolling period slice is.

Before:
<img width="1207" alt="Screenshot 2023-08-18 at 14 26 18" src="https://github.com/UKHSA-Internal/winter-pressures-api/assets/47219506/51ac8527-eb99-4d11-8273-8c0a487f3b28">

After:
<img width="1409" alt="Screenshot 2023-08-18 at 14 29 47" src="https://github.com/UKHSA-Internal/winter-pressures-api/assets/47219506/977984d5-83e0-43b2-a39d-c17e740643bc">


Fixes #CDD-1139

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added unit and integration tests at the right level to prove my change is effective
- [x] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)

