### PR TITLE
Bake in the `DJANGO_SETTINGS_MODULE` env var, which is used to point Django at the correct settings file

### DIFF
--- a/Dockerfile-ingestion
+++ b/Dockerfile-ingestion
@@ -2,6 +2,8 @@ FROM public.ecr.aws/lambda/python:3.11
 
 # Ensure the virtual environment will be available on the `PATH` variable
 ENV PATH=/venv/bin:$PATH
+# Bake in the env var required to point Django at the correct settings file
+ENV DJANGO_SETTINGS_MODULE="metrics.api.settings"
 
 # Copy the production-only dependencies into place for the ingestion component
 COPY requirements-prod-ingestion.txt requirements-prod-ingestion.txt


### PR DESCRIPTION
# Description

This PR includes the following:

- Bakes the `DJANGO_SETTINGS_MODULE` env var into the ingestion dockerfile. This normally isn't needed to be explictly provided as it is normally defaulted to when starting the django server. But the ingestion/lambda doens't actually start the django server

Fixes #CDD-1504

---

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
