### PR TITLE
Hardcode emergency values in headlines endpoint to rectify ONS data temporarily

### DIFF
--- a/metrics/api/views/headlines.py
+++ b/metrics/api/views/headlines.py
@@ -92,7 +92,10 @@ class HeadlinesView(APIView):
             return Response({"value": 212})
         if serialized_model.metric_name == "COVID-19_headline_ONSdeaths_7DayChange":
             return Response({"value": 31})
-        if serialized_model.metric_name == "COVID-19_headline_ONSdeaths_7DayPercentChange":
+        if (
+            serialized_model.metric_name
+            == "COVID-19_headline_ONSdeaths_7DayPercentChange"
+        ):
             return Response({"value": 17.1})
 
         return Response({"value": headline_number})


### PR DESCRIPTION
# Description

Makes a temp change to hardcode 3 headline number values that have been derived from ONS.
Due to the issues with the data we need to roll this back. But we have already ingested that data hence the need for the late hardcoding of the values

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
