### PR TITLE
CDD-1467: Update filenames for bulk downloads

### DIFF
--- a/docs/development_standards.md
+++ b/docs/development_standards.md
@@ -101,6 +101,23 @@ If you feel like your unit test has too many assertions then it is probably wort
 
 *Unit* tests which take > 100ms are most definitely not drawing the right boundaries and should be revisited.
 
+Note keep in mind that test cases should act as a specification of the system, so if an edge or "special" case is
+conditional for a method or function you are testing, make that condition its own test.
+
+An example of this would be formatting file or directory names, the method you are testing may format the names based
+on a set of rules around what special characters are allowed or should be removed. However there could be a case where
+a name under some condition is changed for an alternative display name. A condition that changes one name to another
+would warrant a new test to highlight this requirement in the spec.
+
+```python
+class TestFormatFilenames:
+    def test_filename_is_formatted_correctly(self):
+        ...
+    
+    def test_dashboard_is_changed_to_landing_page(self):
+        ...
+```
+
 ### Patching in tests
 
 When it comes to patching the following pattern is preferred:

--- a/metrics/domain/exports/zip.py
+++ b/metrics/domain/exports/zip.py
@@ -5,6 +5,28 @@ import zipfile
 logger = logging.getLogger(__name__)
 
 
+def write_directory_to_write_stream(
+    directory_name: str,
+    download_group: list[dict[str, str]],
+    zipf: zipfile.ZipFile,
+) -> None:
+    """Mutates the provided zipf in place to create a directory containing associated files.
+
+    Args:
+        directory_name: directory name for grouped downloads.
+        download_group: list of dictionaries containing filename and data.
+        zipf: zipfile write stream.
+
+    Returns:
+        None
+    """
+    try:
+        for download in download_group:
+            zipf.writestr(f"{directory_name}/{download['name']}", download["content"])
+    except KeyError:
+        logger.exception("Failed to create directory directory_name and its files.")
+
+
 def write_data_to_zip(
     downloads: list[dict[str, str]],
 ) -> zip:
@@ -12,18 +34,23 @@ def write_data_to_zip(
 
     Args:
         downloads: A list of dictionaries containing
-            a name and content of the data to be written to a zip file
+            a directory name, filename and content of the data
+            to be written to a zip file.
 
     Returns:
         A zipfile containing downloads
     """
     in_memory_zip = io.BytesIO()
 
-    with zipfile.ZipFile(in_memory_zip, "w") as zipf:
+    with zipfile.ZipFile(in_memory_zip, "w", zipfile.ZIP_DEFLATED) as zipf:
         try:
             for download in downloads:
-                zipf.writestr(download["name"], download["content"])
+                write_directory_to_write_stream(
+                    directory_name=download["directory_name"],
+                    download_group=download["downloads"],
+                    zipf=zipf,
+                )
         except KeyError:
-            logger.exception("Failed to write bulk_downloads to zip write stream")
+            logger.exception("Failed to write bulk downloads to zip write stream.")
 
     return in_memory_zip.getvalue()

--- a/tests/unit/caching/private_api/crawler/test_create_file_and_directory_names_for_chart_cards.py
+++ b/tests/unit/caching/private_api/crawler/test_create_file_and_directory_names_for_chart_cards.py
@@ -1,0 +1,146 @@
+import pytest
+
+from caching.private_api.crawler import PrivateAPICrawler
+
+
+class TestCreateFileAndDirectoryNamesForChartCards:
+    @pytest.mark.parametrize(
+        "chart_card_names, formatted_chart_card_names",
+        [
+            (
+                "chart card name with (20+) chars! - 10,000",
+                "chart_card_name_with_20_chars_10000",
+            ),
+            (
+                "another chart card title, covid cases (20,000+) / tests",
+                "another_chart_card_title_covid_cases_20000_tests",
+            ),
+            (
+                "charts - cards - cases & 54+ (7day)",
+                "charts_cards_cases_54_7day",
+            ),
+            (
+                r"charts,with\slashes/in-the-title-and-no-spaces",
+                "chartswithslashesinthetitleandnospaces",
+            ),
+            (
+                "Test top^&&*ic folder+ / CDD-1467 !@'()%",
+                "test_topic_folder_cdd1467",
+            ),
+            (
+                "t;:!est chart name@",
+                "test_chart_name",
+            ),
+            (
+                'test cdd-1467 spec.!"£$%^&**()?|:;/ial Characters',
+                "test_cdd1467_special_characters",
+            ),
+        ],
+    )
+    def test_format_titles_for_filenames_behaves_correctly(
+        self,
+        chart_card_names: str,
+        formatted_chart_card_names: str,
+        private_api_crawler_with_mocked_internal_api_client: PrivateAPICrawler,
+    ):
+        """
+        Given a string that contains special characters.
+        When the `format_titles_for_filenames()` method is called.
+        Then the string is formatted to remove special characters including spaces.
+        """
+        # Given
+        fake_name = chart_card_names
+
+        # When
+        expected_filename = private_api_crawler_with_mocked_internal_api_client.format_titles_for_filenames(
+            file_name=fake_name
+        )
+
+        # Then
+        assert expected_filename == formatted_chart_card_names
+
+    @pytest.mark.parametrize(
+        "directory_names, formatted_directory_names",
+        [
+            (
+                "directory name with spaces and (12+) / other characters!+",
+                "directory_name_with_spaces_and_12_other_characters",
+            ),
+            (
+                "directory with /slashes and-no-spaces",
+                "directory_with_slashes_andnospaces",
+            ),
+            (
+                "top$ic folder",
+                "topic_folder",
+            ),
+            (
+                r"t%:;£est\ 1467 /charts ()$%^* TEST?[]",
+                "test_1467_charts_test",
+            ),
+        ],
+    )
+    def test_create_directory_name_for_downloads_behaves_correctly(
+        self,
+        directory_names: str,
+        formatted_directory_names: str,
+        private_api_crawler_with_mocked_internal_api_client: PrivateAPICrawler,
+    ):
+        """
+        Given a fake directory name that contains special characters.
+        When the `create_directory_for_downloads()` is called.
+        Then the string is formatted to remove special characters.
+        """
+        # Given
+        fake_directory_name = directory_names
+
+        # When
+        expected_file_name = private_api_crawler_with_mocked_internal_api_client.create_directory_name_for_downloads(
+            file_name=fake_directory_name,
+        )
+
+        # Then
+        assert expected_file_name == formatted_directory_names
+
+    def test_data_dashboard_is_renamed_landing_page(
+        self,
+        private_api_crawler_with_mocked_internal_api_client: PrivateAPICrawler,
+    ):
+        """
+        Given a directory name of "UKHSA data dashboard"
+        When the `create_directory_name_for_downloads()` method id called.
+        Then the directory name is changed to landing_page.
+        """
+        # Given
+        fake_directory_name = "UKHSA data dashboard"
+
+        # When
+        expected_file_name = private_api_crawler_with_mocked_internal_api_client.create_directory_name_for_downloads(
+            file_name=fake_directory_name,
+        )
+
+        # Then
+        assert expected_file_name == "landing_page"
+
+    def test_create_filename_for_chart_card_adds_file_extension(
+        self,
+        private_api_crawler_with_mocked_internal_api_client: PrivateAPICrawler,
+    ):
+        """
+        Given a fake filename that contains special characters.
+        When the `create_filename_for_chart_card()` is called.
+        Then the string is formatted to remove special characters and suffixed
+            with the appropriate file extension.
+        """
+        # Given
+        fake_file_name = "chart card title"
+        fake_file_format = "csv"
+
+        # When
+        expected_file_name = private_api_crawler_with_mocked_internal_api_client.create_filename_for_chart_card(
+            file_name=fake_file_name,
+            file_format=fake_file_format,
+        )
+
+        # Then
+        assert expected_file_name == f"chart_card_title.{fake_file_format}"

--- a/tests/unit/metrics/domain/exports/test_zip.py
+++ b/tests/unit/metrics/domain/exports/test_zip.py
@@ -2,20 +2,24 @@ from unittest import mock
 
 from _pytest.logging import LogCaptureFixture
 
-from metrics.domain.exports.zip import write_data_to_zip
+from metrics.domain.exports.zip import (
+    write_data_to_zip,
+    write_directory_to_write_stream,
+)
+
+MODULE_PATH = "metrics.domain.exports.zip"
 
 
 class TestWriteDataToZip:
-    @mock.patch("metrics.domain.exports.zip.zipfile.ZipFile")
-    def test_behaves_as_expected(
+    @mock.patch(f"{MODULE_PATH}.zipfile.ZipFile")
+    def test_write_directory_to_stream_behaves_as_expected(
         self,
-        spy_zipfile: mock.MagicMock,
+        mocked_zip_writestr: mock.MagicMock,
     ):
         """
-        Given a valid list of downloads is provided
-        When the write_data_to_zip() method is called
-        Then the zipfile.zipfile method is called once and
-            the return value is of type io.BytesIO
+        Given a valid directory name and download_group.
+        When the `write_directory_to_write_stream()` is called.
+        Then `zipfile.writestr()` is called n times.
         """
         # Given
         expected_csv_body = [
@@ -32,19 +36,114 @@ class TestWriteDataToZip:
             "2023-03-08",
             "2364",
         ]
-        fake_downloads = [{"name": "chart_name", "content": expected_csv_body}]
+        fake_directory_name = "directory_name"
+        fake_download_group = [
+            {"name": "chart_one", "content": expected_csv_body},
+            {"name": "chart_two", "content": expected_csv_body},
+        ]
+
+        # When
+        write_directory_to_write_stream(
+            directory_name=fake_directory_name,
+            download_group=fake_download_group,
+            zipf=mocked_zip_writestr,
+        )
+
+        # Then
+        expected_calls = [
+            mock.call("directory_name/chart_one", expected_csv_body),
+            mock.call("directory_name/chart_two", expected_csv_body),
+        ]
+        mocked_zip_writestr.writestr.assert_has_calls(
+            expected_calls,
+            any_order=True,
+        )
+
+    @mock.patch(f"{MODULE_PATH}.zipfile.ZipFile")
+    def test_write_directory_to_stream_logs_exception(
+        self,
+        mocked_zip_writestr: mock.MagicMock,
+        caplog: LogCaptureFixture,
+    ):
+        """
+        Given an invalid download group.
+        When the `write_directory_to_write_stream()` is called.
+        Then a KeyError is logged.
+        """
+        # Given
+        fake_directory_name = "directory_name"
+        fake_download_group = [
+            {"wrong_key": "chart_one", "content": []},
+        ]
+
+        # When
+        write_directory_to_write_stream(
+            directory_name=fake_directory_name,
+            download_group=fake_download_group,
+            zipf=mocked_zip_writestr,
+        )
+
+        # Then
+        expected_log = "Failed to create directory directory_name and its files."
+        assert expected_log in caplog.text
+
+    @mock.patch(f"{MODULE_PATH}.zipfile.ZipFile")
+    @mock.patch(f"{MODULE_PATH}.write_directory_to_write_stream")
+    def test_behaves_as_expected(
+        self,
+        spy_write_directory_to_write_stream: mock.MagicMock,
+        spy_zipfile: mock.MagicMock,
+    ):
+        """
+        Given a valid list of downloads is provided
+        When the `write_data_to_zip()` method is called
+        Then the zipfile.Zipfile is called once and the
+            `write_directory_to_write_stream()` is called n times
+        """
+        # Given
+        expected_csv_body = [
+            "infectious_disease",
+            "respiratory",
+            "COVID-19",
+            "Nation",
+            "England",
+            "COVID-19_deaths_ONSByDay",
+            "all",
+            "75+",
+            "default",
+            "2023",
+            "2023-03-08",
+            "2364",
+        ]
+        fake_downloads = [
+            {
+                "directory_name": "group one",
+                "downloads": [
+                    {"name": "chart_one", "content": expected_csv_body},
+                    {"name": "chart_two", "content": expected_csv_body},
+                ],
+            },
+            {
+                "directory_name": "group two",
+                "downloads": [
+                    {"name": "chart_one", "content": expected_csv_body},
+                    {"name": "chart_two", "content": expected_csv_body},
+                ],
+            },
+        ]
 
         # When
         expected_zip_files = write_data_to_zip(downloads=fake_downloads)
 
         # Then
         spy_zipfile.assert_called_once()
+        assert spy_write_directory_to_write_stream.call_count == 2
         assert isinstance(expected_zip_files, bytes)
 
     def test_logs_failure(self, caplog: LogCaptureFixture):
         """
         Given an invalid list of downloads is provided
-        When the write_data_to_zip() method is called
+        When the `write_data_to_zip()` method is called
         Then a keyError exception is logged.
         """
         # Given
@@ -63,12 +162,18 @@ class TestWriteDataToZip:
             "2364",
         ]
         fake_invalid_downloads = [
-            {"wrong_key": "chart_name", "content": expected_csv_body}
+            {
+                "wrong_key": "name",
+                "downloads": [
+                    {"name": "chart_one", "content": expected_csv_body},
+                    {"name": "chart_two", "content": expected_csv_body},
+                ],
+            }
         ]
 
         # When
         write_data_to_zip(downloads=fake_invalid_downloads)
 
         # Then
-        expected_log = "Failed to write bulk_downloads to zip write stream"
+        expected_log = "Failed to write bulk downloads to zip write stream."
         assert expected_log in caplog.text


### PR DESCRIPTION
# Description

This PR updates the filename create for chart card downloads removing special characters including '()/\+!-' and spaces. It also supports directory name formatting and separates bulk download files into directories based on page name.

Fixes #CDD-1487

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [x] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
