### PR TITLE
Remove API key from `suggestions/` endpoint

### DIFF
--- a/feedback/api/views/suggestions.py
+++ b/feedback/api/views/suggestions.py
@@ -4,7 +4,6 @@ from django.http import HttpResponse
 from drf_spectacular.utils import extend_schema
 from rest_framework.request import Request
 from rest_framework.views import APIView
-from rest_framework_api_key.permissions import HasAPIKey
 
 from feedback import send_email
 from feedback.api.serializers.questions import SuggestionsSerializer
@@ -13,7 +12,7 @@ SUGGESTIONS_API_TAG = "suggestions"
 
 
 class SuggestionsView(APIView):
-    permission_classes = [HasAPIKey]
+    permission_classes = []
 
     @extend_schema(tags=[SUGGESTIONS_API_TAG], request=SuggestionsSerializer)
     def post(self, request: Request, *args, **kwargs) -> HttpResponse:


### PR DESCRIPTION
# Description

This PR includes the following:

-Removes the API key from being enforced at the application level for the `suggestions/` endpoint


---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
