### PR TITLE
Debt/move dev dependencies into dev requirements/cdd 1212

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,7 +12,6 @@ isort==5.13.2
 pip-api==0.0.33
 pip_audit==2.7.1
 pip-requirements-parser==32.0.1
-pyparsing==3.1.1
 pre-commit==3.6.2
 pylint==3.1.0
 pylint-django==2.5.5

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -58,6 +58,7 @@ Pillow==10.2.0
 platformdirs==3.11.0
 plotly==5.19.0
 pluggy==1.4.0
+pyparsing==3.1.1
 psycopg2==2.9.9
 pyrsistent==0.20.0
 python-dateutil==2.8.2


### PR DESCRIPTION
# Description

This PR includes the following:

- Moves the remaining dev-only dependencies out of the prod requirements and into the dev dependencies. This should help slim down the number of dependencies needed for the application container image

Fixes #CDD-1212

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
