### PR TITLE
Remove creation of API key within `InternalAPIClient`

### DIFF
--- a/caching/internal_api_client.py
+++ b/caching/internal_api_client.py
@@ -32,11 +32,9 @@ class InternalAPIClient:
     def __init__(
         self,
         client: Optional[APIClient] = None,
-        api_key_manager: Optional[CustomAPIKeyManager] = None,
         force_refresh: bool = False,
         cache_check_only: bool = False,
     ):
-        self._api_key_manager = api_key_manager or self.create_api_key_manager()
         self._client = client or self.create_api_client()
 
         # Endpoints
@@ -51,36 +49,17 @@ class InternalAPIClient:
         self.force_refresh = force_refresh
         self.cache_check_only = cache_check_only
 
-    # API key manager & client
+    # API client
 
-    @property
-    def temporary_api_key_name(self) -> str:
-        return "Crawler Key"
-
-    def create_api_client(self) -> APIClient:
+    @staticmethod
+    def create_api_client() -> APIClient:
         """Initializes a new `APIClient` which can be used to emulate requests made to the private API.
 
         Returns:
-            An authenticated `APIClient` instance
+            An `APIClient` instance
 
         """
-        _, key = self._api_key_manager.create_key(name=self.temporary_api_key_name)
-
-        api_client = APIClient()
-        api_client.credentials(HTTP_AUTHORIZATION=key)
-
-        return api_client
-
-    @staticmethod
-    def create_api_key_manager() -> CustomAPIKeyManager:
-        """Initializes a new `CustomAPIKeyManager` which can be used to create a valid API key
-
-        Returns:
-            A `CustomAPIKeyManager` instance with the `APIKey` model set
-        """
-        api_key_manager = CustomAPIKeyManager()
-        api_key_manager.model = APIKey
-        return api_key_manager
+        return APIClient()
 
     # Headers
 

--- a/tests/unit/caching/crawler/test_class_methods.py
+++ b/tests/unit/caching/crawler/test_class_methods.py
@@ -7,19 +7,12 @@ from caching.internal_api_client import InternalAPIClient
 class TestCrawlerCreate:
     # Tests for the create class methods
 
-    @mock.patch.object(InternalAPIClient, "create_api_client")
-    def test_create_crawler_for_cache_checking_only(
-        self, mocked_create_api_client: mock.MagicMock
-    ):
+    def test_create_crawler_for_cache_checking_only(self):
         """
         Given no pre-existing `InternalAPIClient`
         When the `create_crawler_for_cache_checking_only` class method
             is called from the `Crawler` class
         Then the correct object is returned
-
-        Patches:
-            `mocked_create_api_client`: To remove the side effect
-                of having to create an API key and therefore hit the db
         """
         # Given / When
         crawler = Crawler.create_crawler_for_cache_checking_only()
@@ -27,19 +20,12 @@ class TestCrawlerCreate:
         # Then
         assert crawler._internal_api_client.cache_check_only
 
-    @mock.patch.object(InternalAPIClient, "create_api_client")
-    def test_create_crawler_for_force_cache_refresh(
-        self, mocked_create_api_client: mock.MagicMock
-    ):
+    def test_create_crawler_for_force_cache_refresh(self):
         """
         Given no pre-existing `InternalAPIClient`
         When the `create_crawler_for_force_cache_refresh` class method
             is called from the `Crawler` class
         Then the correct object is returned
-
-        Patches:
-            `mocked_create_api_client`: To remove the side effect
-                of having to create an API key and therefore hit the db
         """
         # Given / When
         crawler = Crawler.create_crawler_for_force_cache_refresh()

--- a/tests/unit/caching/test_internal_api_client.py
+++ b/tests/unit/caching/test_internal_api_client.py
@@ -45,32 +45,13 @@ class TestInternalAPIClient:
         Then the correct endpoint path is returned
         """
         # Given
-        internal_api_client = InternalAPIClient(
-            client=mock.Mock(), api_key_manager=mock.Mock()
-        )
+        internal_api_client = InternalAPIClient(client=mock.Mock())
 
         # When
         retrieved_endpoint_path = getattr(internal_api_client, attribute_on_class)
 
         # Then
         assert retrieved_endpoint_path == expected_path
-
-    def test_key_manager_can_be_provided_to_init(self):
-        """
-        Given a mocked pre-defined api key manager
-        When an instance of the `InternalAPIClient` is created
-        Then the internal `_api_key_manager` is set with the provided client object
-        """
-        # Given
-        mocked_key_manager = mock.Mock()
-
-        # When
-        internal_api_client = InternalAPIClient(
-            client=mock.Mock(), api_key_manager=mocked_key_manager
-        )
-
-        # Then
-        assert internal_api_client._api_key_manager == mocked_key_manager
 
     def test_client_can_be_provided_to_init(self):
         """
@@ -82,36 +63,10 @@ class TestInternalAPIClient:
         mocked_client = mock.Mock()
 
         # When
-        internal_api_client = InternalAPIClient(
-            client=mocked_client, api_key_manager=mock.Mock()
-        )
+        internal_api_client = InternalAPIClient(client=mocked_client)
 
         # Then
         assert internal_api_client._client == mocked_client
-
-    @mock.patch.object(InternalAPIClient, "create_api_key_manager")
-    def test_create_api_key_manager_is_called_when_not_provided(
-        self, spy_create_api_key_manager
-    ):
-        """
-        Given an instance of the `InternalAPIClient`
-            which has not been provided with an API key manager
-        When the `InternalAPIClient` is initialized
-        Then the `create_api_key_manager()` method is called
-
-        Patches:
-            `spy_create_api_key_manager`: For the main assertion
-
-        """
-        # Given / When
-        internal_api_client = InternalAPIClient(client=mock.Mock())
-
-        # Then
-        spy_create_api_key_manager.assert_called_once()
-        assert (
-            internal_api_client._api_key_manager
-            == spy_create_api_key_manager.return_value
-        )
 
     @mock.patch.object(InternalAPIClient, "create_api_client")
     def test_create_api_client_is_called_when_not_provided(self, spy_create_api_client):
@@ -125,7 +80,7 @@ class TestInternalAPIClient:
             `spy_create_api_client`: For the main assertion
         """
         # Given / When
-        internal_api_client = InternalAPIClient(api_key_manager=mock.Mock())
+        internal_api_client = InternalAPIClient()
 
         # Then
         spy_create_api_client.assert_called_once()
@@ -163,24 +118,6 @@ class TestInternalAPIClient:
 
     # API key manager & API client tests
 
-    def test_create_api_key_manager(self):
-        """
-        Given an instance of the `InternalAPIClient`
-        When `create_api_key_manager()` is called from the `InternalAPIClient`
-        Then an instance of the `CustomAPIKeyManager` is returned
-        """
-        # Given
-        internal_api_client = InternalAPIClient(
-            client=mock.Mock(), api_key_manager=mock.Mock()
-        )
-
-        # When
-        created_api_key_manager = internal_api_client.create_api_key_manager()
-
-        # Then
-        assert isinstance(created_api_key_manager, CustomAPIKeyManager)
-        assert created_api_key_manager.model == APIKey
-
     def test_create_api_client_returns_api_client(self):
         """
         Given an instance of the `InternalAPIClient`
@@ -189,46 +126,13 @@ class TestInternalAPIClient:
         And an API key has been created and set on the authorization of the client
         """
         # Given
-        internal_api_client = InternalAPIClient(
-            client=mock.Mock(), api_key_manager=FakeAPIKeyManager()
-        )
+        internal_api_client = InternalAPIClient(client=mock.Mock())
 
         # When
         created_api_client = internal_api_client.create_api_client()
 
         # Then
         assert isinstance(created_api_client, APIClient)
-
-    @mock.patch.object(APIClient, "credentials")
-    def test_create_api_client_sets_api_key_on_client(
-        self, spy_credentials: mock.MagicMock
-    ):
-        """
-        Given an instance of the `InternalAPIClient`
-        When `create_api_client()` is called from the `InternalAPIClient`
-        Then a new API key is created and set on the authorization of the client
-        """
-        # Given
-        mocked_api_key_manager = mock.Mock()
-        fake_expected_api_key_for_header = "abc"
-        mocked_api_key_manager.create_key.return_value = (
-            mock.Mock(),
-            fake_expected_api_key_for_header,
-        )
-        internal_api_client = InternalAPIClient(
-            client=mock.Mock(), api_key_manager=mocked_api_key_manager
-        )
-
-        # When
-        internal_api_client.create_api_client()
-
-        # Then
-        mocked_api_key_manager.create_key.assert_called_once_with(
-            name=internal_api_client.temporary_api_key_name
-        )
-        spy_credentials.assert_called_once_with(
-            HTTP_AUTHORIZATION=fake_expected_api_key_for_header
-        )
 
     # Header construction tests
 
@@ -277,9 +181,7 @@ class TestInternalAPIClient:
         # Given
         mocked_client = mock.Mock()
         mocked_request_data = mock.Mock()
-        internal_api_client = InternalAPIClient(
-            client=mocked_client, api_key_manager=mock.Mock()
-        )
+        internal_api_client = InternalAPIClient(client=mocked_client)
 
         # When
         response = internal_api_client.hit_headlines_endpoint(data=mocked_request_data)
@@ -301,9 +203,7 @@ class TestInternalAPIClient:
         # Given
         mocked_client = mock.Mock()
         mocked_request_data = mock.Mock()
-        internal_api_client = InternalAPIClient(
-            client=mocked_client, api_key_manager=mock.Mock()
-        )
+        internal_api_client = InternalAPIClient(client=mocked_client)
 
         # When
         response = internal_api_client.hit_trends_endpoint(data=mocked_request_data)
@@ -325,9 +225,7 @@ class TestInternalAPIClient:
         # Given
         mocked_client = mock.Mock()
         mocked_request_data = mock.Mock()
-        internal_api_client = InternalAPIClient(
-            client=mocked_client, api_key_manager=mock.Mock()
-        )
+        internal_api_client = InternalAPIClient(client=mocked_client)
 
         # When
         response = internal_api_client.hit_charts_endpoint(data=mocked_request_data)
@@ -350,9 +248,7 @@ class TestInternalAPIClient:
         # Given
         mocked_client = mock.Mock()
         mocked_request_data = mock.Mock()
-        internal_api_client = InternalAPIClient(
-            client=mocked_client, api_key_manager=mock.Mock()
-        )
+        internal_api_client = InternalAPIClient(client=mocked_client)
 
         # When
         response = internal_api_client.hit_tables_endpoint(data=mocked_request_data)
@@ -375,9 +271,7 @@ class TestInternalAPIClient:
         # Given
         mocked_client = mock.Mock()
         mocked_request_data = mock.Mock()
-        internal_api_client = InternalAPIClient(
-            client=mocked_client, api_key_manager=mock.Mock()
-        )
+        internal_api_client = InternalAPIClient(client=mocked_client)
 
         # When
         response = internal_api_client.hit_downloads_endpoint(data=mocked_request_data)
@@ -399,9 +293,7 @@ class TestInternalAPIClient:
         """
         # Given
         mocked_client = mock.Mock()
-        internal_api_client = InternalAPIClient(
-            client=mocked_client, api_key_manager=mock.Mock()
-        )
+        internal_api_client = InternalAPIClient(client=mocked_client)
 
         # When
         response = internal_api_client.hit_pages_list_endpoint()
@@ -423,9 +315,7 @@ class TestInternalAPIClient:
         # Given
         mocked_client = mock.Mock()
         fake_page_id = 123
-        internal_api_client = InternalAPIClient(
-            client=mocked_client, api_key_manager=mock.Mock()
-        )
+        internal_api_client = InternalAPIClient(client=mocked_client)
 
         # When
         response = internal_api_client.hit_pages_detail_endpoint(page_id=fake_page_id)


### PR DESCRIPTION
# Description

This PR includes the following:

- Removes the bit which was created an API key within the `InternalAPIClient` used by the `Crawler` when filling the cache. As the API key enforcement has now moved to the load balancer

Fixes #CDD-1278

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
