### PR TITLE
Remove API key constraint from headless CMS API endpointe

### DIFF
--- a/cms/dashboard/viewsets.py
+++ b/cms/dashboard/viewsets.py
@@ -12,7 +12,7 @@ from cms.dashboard.serializers import CMSDraftPagesSerializer, ListablePageSeria
 
 @extend_schema(tags=["cms"])
 class CMSPagesAPIViewSet(PagesAPIViewSet):
-    permission_classes = [HasAPIKey]
+    permission_classes = []
     base_serializer_class = ListablePageSerializer
     listing_default_fields = PagesAPIViewSet.listing_default_fields + ["show_in_menus"]
 
@@ -28,7 +28,7 @@ class CMSPagesAPIViewSet(PagesAPIViewSet):
 @extend_schema(tags=["cms"])
 class CMSDraftPagesViewSet(PagesAPIViewSet):
     base_serializer_class = CMSDraftPagesSerializer
-    permission_classes = [HasAPIKey]
+    permission_classes = []
 
     def detail_view(self, request: Request, pk: int) -> Response:
         instance = self.get_object()

--- a/tests/unit/cms/dashboard/test_viewsets.py
+++ b/tests/unit/cms/dashboard/test_viewsets.py
@@ -36,12 +36,11 @@ class TestCMSDraftPagesViewSet:
         assert len(urlpatterns) == 1
         assert urlpatterns[0].name == "detail"
 
-    def test_permission_classes_has_api_key(self):
+    def test_permission_classes_has_no_api_key_constraint(self):
         """
         Given an instance of the `CMSDraftPagesViewSet`
         When `permission_classes` is called
-        Then a list of 1 item is returned
-            which is the `HasAPIKey` class
+        Then an empty list is returned
         """
         # Given
         draft_pages_viewset = CMSDraftPagesViewSet()
@@ -50,8 +49,7 @@ class TestCMSDraftPagesViewSet:
         permission_classes = draft_pages_viewset.permission_classes
 
         # Then
-        assert len(permission_classes) == 1
-        assert permission_classes[0] is HasAPIKey
+        assert permission_classes == []
 
 
 class TestCMSPagesAPIViewSet:


### PR DESCRIPTION
# Description

This PR includes the following:

- Removes the API key restriction from the headless CMS API endpoints

Fixes #CDD-1278

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
