### PR TITLE
Clear records associated with metrics tables prior to uploading truncated dataset

### DIFF
--- a/tests/unit/metrics/data/operations/test_truncated_dataset.py
+++ b/tests/unit/metrics/data/operations/test_truncated_dataset.py
@@ -4,8 +4,24 @@ from unittest import mock
 from _pytest.logging import LogCaptureFixture
 from pydantic_core._pydantic_core import ValidationError
 
+from metrics.data.models.api_models import APITimeSeries
+from metrics.data.models.core_models import (
+    Age,
+    CoreHeadline,
+    CoreTimeSeries,
+    Geography,
+    GeographyType,
+    Metric,
+    MetricGroup,
+    Stratum,
+    SubTheme,
+    Theme,
+    Topic,
+)
 from metrics.data.operations.truncated_dataset import (
     _gather_test_data_source_file_paths,
+    clear_metrics_tables,
+    collect_all_metric_models,
     upload_truncated_test_data,
 )
 
@@ -26,10 +42,99 @@ class TestGatherTestDataSourceFilePaths:
         assert len(gathered_test_file_paths) == 52
 
 
+class TestCollectAllMetricModels:
+    def test_delegates_call_for_each_model(self):
+        """
+        Given no input
+        When `collect_all_metric_models()` is called
+        Then the correct metric models are returned
+        """
+        # Given / When
+        metric_models = collect_all_metric_models()
+
+        # Then
+        assert CoreHeadline in metric_models
+        assert CoreTimeSeries in metric_models
+        assert APITimeSeries in metric_models
+        assert Theme in metric_models
+        assert SubTheme in metric_models
+        assert Topic in metric_models
+        assert MetricGroup in metric_models
+        assert Metric in metric_models
+        assert GeographyType in metric_models
+        assert Geography in metric_models
+        assert Stratum in metric_models
+        assert Age in metric_models
+
+
+class TestClearMetricsTables:
+    @mock.patch(f"{MODULE_PATH}.collect_all_metric_models")
+    def test_calls_delete_on_collected_models(
+        self, spy_collect_all_metric_models: mock.MagicMock, caplog: LogCaptureFixture
+    ):
+        """
+        Given no input
+        When `clear_metrics_tables()` is called
+        Then `objects.all().delete()` is called
+            on each of the models returned from `collect_all_metric_models()`
+
+        Patches:
+            `spy_collect_all_metric_models`: To isolate the
+                returned models and cast the main assertions on them
+
+        """
+        # Given
+        mocked_collected_metric_models = [
+            mock.MagicMock(__name__=f"model-{i}") for i in range(10)
+        ]
+        spy_collect_all_metric_models.return_value = mocked_collected_metric_models
+
+        # When
+        clear_metrics_tables()
+
+        # Then
+        for mocked_metric_model in mocked_collected_metric_models:
+            assert mock.call.objects.all().delete() in mocked_metric_model.mock_calls
+
+    @mock.patch(f"{MODULE_PATH}.collect_all_metric_models")
+    def test_records_expected_logs(
+        self, spy_collect_all_metric_models: mock.MagicMock, caplog: LogCaptureFixture
+    ):
+        """
+        Given no input
+        When `clear_metrics_tables()` is called
+        Then the correct logs are recorded
+
+        Patches:
+            `spy_collect_all_metric_models`: To isolate the
+                returned models
+
+        """
+        # Given
+        mocked_collected_metric_models = [
+            mock.MagicMock(__name__=f"model-{i}") for i in range(10)
+        ]
+        # `MagicMock` does not implement `__name__` by default hence the need to explicitly set it here
+        spy_collect_all_metric_models.return_value = mocked_collected_metric_models
+
+        # When
+        clear_metrics_tables()
+
+        # Then
+        for mocked_metric_model in mocked_collected_metric_models:
+            assert f"Deleting records of {mocked_metric_model.__name__}" in caplog.text
+
+        assert "Completed deleting existing metrics records" in caplog.text
+
+
 class TestUploadTruncatedTestData:
+    @mock.patch(f"{MODULE_PATH}.clear_metrics_tables")
     @mock.patch(f"{MODULE_PATH}.file_ingester")
     def test_error_log_made_for_failed_file(
-        self, mocked_file_ingester: mock.MagicMock, caplog: LogCaptureFixture
+        self,
+        mocked_file_ingester: mock.MagicMock,
+        mocked_clear_metrics_tables: mock.MagicMock,
+        caplog: LogCaptureFixture,
     ):
         """
         Given the `file_ingester()` which will fail
@@ -40,6 +145,9 @@ class TestUploadTruncatedTestData:
             `mocked_file_ingester`: To simulate an error
                 occuring when uploading a file via the
                 call to the `file_ingester()` function
+            `mocked_clear_metrics_tables`: To remove
+                the side effect of clearing records
+                and having to hit the database
         """
         # Given
         mocked_file_ingester.side_effect = ValidationError
@@ -50,9 +158,13 @@ class TestUploadTruncatedTestData:
         # Then
         assert "Failed upload of" in caplog.text
 
+    @mock.patch(f"{MODULE_PATH}.clear_metrics_tables")
     @mock.patch(f"{MODULE_PATH}.file_ingester")
     def test_logs_made_correctly(
-        self, mocked_file_ingester: mock.MagicMock, caplog: LogCaptureFixture
+        self,
+        mocked_file_ingester: mock.MagicMock,
+        mocked_clear_metrics_tables: mock.MagicMock,
+        caplog: LogCaptureFixture,
     ):
         """
         Given a set of truncated test files
@@ -62,6 +174,9 @@ class TestUploadTruncatedTestData:
         Patches:
             `mocked_file_ingester`: To remove side effects
                 of having to upload to the database
+            `mocked_clear_metrics_tables`: To remove
+                the side effect of clearing records
+                and having to hit the database
         """
         # Given
         gathered_test_file_paths: list[Path] = _gather_test_data_source_file_paths()
@@ -79,9 +194,12 @@ class TestUploadTruncatedTestData:
 
         assert "Completed truncated dataset upload" in formatted_logged_text
 
+    @mock.patch(f"{MODULE_PATH}.clear_metrics_tables")
     @mock.patch(f"{MODULE_PATH}.file_ingester")
     def test_delegates_calls_successfully_for_each_source_file(
-        self, spy_file_ingester: mock.MagicMock
+        self,
+        spy_file_ingester: mock.MagicMock,
+        mocked_clear_metrics_tables: mock.MagicMock,
     ):
         """
         Given a set of truncated test files
@@ -91,6 +209,9 @@ class TestUploadTruncatedTestData:
         Patches:
             `spy_file_ingester`: For the main assertion
                  and for collecting the calls which were made
+            `mocked_clear_metrics_tables`: To remove
+                the side effect of clearing records
+                and having to hit the database
         """
         # Given
         gathered_test_file_paths: list[Path] = _gather_test_data_source_file_paths()
@@ -111,3 +232,27 @@ class TestUploadTruncatedTestData:
         # Check that they match with the gathered test file paths
         for gathered_test_file_path in gathered_test_file_paths:
             assert str(gathered_test_file_path) in file_paths_called_by_file_ingester
+
+    @mock.patch(f"{MODULE_PATH}.file_ingester")
+    @mock.patch(f"{MODULE_PATH}.clear_metrics_tables")
+    def test_delegates_call_to_delete_existing_metrics(
+        self,
+        spy_clear_metrics_tables: mock.MagicMock,
+        mocked_file_ingester: mock.MagicMock,
+    ):
+        """
+        Given no input
+        When `upload_truncated_test_data()` is called
+        Then `clear_metrics_tables()` is called to clear
+            the existing records in the metrics tables
+
+        Patches:
+            `spy_clear_metrics_tables`: For the main assertion
+            `mocked_file_ingester`: To remove side effects
+                of having to upload to the database
+        """
+        # Given / When
+        upload_truncated_test_data()
+
+        # Then
+        spy_clear_metrics_tables.assert_called_once()


### PR DESCRIPTION
# Description

This PR includes the following:

- Deletes all records within the metrics tables before the upload truncated dataset action is ran

Fixes #CDD-1246

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
