### PR TITLE
Add temp hack to filter for `age=65+` for `COVID-19_headline_vaccines_autumn23Uptake` metric name

### DIFF
--- a/metrics/api/views/headlines.py
+++ b/metrics/api/views/headlines.py
@@ -88,6 +88,8 @@ class HeadlinesView(APIView):
             # This is a temporary patch to ensure the correct age is set for this metric
             if metric == "COVID-19_headline_vaccines_spring23Total":
                 request_data["age"] = "75+"
+            if metric == "COVID-19_headline_vaccines_autumn23Uptake":
+                request_data["age"] = "65+"
 
             return _handle_beta_schema_headlines_request(request_data=request_data)
 


### PR DESCRIPTION
# Description

This PR includes the following:

- Hacks a hardcoded rule in place to always apply `age=65+` for headline metrics of `COVID-19_headline_vaccines_autumn23Uptake`.
- This is a temporary hack until the FE migrates to using the v3 headlines endpoint

Fixes #CDD-1537

---

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
