### PR TITLE
Implement lazy loading for the Private API crawler

### DIFF
--- a/caching/private_api/crawler.py
+++ b/caching/private_api/crawler.py
@@ -45,6 +45,13 @@ class PrivateAPICrawler:
         internal_api_client = InternalAPIClient(force_refresh=True)
         return cls(internal_api_client=internal_api_client)
 
+    @classmethod
+    def create_crawler_for_lazy_loading(cls) -> Self:
+        internal_api_client = InternalAPIClient(
+            force_refresh=False, cache_check_only=False
+        )
+        return cls(internal_api_client=internal_api_client)
+
     # Process headless CMS API
 
     def process_list_pages_for_headless_cms_api(self) -> None:

--- a/caching/private_api/handlers.py
+++ b/caching/private_api/handlers.py
@@ -139,13 +139,15 @@ def get_all_downloads(file_format: str = "csv") -> list[dict[str, str]]:
         file_format: the format for download response data supports csv and json
             defaults to csv.
 
-    Notes: You can pass all pages to the crawler's `get_all_downloads'
+    Notes:
+        You can pass all pages to the crawler's `get_all_downloads'
         and it will skip over any that don't contain chart data
         skipped pages will be logged.
 
     Returns:
        A list of dictionaries containing a filename and download content.
+
     """
     pages = collect_all_pages()
-    crawler = PrivateAPICrawler.create_crawler_for_cache_checking_only()
+    crawler = PrivateAPICrawler.create_crawler_for_lazy_loading()
     return crawler.get_all_downloads(pages=pages, file_format=file_format)

--- a/tests/unit/caching/private_api/crawler/test_class_methods.py
+++ b/tests/unit/caching/private_api/crawler/test_class_methods.py
@@ -29,3 +29,17 @@ class TestPrivateAPICrawlerCreate:
 
         # Then
         assert crawler._internal_api_client.force_refresh
+
+    def test_create_crawler_for_lazy_loading(self):
+        """
+        Given no pre-existing `InternalAPIClient`
+        When the `create_crawler_for_lazy_loading` class method
+            is called from the `PrivateAPICrawler` class
+        Then the correct object is returned
+        """
+        # Given / When
+        crawler = PrivateAPICrawler.create_crawler_for_lazy_loading()
+
+        # Then
+        assert not crawler._internal_api_client.force_refresh
+        assert not crawler._internal_api_client.cache_check_only

--- a/tests/unit/caching/private_api/test_handlers.py
+++ b/tests/unit/caching/private_api/test_handlers.py
@@ -335,10 +335,10 @@ class TestHydrateCacheForAllPages:
 
 class TestGetAllDownloads:
     @mock.patch(f"{MODULE_PATH}.collect_all_pages")
-    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_cache_checking_only")
+    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_lazy_loading")
     def test_delegates_calls_correctly(
         self,
-        spy_create_crawler_for_cache_checking_only: mock.MagicMock,
+        spy_create_crawler_for_lazy_loading: mock.MagicMock,
         spy_collect_all_pages: mock.MagicMock,
     ):
         """
@@ -348,7 +348,7 @@ class TestGetAllDownloads:
             crawler_get_all_downloads() methods.
         """
         # Given
-        crawler = spy_create_crawler_for_cache_checking_only.return_value
+        crawler = spy_create_crawler_for_lazy_loading.return_value
         fake_file_format = "csv"
 
         # When
@@ -357,16 +357,16 @@ class TestGetAllDownloads:
         # Then
         spy_collect_all_pages.assert_called_once()
         expected_pages = spy_collect_all_pages.return_value
-        spy_create_crawler_for_cache_checking_only.assert_called_once()
+        spy_create_crawler_for_lazy_loading.assert_called_once()
         crawler.get_all_downloads.assert_called_once_with(
             pages=expected_pages, file_format=fake_file_format
         )
 
     @mock.patch(f"{MODULE_PATH}.collect_all_pages")
-    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_cache_checking_only")
+    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_lazy_loading")
     def test_default_file_format_can_be_changed_to_json(
         self,
-        spy_create_crawler_for_cache_checking_only: mock.MagicMock,
+        spy_create_crawler_for_lazy_loading: mock.MagicMock,
         spy_collect_all_pages,
     ):
         """
@@ -376,7 +376,7 @@ class TestGetAllDownloads:
         Then The file_format parameter set to json.
         """
         # Given
-        crawler = spy_create_crawler_for_cache_checking_only.return_value
+        crawler = spy_create_crawler_for_lazy_loading.return_value
         file_format = "json"
 
         # Then
@@ -389,10 +389,10 @@ class TestGetAllDownloads:
         )
 
     @mock.patch(f"{MODULE_PATH}.collect_all_pages")
-    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_cache_checking_only")
+    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_lazy_loading")
     def test_default_file_format_is_csv(
         self,
-        spy_create_crawler_for_cache_checking_only: mock.MagicMock,
+        spy_create_crawler_for_lazy_loading: mock.MagicMock,
         spy_collect_all_pages,
     ):
         """
@@ -401,7 +401,7 @@ class TestGetAllDownloads:
         Then The default file_format parameter is set to csv.
         """
         # Given
-        crawler = spy_create_crawler_for_cache_checking_only.return_value
+        crawler = spy_create_crawler_for_lazy_loading.return_value
 
         # When
         get_all_downloads()


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds a new class method on the private api crawler to create a crawler which will lazy load the cache
- This means we can use this mode when trying to fetch things from the cache after the initial crawl i.e. like bulk downloads

Fixes #CDD-1466

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
