### PR TITLE
Set `WAGTAILAPI_LIMIT_MAX` to None

### DIFF
--- a/metrics/api/settings.py
+++ b/metrics/api/settings.py
@@ -306,6 +306,10 @@ WAGTAILSEARCH_BACKENDS = {
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
 WAGTAILADMIN_BASE_URL = "http://example.com"
 
+# Controls the maximum number of results which can be requested from the pages API.
+# Set to None for no limit.
+WAGTAILAPI_LIMIT_MAX = None
+
 
 # Email server config
 EMAIL_BACKEND = config.EMAIL_BACKEND


### PR DESCRIPTION
# Description

This PR includes the following:

- Sets `WAGTAILAPI_LIMIT_MAX` to None. This means we can set the `limit` query param when making requests to the pages/ API to be any number above the previous max of 20 as well.

Fixes #CDD-1560

---

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
