### PR TITLE
CDD-1394: Create new handler for private API downloads

### DIFF
--- a/caching/private_api/handlers.py
+++ b/caching/private_api/handlers.py
@@ -127,3 +127,22 @@ def force_cache_refresh_for_all_pages() -> None:
     """
     crawler = PrivateAPICrawler.create_crawler_for_force_cache_refresh()
     _crawl_all_pages(crawler=crawler)
+
+
+def get_all_downloads(file_format: str = "csv") -> list[dict[str, str]]:
+    """Get all downloads from chart cards on supported pages
+
+    Args:
+        file_format: the format for download response data supports csv and json
+            defaults to csv.
+
+    Notes: You can pass all pages to the crawler's `get_all_downloads'
+        and it will skip over any that don't contain chart data
+        skipped pages will be logged.
+
+    Returns:
+       A list of dictionaries containing a filename and download content.
+    """
+    pages = collect_all_pages()
+    crawler = PrivateAPICrawler.create_crawler_for_cache_checking_only()
+    return crawler.get_all_downloads(pages=pages, file_format=file_format)


### PR DESCRIPTION
# Description

This PR adds a new handler for the private API crawler to retrieve all downloads for charts included on the data dashboard.

Fixes #CDD-1394

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
