### PR TITLE
Add config for `APIENV=STANDALONE` which will allow for deployment of container without needing to connect to a remote postgres db

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,8 +11,8 @@ load_dotenv(dotenv_path)
 logger = logging.getLogger(__name__)
 
 # The environment in which this app is running in.
-# If this is set to "LOCAL" then a local sqlite db will be used
-# If this is set to any value other than "LOCAL"
+# If this is set to "LOCAL" or "STANDALONE" then a local sqlite db will be used
+# If this is set to any value other than "LOCAL" or "STANDALONE"
 #   then the `POSTGRES` credentials below
 #   will be used to connect to a remote database
 APIENV = os.environ.get("APIENV")

--- a/metrics/api/settings.py
+++ b/metrics/api/settings.py
@@ -146,7 +146,7 @@ else:
 # Puts the db at the root level of the repo instead of within the `metrics` app
 ROOT_LEVEL_BASE_DIR = BASE_DIR.parent
 
-if config.APIENV == "LOCAL":
+if config.APIENV in ("LOCAL", "STANDALONE"):
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds some config to the django settings which will check for the `APIENV` being either *LOCAL* or *STANDALONE*.
- Allows us to spin up the container without needing to connect to a remote postgres db and have `DEBUG` set to `FALSE`

Fixes #CDD-1300

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
