### PR TITLE
Chore/bump wagtail to version 6

### DIFF
--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -90,7 +90,7 @@ typing_extensions==4.9.0
 uritemplate==4.1.1
 urllib3==2.0.7
 virtualenv==20.24.6
-wagtail==5.2.3
+wagtail==6.0
 wagtail_trash==3.0.0
 wagtail_modeladmin==2.0.0
 webencodings==0.5.1


### PR DESCRIPTION
# Description

This PR includes the following:

- Bumps django-taggit and wagtail. The latter of which was previously blocked from being bumped because of another dependency, wagtail-trash

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
