### PR TITLE
Temporarily hide `enable_area_selector` field from `TopicPage` content panels

### DIFF
--- a/cms/topic/models.py
+++ b/cms/topic/models.py
@@ -37,7 +37,6 @@ class TopicPage(Page):
     # Editor panels configuration
     content_panels = Page.content_panels + [
         FieldPanel("date_posted"),
-        FieldPanel("enable_area_selector"),
         FieldPanel("page_description"),
         FieldPanel("body"),
     ]

--- a/tests/unit/cms/topic/test_models.py
+++ b/tests/unit/cms/topic/test_models.py
@@ -199,7 +199,6 @@ class TestTemplateCOVID19Page:
         "expected_content_panel_name",
         [
             "date_posted",
-            "enable_area_selector",
             "page_description",
             "body",
         ],


### PR DESCRIPTION


---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
