### PR TITLE
Remove deprecated `geographies/types` v1 endpoint

### DIFF
--- a/metrics/api/serializers/geographies.py
+++ b/metrics/api/serializers/geographies.py
@@ -5,31 +5,8 @@ from rest_framework import serializers
 from metrics.data.managers.core_models.time_series import CoreTimeSeriesQuerySet
 from metrics.data.models.core_models import (
     CoreTimeSeries,
-    Geography,
-    GeographyType,
     Topic,
 )
-
-
-class GeographySerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Geography
-        fields = ["id", "name"]
-
-
-class GeographyTypesDetailSerializer(serializers.ModelSerializer):
-    geographies = GeographySerializer(many=True, read_only=True)
-
-    class Meta:
-        model = GeographyType
-        fields = ["geographies"]
-
-
-class GeographyTypesSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = GeographyType
-        fields = ["id", "name"]
-
 
 GEOGRAPHY_TYPE_RESULT = dict[str, list[dict[str, str]]]
 

--- a/metrics/api/urls_construction.py
+++ b/metrics/api/urls_construction.py
@@ -9,7 +9,6 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 from rest_framework import routers
-from rest_framework.routers import DefaultRouter
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.api.v2.router import WagtailAPIRouter
 
@@ -26,7 +25,7 @@ from metrics.api.views import (
     TablesView,
     TrendsView,
 )
-from metrics.api.views.geographies import GeographiesView, GeographyTypesViewSet
+from metrics.api.views.geographies import GeographiesView
 from public_api import construct_urlpatterns_for_public_api
 
 router = routers.DefaultRouter()
@@ -109,11 +108,6 @@ def construct_public_api_urlpatterns(
 
 API_PREFIX = "api/"
 
-geographies_router = DefaultRouter()
-geographies_router.register(
-    prefix=f"{API_PREFIX}geographies/v1/types", viewset=GeographyTypesViewSet
-)
-
 private_api_urlpatterns = [
     # Headless CMS API - pages + drafts endpoints
     path(API_PREFIX, cms_api_router.urls),
@@ -127,7 +121,6 @@ private_api_urlpatterns = [
     re_path(f"^{API_PREFIX}tables/v4", TablesView.as_view()),
     re_path(f"^{API_PREFIX}trends/v3", TrendsView.as_view()),
 ]
-private_api_urlpatterns += geographies_router.urls
 
 feedback_urlpatterns = construct_urlpatterns_for_feedback(prefix=API_PREFIX)
 

--- a/metrics/api/views/geographies.py
+++ b/metrics/api/views/geographies.py
@@ -1,44 +1,14 @@
 from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from caching.private_api.decorators import cache_response
 from metrics.api.serializers.geographies import (
     GEOGRAPHY_TYPE_RESULT,
     GeographiesSerializer,
-    GeographyTypesDetailSerializer,
-    GeographyTypesSerializer,
 )
-from metrics.data.models.core_models import GeographyType
 
 GEOGRAPHIES_API_TAG = "geographies"
-
-
-@extend_schema(tags=[GEOGRAPHIES_API_TAG], deprecated=True)
-class GeographyTypesViewSet(ReadOnlyModelViewSet):
-    """
-    Note: This ViewSet and the `geographies/v1` endpoint have been deprecated.
-        This will be replaced by a new `API_VIEW` and v2 endpoint that retrieves geographies
-        data based on a selected topic.
-    """
-
-    permission_classes = []
-    queryset = GeographyType.objects.all().order_by("name")
-    serializer_class = GeographyTypesSerializer
-
-    def get_serializer_class(self):
-        if self.action == "retrieve":
-            return GeographyTypesDetailSerializer
-        return self.serializer_class
-
-    @cache_response()
-    def list(self, request, *args, **kwargs):  # noqa: A003
-        return super().list(request, *args, **kwargs)
-
-    @cache_response()
-    def retrieve(self, request, *args, **kwargs):
-        return super().retrieve(request, *args, **kwargs)
 
 
 @extend_schema(tags=[GEOGRAPHIES_API_TAG])

--- a/tests/integration/metrics/api/views/test_geographies.py
+++ b/tests/integration/metrics/api/views/test_geographies.py
@@ -4,78 +4,7 @@ import pytest
 from rest_framework.response import Response
 from rest_framework.test import APIClient
 
-from metrics.data.models.core_models import GeographyType
-from tests.factories.metrics.geography_type import GeographyTypeFactory
 from tests.factories.metrics.time_series import CoreTimeSeriesFactory
-
-
-class TestGeographyTypesViewSet:
-    @property
-    def path(self) -> str:
-        return "/api/geographies/v1/types/"
-
-    @pytest.mark.django_db
-    def test_list_view_returns_correct_response(self):
-        """
-        Given a number of `GeographyType` records in the database
-        When a GET request is made to the list
-            `/api/geographies/v1/types/` endpoint
-        Then the ID and the name of each `GeographyType` record
-            are listed in the response
-        """
-        # Given
-        client = APIClient()
-        geography_type_names = ["Nation", "Lower Tier Local Authority"]
-        geography_types = [
-            GeographyType.objects.create(name=geography_type_name)
-            for geography_type_name in geography_type_names
-        ]
-
-        # When
-        response: Response = client.get(path=self.path)
-
-        # Then
-        assert response.status_code == HTTPStatus.OK
-        for geography_type in geography_types:
-            expected_data_for_geography_type = {
-                "id": geography_type.id,
-                "name": geography_type.name,
-            }
-            assert expected_data_for_geography_type in response.data
-
-    @pytest.mark.django_db
-    def test_detail_view_returns_correct_response(self):
-        """
-        Given a `GeographyType` record in the database
-        And a number of associated `Geography` records
-        When a GET request is made to the detail
-            `/api/geographies/v1/types/{id}` endpoint
-        Then the ID and the name of each `Geography` record
-            associated with the requested `GeographyType`
-            are listed in the response
-        """
-        # Given
-        client = APIClient()
-        geography_names = ["London", "Leeds"]
-        geography_type = GeographyTypeFactory.create(
-            name="Lower Tier Local",
-            with_geographies__geography_names=geography_names,
-        )
-
-        # When
-        path = f"{self.path}{geography_type.id}/"
-        response: Response = client.get(path=path)
-
-        # Then
-        assert response.status_code == HTTPStatus.OK
-        returned_associated_geographies = response.data["geographies"]
-
-        for associated_geography in geography_type.geographies.all():
-            expected_geography_detail_data = {
-                "id": associated_geography.id,
-                "name": associated_geography.name,
-            }
-            assert expected_geography_detail_data in returned_associated_geographies
 
 
 class TestGeographiesView:

--- a/tests/unit/metrics/api/serializers/test_geographies.py
+++ b/tests/unit/metrics/api/serializers/test_geographies.py
@@ -3,58 +3,14 @@ from unittest import mock
 
 from metrics.api.serializers.geographies import (
     GeographiesSerializer,
-    GeographySerializer,
-    GeographyTypesSerializer,
     _serialize_queryset,
 )
 from tests.fakes.factories.metrics.core_time_series_factory import (
     FakeCoreTimeSeriesFactory,
 )
-from tests.fakes.factories.metrics.geography_factory import FakeGeographyFactory
-from tests.fakes.factories.metrics.geography_type_factory import (
-    FakeGeographyTypeFactory,
-)
 from tests.fakes.managers.time_series_manager import FakeCoreTimeSeriesManager
 from tests.fakes.managers.topic_manager import FakeTopicManager
 from tests.fakes.models.metrics.topic import FakeTopic
-
-
-class TestGeographySerializer:
-    def test_returns_expected_serialized_data(self):
-        """
-        Given a `Geography` object
-        When the object is serialized with the `GeographySerializer`
-        Then the correct data is returned
-        """
-        # Given
-        fake_geography = FakeGeographyFactory.build_example()
-
-        # When
-        serializer = GeographySerializer(instance=fake_geography)
-
-        # Then
-        serialized_data = serializer.data
-        assert serialized_data["name"] == fake_geography.name
-        assert serialized_data["id"] == fake_geography.id
-
-
-class TestGeographyTypesSerializer:
-    def test_returns_expected_serialized_data(self):
-        """
-        Given a `GeographyType` object
-        When the object is serialized with the `GeographyTypesSerializer`
-        Then the correct data is returned
-        """
-        # Given
-        fake_geography_type = FakeGeographyTypeFactory.build_example()
-
-        # When
-        serializer = GeographyTypesSerializer(instance=fake_geography_type)
-
-        # Then
-        serialized_data = serializer.data
-        assert serialized_data["name"] == fake_geography_type.name
-        assert serialized_data["id"] == fake_geography_type.id
 
 
 class TestGeographiesSerializer:

--- a/tests/unit/metrics/api/test_urls_construction.py
+++ b/tests/unit/metrics/api/test_urls_construction.py
@@ -23,7 +23,7 @@ PRIVATE_API_ENDPOINT_PATHS = [
     "api/bulkdownloads/v1",
     "api/tables/v4",
     "api/trends/v3",
-    "api/geographies/v1/types/",
+    "api/geographies/v2/",
 ]
 
 FEEDBACK_API_ENDPOINT_PATHS = ["api/suggestions/v1"]


### PR DESCRIPTION
# Description

This PR includes the following:

- Removes the now deprecated `geographies/types` v1 endpoints

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
