### PR TITLE
Add default `age=all` value

### DIFF
--- a/metrics/api/views/headlines.py
+++ b/metrics/api/views/headlines.py
@@ -83,6 +83,12 @@ class HeadlinesView(APIView):
             request_data = request.query_params.dict()
             request_data["geography"] = "England"
             request_data["geography_type"] = "Nation"
+            request_data["age"] = "all"
+
+            # This is a temporary patch to ensure the correct age is set for this metric
+            if metric == "COVID-19_headline_vaccines_spring23Total":
+                request_data["age"] = "75+"
+
             return _handle_beta_schema_headlines_request(request_data=request_data)
 
         return Response({"value": headline_number})

--- a/metrics/api/views/trends.py
+++ b/metrics/api/views/trends.py
@@ -81,6 +81,7 @@ class TrendsView(APIView):
             request_data = request.query_params.dict()
             request_data["geography"] = "England"
             request_data["geography_type"] = "Nation"
+            request_data["age"] = "all"
             return _handle_beta_schema_trends_request(request_data=request_data)
 
         return Response(trends_data)


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds a default `age=all` for v2 trends and headlines
- Adds a default age for the `COVID-19_headline_vaccines_spring23Total` metric, this is needed because the headline numbers row card on the dashboard asks for this, but the latest dataset filters this for `age=75+`. So until the CMS supports geography and age selections, and the FE migrates to the headlines v3 endpoint, this horrible patch will have to stay in place

---

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
