### PR TITLE
Remove use of `re` when creating slug for CMS pages in `build_cms_site` management command

### DIFF
--- a/cms/dashboard/management/commands/build_cms_site.py
+++ b/cms/dashboard/management/commands/build_cms_site.py
@@ -5,7 +5,6 @@ Only intended for use during development
 
 import json
 import logging
-import re
 
 from django.core.management.base import BaseCommand
 from wagtail.models import Page, Site
@@ -33,8 +32,7 @@ def make_slug(page_title: str) -> str:
         The page title as a slug with invalid characters removed.
         Currently only removes quotes, commas and full-stops.
     """
-
-    return re.sub("'|\.|\s|,", "-", page_title.lower())
+    return page_title.lower().replace("'", "").replace(" ", "-")
 
 
 def open_example_page_response(page_name: str):


### PR DESCRIPTION
# Description

---

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
