### PR TITLE
Task/remove ingestion endpoint from private api /cdd 1127

### DIFF
--- a/metrics/api/urls_construction.py
+++ b/metrics/api/urls_construction.py
@@ -214,7 +214,6 @@ def construct_urlpatterns(
             )
         case AppMode.PRIVATE_API.value:
             constructed_url_patterns += private_api_urlpatterns
-            constructed_url_patterns += ingestion_urlpatterns
         case AppMode.FEEDBACK_API.value:
             constructed_url_patterns += feedback_urlpatterns
         case _:

--- a/tests/unit/metrics/api/test_urls_construction.py
+++ b/tests/unit/metrics/api/test_urls_construction.py
@@ -152,7 +152,7 @@ class TestConstructUrlpatterns:
 
     @pytest.mark.parametrize(
         "private_api_endpoint_path",
-        PRIVATE_API_ENDPOINT_PATHS + INGESTION_API_ENDPOINT_PATHS,
+        PRIVATE_API_ENDPOINT_PATHS,
     )
     def test_private_api_mode_returns_private_api_urls(
         self, private_api_endpoint_path: str
@@ -203,7 +203,8 @@ class TestConstructUrlpatterns:
         "excluded_endpoint_path",
         PUBLIC_API_ENDPOINT_PATHS
         + CMS_ADMIN_ENDPOINT_PATHS
-        + FEEDBACK_API_ENDPOINT_PATHS,
+        + FEEDBACK_API_ENDPOINT_PATHS
+        + INGESTION_API_ENDPOINT_PATHS,
     )
     def test_private_api_mode_does_not_return_other_urls(
         self, excluded_endpoint_path: str
@@ -250,7 +251,8 @@ class TestConstructUrlpatterns:
         "excluded_endpoint_path",
         PRIVATE_API_ENDPOINT_PATHS
         + CMS_ADMIN_ENDPOINT_PATHS
-        + FEEDBACK_API_ENDPOINT_PATHS,
+        + FEEDBACK_API_ENDPOINT_PATHS
+        + INGESTION_API_ENDPOINT_PATHS,
     )
     def test_public_api_mode_does_not_return_other_urls(
         self, excluded_endpoint_path: str
@@ -292,7 +294,8 @@ class TestConstructUrlpatterns:
         "excluded_endpoint_path",
         PRIVATE_API_ENDPOINT_PATHS
         + PUBLIC_API_ENDPOINT_PATHS
-        + FEEDBACK_API_ENDPOINT_PATHS,
+        + FEEDBACK_API_ENDPOINT_PATHS
+        + INGESTION_API_ENDPOINT_PATHS,
     )
     def test_cms_admin_mode_does_not_return_other_urls(
         self, excluded_endpoint_path: str
@@ -334,7 +337,8 @@ class TestConstructUrlpatterns:
         "excluded_endpoint_path",
         PRIVATE_API_ENDPOINT_PATHS
         + PUBLIC_API_ENDPOINT_PATHS
-        + CMS_ADMIN_ENDPOINT_PATHS,
+        + CMS_ADMIN_ENDPOINT_PATHS
+        + INGESTION_API_ENDPOINT_PATHS,
     )
     def test_feedback_api_mode_does_not_return_other_urls(
         self, excluded_endpoint_path: str


### PR DESCRIPTION
# Description

This PR includes the following:

- Removes the `ingestion/` endpoint from being exposed on the private API

Notes:
This doesn't mean we can't technically use the private API as a job to bootstrap or ingest in the way we were doing before.

Fixes #CDD-1127

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
