### PR TITLE
Migrate to using `list_objects_v2` instead of `list_objects` on the `AWSClient`

### DIFF
--- a/ingestion/aws_client.py
+++ b/ingestion/aws_client.py
@@ -62,7 +62,7 @@ class AWSClient:
                 ]
 
         """
-        bucket_objects: list[S3_BUCKET_ITEM_OBJECT_TYPE] = self._client.list_objects(
+        bucket_objects: list[S3_BUCKET_ITEM_OBJECT_TYPE] = self._client.list_objects_v2(
             Bucket=self._bucket_name, Prefix=self._inbound_folder
         )
         bucket_contents: list[S3_BUCKET_ITEM_OBJECT_TYPE] = bucket_objects["Contents"]

--- a/tests/unit/ingestion/test_aws_client.py
+++ b/tests/unit/ingestion/test_aws_client.py
@@ -155,7 +155,7 @@ class TestAWSClient:
             "MaxKeys": 1000,
         }
         mocked_boto3_client = aws_client_with_mocked_boto_client._client
-        mocked_boto3_client.list_objects.return_value = fake_returned_bucket_objects
+        mocked_boto3_client.list_objects_v2.return_value = fake_returned_bucket_objects
 
         # When
         keys: list[
@@ -202,7 +202,7 @@ class TestAWSClient:
             "MaxKeys": 1000,
         }
         mocked_boto3_client = aws_client_with_mocked_boto_client._client
-        mocked_boto3_client.list_objects.return_value = fake_returned_bucket_objects
+        mocked_boto3_client.list_objects_v2.return_value = fake_returned_bucket_objects
 
         # When
         keys: list[


### PR DESCRIPTION
# Description

This PR includes the following:

- Migrates to using `list_objects_v2` instead of `list_objects` on the underlying boto3 client on the `AWSClient`

Fixes #CDD-1312

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
