### PR TITLE
Update tests to check `embargo` fields given as dates are cast to midnight by of that date if time not provided

### DIFF
--- a/tests/unit/ingestion/data_transfer_models/test_time_series.py
+++ b/tests/unit/ingestion/data_transfer_models/test_time_series.py
@@ -111,22 +111,35 @@ class TestInboundTimeSeriesSpecificFields:
     def test_raises_error_when_date_passed_to_embargo(self):
         """
         Given a payload containing a date string for `embargo`
+            without a specified timestamp
         When the `InboundTimeSeriesSpecificFields` model is initialized
-        Then a `ValidationError` is raised
+        Then the model is deemed valid
+        And the embargo is cast on the correct date
+            with a timestamp of midnight
         """
         # Given
         fake_date = "2023-11-20"
         fake_epiweek = 46
         fake_embargo = "2023-11-30"
 
-        # When / Then
-        with pytest.raises(ValidationError):
+        # When
+        inbound_time_series_specific_fields_validation = (
             InboundTimeSeriesSpecificFields(
                 date=fake_date,
                 epiweek=fake_epiweek,
                 embargo=fake_embargo,
                 metric_value=123,
             )
+        )
+
+        # Then
+        validated_embargo = inbound_time_series_specific_fields_validation.embargo
+        assert validated_embargo.year == 2023
+        assert validated_embargo.month == 11
+        assert validated_embargo.day == 30
+        assert validated_embargo.hour == 0
+        assert validated_embargo.minute == 0
+        assert validated_embargo.second == 0
 
 
 class TestTimeSeriesDTO:


### PR DESCRIPTION


---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
