### PR TITLE
CDD-1348: add application/json accept header to public api crawler

### DIFF
--- a/caching/public_api/crawler.py
+++ b/caching/public_api/crawler.py
@@ -62,9 +62,24 @@ class PublicAPICrawler:
         headers["Accept"] = "text/html"
         return headers
 
+    def build_headers_for_json(self) -> dict[str, str]:
+        """Constructs headers which should be used in JSON requests
+
+        Notes:
+            In this case, the CDN auth key is constructed.
+            And the "Accept" header is provided as "application/json"
+
+        Returns:
+            Dict containing the necessary header key-value pairs
+
+        """
+        headers = self._build_base_headers()
+        headers["Accept"] = "application/json"
+        return headers
+
     # Endpoint call methods
 
-    def _hit_endpoint_for_json(self, url: str) -> dict:
+    def _hit_endpoint_with_base_headers(self, url: str) -> dict:
         """Makes a `GET` request to the given `url` for a JSON response
 
         Args:
@@ -81,7 +96,25 @@ class PublicAPICrawler:
         )
         return response.json()
 
-    def _hit_endpoint_for_html(self, url: str) -> str:
+    def _hit_endpoint_with_accept_json(self, url: str) -> str:
+        """Makes a 'GET' request to the given 'url' for a JSON response
+        Args:
+            url: The URL to amke the request to
+
+        Returns:
+            url: The URL to make the request to
+
+        """
+        headers = self.build_headers_for_json()
+        response = requests.get(
+            url=url,
+            timeout=self._request_timeout,
+            headers=headers,
+        )
+
+        return response.content
+
+    def _hit_endpoint_with_accept_html(self, url: str) -> str:
         """Makes a `GET` request to the given `url` for an HTML response
 
         Args:
@@ -97,6 +130,7 @@ class PublicAPICrawler:
             timeout=self._request_timeout,
             headers=headers,
         )
+
         return response.content
 
     def hit_endpoint(self, url: str) -> dict:
@@ -109,8 +143,9 @@ class PublicAPICrawler:
             Dict containing the JSON response data
 
         """
-        self._hit_endpoint_for_html(url=url)
-        return self._hit_endpoint_for_json(url=url)
+        self._hit_endpoint_with_accept_html(url=url)
+        self._hit_endpoint_with_accept_json(url=url)
+        return self._hit_endpoint_with_base_headers(url=url)
 
     @staticmethod
     def _is_url(value: str) -> bool:


### PR DESCRIPTION
# Description

This PR adds a support for crawling the public API with `application/json` accept header and populating CloudFront cache with those objects.

Fixes #CDD-1348

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
