### PR TITLE
CDD-1393: Add support to private API crawler for chart downloads

### DIFF
--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -14,7 +14,7 @@ coreapi==2.3.3
 coreschema==0.0.4
 cyclonedx-python-lib==4.2.3
 distlib==0.3.7
-Django==4.2.6
+Django==4.2.7
 django-cors-headers==4.3.0
 django-db-connection-pool==1.2.4
 django-filter==22.1

--- a/tests/unit/caching/private_api/crawler/conftest.py
+++ b/tests/unit/caching/private_api/crawler/conftest.py
@@ -63,3 +63,38 @@ def example_chart_block() -> dict[str, str | list[dict]]:
             }
         ],
     }
+
+
+@pytest.fixture
+def example_chart_row_cards() -> dict[str, str | list[dict]]:
+    return [
+        {
+            "type": "chart_row_card",
+            "value": {
+                "columns": [
+                    {
+                        "type": "chart_card",
+                        "value": "",
+                    },
+                    {
+                        "type": "chart_card",
+                        "value": "",
+                    },
+                ]
+            },
+        }
+    ]
+
+
+@pytest.fixture
+def example_chart_row_column() -> dict[str, str | list[dict]]:
+    return [
+        {
+            "type": "chart_card",
+            "value": {"title": "title text one", "body": "body text one", "chart": []},
+        },
+        {
+            "type": "chart_card",
+            "value": {"title": "title text two", "body": "body text two", "chart": []},
+        },
+    ]

--- a/tests/unit/caching/private_api/crawler/test_build_request_data.py
+++ b/tests/unit/caching/private_api/crawler/test_build_request_data.py
@@ -205,10 +205,11 @@ class TestPrivateAPICrawlerBuildRequestData:
         """
         # Given
         chart_block_data = example_chart_block
+        file_format = "csv"
 
         # When
         downloads_request_data = private_api_crawler_with_mocked_internal_api_client._build_downloads_request_data(
-            chart_block=chart_block_data,
+            chart_block=chart_block_data, file_format=file_format
         )
 
         # Then

--- a/tests/unit/caching/private_api/crawler/test_get_all_downloads.py
+++ b/tests/unit/caching/private_api/crawler/test_get_all_downloads.py
@@ -1,0 +1,209 @@
+import logging
+from unittest import mock
+
+from _pytest.logging import LogCaptureFixture
+
+from caching.private_api.crawler import PrivateAPICrawler
+from tests.fakes.factories.cms.common_page_factory import FakeCommonPageFactory
+from tests.fakes.factories.cms.topic_page_factory import FakeTopicPageFactory
+
+logger = logging.getLogger(__name__)
+
+
+class TestPrivateAPICrawlerGetAllDownloads:
+    def test_create_file_name_for_chart_card_formats_correctly(
+        self, private_api_crawler_with_mocked_internal_api_client: PrivateAPICrawler
+    ):
+        """
+        Given a fake file_name
+        When create_file_name_for_chart_card() is called
+        Then a formatted version of the string will be returned with a file
+            extension that matches the file_format provided.
+        """
+        # Given
+        fake_file_name = "chart title name"
+        fake_file_format = "csv"
+
+        # When
+        file_name = private_api_crawler_with_mocked_internal_api_client.create_filename_for_chart_card(
+            file_name=fake_file_name,
+            file_format=fake_file_format,
+        )
+
+        # Then
+        expected_file_name = "chart_title_name.csv"
+        assert expected_file_name == file_name
+
+    @mock.patch.object(PrivateAPICrawler, "create_filename_for_chart_card")
+    @mock.patch.object(PrivateAPICrawler, "_process_download_for_chart_block")
+    def test_get_downloads_from_chart_row_columns_delegates_calls_correctly(
+        self,
+        spy_process_download_for_chart_block: mock.MagicMock,
+        spy_create_filename_for_chart_card: mock.MagicMock,
+        private_api_crawler_with_mocked_internal_api_client: PrivateAPICrawler,
+        example_chart_row_column: dict[str, str | list[dict]],
+    ):
+        """
+        Given two faked chart_row_columns
+        When the get_downloads_from_chart_row_columns() method is called
+        Then _process_download_for_cart_block is called twice
+            and two downloads are returned.
+        """
+        # Given
+        faked_two_row_columns = example_chart_row_column
+
+        # When
+        downloads = private_api_crawler_with_mocked_internal_api_client.get_downloads_from_chart_row_columns(
+            chart_row_columns=faked_two_row_columns, file_format="csv"
+        )
+
+        # Then
+        spy_create_filename_for_chart_card.assert_called()
+        expected_calls = [
+            mock.call(chart_block=chart_card["value"], file_format="csv")
+            for chart_card in faked_two_row_columns
+        ]
+        spy_process_download_for_chart_block.assert_has_calls(expected_calls)
+        assert len(downloads) == len(faked_two_row_columns)
+
+    @mock.patch.object(PrivateAPICrawler, "get_downloads_from_chart_row_columns")
+    def test_get_downloads_from_chart_cards_delegates_calls_correctly(
+        self,
+        spy_get_downloads_from_chart_row_columns: mock.MagicMock,
+        private_api_crawler_with_mocked_internal_api_client: PrivateAPICrawler,
+        example_chart_row_cards: list[dict[str, str | list[dict]]],
+    ):
+        """
+        Given a chart_row_card containing two columns
+        When get_downloads_from_chard_cards() is called
+        Then a single call to get_downloads_from_chart_row_columns() is made
+        """
+        # Given
+        mocked_row_cards = example_chart_row_cards
+
+        # When
+        private_api_crawler_with_mocked_internal_api_client.get_downloads_from_chart_cards(
+            chart_row_cards=mocked_row_cards, file_format="csv"
+        )
+
+        # Then
+        spy_get_downloads_from_chart_row_columns.assert_called_once()
+
+    @mock.patch.object(PrivateAPICrawler, "get_content_cards_from_section")
+    @mock.patch.object(PrivateAPICrawler, "get_chart_row_cards_from_content_cards")
+    def test_get_chart_row_cards_from_page_section_delegates_calls_correctly(
+        self,
+        spy_get_chart_row_cards_from_content_cards: mock.MagicMock,
+        spy_get_content_cards_from_section: mock.MagicMock,
+        private_api_crawler_with_mocked_internal_api_client: PrivateAPICrawler,
+    ):
+        """
+        Given I have a page section
+        When the get_chart_row_cards_from_page_section() is called
+        Then the correct calls are delegated.
+        """
+        # Given
+        mock_section = mock.Mock()
+
+        # When
+        private_api_crawler_with_mocked_internal_api_client.get_chart_row_cards_from_page_section(
+            section=mock_section
+        )
+
+        # Then
+        spy_get_content_cards_from_section.assert_called_once_with(section=mock_section)
+        expected_content_cards = spy_get_content_cards_from_section.return_value
+        spy_get_chart_row_cards_from_content_cards.assert_called_once_with(
+            content_cards=expected_content_cards
+        )
+
+    @mock.patch.object(PrivateAPICrawler, "get_chart_row_cards_from_page_section")
+    @mock.patch.object(PrivateAPICrawler, "get_downloads_from_chart_cards")
+    def test_get_downloads_from_sections_delegates_calls_correctly(
+        self,
+        spy_get_downloads_from_chart_cards: mock.MagicMock,
+        spy_get_chart_row_cards_from_page_section: mock.MagicMock,
+        private_api_crawler_with_mocked_internal_api_client: PrivateAPICrawler,
+    ):
+        """
+        Given: A list of sections
+        When the get_downloads_from_page_sections() is called
+        Then the process_chart_row_cards_from_page_section will
+            be called for each section supplied.
+        """
+        # Given
+        mock_sections = [mock.Mock()]
+
+        # When
+        private_api_crawler_with_mocked_internal_api_client.get_downloads_from_page_sections(
+            sections=mock_sections, file_format="csv"
+        )
+
+        # Then
+        mocked_calls = [mock.call(section=section) for section in mock_sections]
+        spy_get_chart_row_cards_from_page_section.assert_has_calls(mocked_calls)
+        chart_row_cards = spy_get_chart_row_cards_from_page_section.return_value
+        spy_get_downloads_from_chart_cards.assert_called_with(
+            chart_row_cards=chart_row_cards,
+            file_format="csv",
+        )
+
+    @mock.patch.object(PrivateAPICrawler, "get_downloads_from_page_sections")
+    def test_get_all_downloads_delegates_calls_correctly(
+        self,
+        spy_get_downloads_from_page_sections: mock.MagicMock,
+        private_api_crawler_with_mocked_internal_api_client: PrivateAPICrawler,
+    ):
+        """
+        Given: I have a list of pages
+        When: Each page is passed to `get_downloads_from_page_sections()`
+        Then: `get_downloads_from_page_sections()` should receive the correct
+            number of calls
+        """
+        # Given
+        fake_pages = [
+            FakeTopicPageFactory._build_page(page_name="covid_19"),
+            FakeTopicPageFactory._build_page(page_name="influenza"),
+        ]
+
+        # When
+        private_api_crawler_with_mocked_internal_api_client.get_all_downloads(
+            pages=fake_pages, file_format="csv"
+        )
+
+        # Then
+        expected_pages = [
+            mock.call(sections=page.body.raw_data, file_format="csv")
+            for page in fake_pages
+        ]
+        spy_get_downloads_from_page_sections.assert_has_calls(
+            expected_pages, any_order=True
+        )
+
+    @mock.patch.object(PrivateAPICrawler, "get_downloads_from_page_sections")
+    def test_get_all_downloads_logs_unsupported_pages(
+        self,
+        mocked_get_downloads_from_page_sections: mock.MagicMock,
+        private_api_crawler_with_mocked_internal_api_client: PrivateAPICrawler,
+        caplog: LogCaptureFixture,
+    ):
+        """
+        Given: A list of pages, not all containing chart data
+        When: the `get_all_downloads()` function is called.
+        Then: an attribution exception is caught and the page logged out
+            before continuing to the next page.
+        """
+        # Given
+        fake_pages = [
+            FakeCommonPageFactory.build_blank_page(title="About"),
+            FakeTopicPageFactory._build_page(page_name="covid_19"),
+        ]
+
+        # When
+        private_api_crawler_with_mocked_internal_api_client.get_all_downloads(
+            pages=fake_pages, file_format="csv"
+        )
+
+        # Then
+        expected_log = f"Page {fake_pages[0]} does not contain chart data"
+        assert expected_log in caplog.text

--- a/tests/unit/caching/private_api/crawler/test_process_blocks.py
+++ b/tests/unit/caching/private_api/crawler/test_process_blocks.py
@@ -348,6 +348,7 @@ class TestCrawlerProcessIndividualBlocks:
             on the `InternalAPIClient`
         """
         # Given
+        file_format = "csv"
         chart_block = {"value": example_chart_block}
         spy_internal_api_client: mock.Mock = (
             private_api_crawler_with_mocked_internal_api_client._internal_api_client
@@ -360,7 +361,8 @@ class TestCrawlerProcessIndividualBlocks:
 
         # Then
         expected_downloads_request_data = private_api_crawler_with_mocked_internal_api_client._build_downloads_request_data(
-            chart_block=example_chart_block
+            chart_block=example_chart_block,
+            file_format=file_format,
         )
         spy_internal_api_client.hit_downloads_endpoint.assert_called_once_with(
             data=expected_downloads_request_data


### PR DESCRIPTION
# Description

This PR adds support to the private API crawler for getting all chart downloads in csv/json.

This is the first part of three PRs to enable bulk download functionality.

Fixes #CDD-1393: Update private API crawler for downloads

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
