### PR TITLE
Allow `trash-whats-new` as well as `whats-new` when deleting the `WhatsNewParentPage`

### DIFF
--- a/cms/whats_new/models/parent.py
+++ b/cms/whats_new/models/parent.py
@@ -74,7 +74,7 @@ class WhatsNewParentPage(Page):
             raise WhatsNewParentMultipleLivePagesError
 
     def _raise_error_if_slug_not_whats_new(self) -> None:
-        if self.slug != "whats-new":
+        if "whats-new" not in self.slug:
             raise WhatsNewParentSlugNotValidError
 
 

--- a/tests/unit/cms/whats_new/models/test_parent.py
+++ b/tests/unit/cms/whats_new/models/test_parent.py
@@ -29,15 +29,48 @@ class TestWhatsNewParentPage:
         Patches:
             `spy_raise_error_for_multiple_live_pages`: To check
                 validation is performed for preventing multiple live pages
-            `spy_raise_error_if_slug_not_whats_new`: To check
-                validation is performed for preventing a slug which is
-                not equal to `whats-new`
+           `spy_raise_error_if_slug_not_whats_new`: To check
+                validation is performed for preventing a slug which
+                does not contain `whats-new`
 
         """
         # Given
         fake_whats_new_parent_page = (
             FakeWhatsNewParentPageFactory.build_page_from_template()
         )
+
+        # When
+        fake_whats_new_parent_page.clean()
+
+        # Then
+        spy_raise_error_for_multiple_live_pages.assert_called_once()
+        spy_raise_error_if_slug_not_whats_new.assert_called_once()
+
+    @mock.patch.object(WhatsNewParentPage, "_raise_error_if_slug_not_whats_new")
+    @mock.patch.object(WhatsNewParentPage, "_raise_error_for_multiple_live_pages")
+    def test_clean_passes_for_trash_can_slug(
+        self,
+        spy_raise_error_for_multiple_live_pages: mock.MagicMock,
+        spy_raise_error_if_slug_not_whats_new: mock.MagicMock,
+    ):
+        """
+        Given a `WhatsNewParentPage` which has slug prefixed with "trash-"
+        When `clean()` is called from that model
+        Then the extra validation methods are called out to
+
+        Patches:
+            `spy_raise_error_for_multiple_live_pages`: To check
+                validation is performed for preventing multiple live pages
+            `spy_raise_error_if_slug_not_whats_new`: To check
+                validation is performed for preventing a slug which
+                does not contain `whats-new`
+
+        """
+        # Given
+        fake_whats_new_parent_page = (
+            FakeWhatsNewParentPageFactory.build_page_from_template()
+        )
+        fake_whats_new_parent_page.slug = "trash-whats-new"
 
         # When
         fake_whats_new_parent_page.clean()


### PR DESCRIPTION
# Description

This PR includes the following:

- Allows slugs which contain `whats-new` for the parent page instead of strict equality.
- This allows for pages to be deleted (which then become `trash-whats-new`

---

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
