### PR TITLE
Remove unused filtering of `"body"` from requests made to headlines & trend endpoints from build of cache key

### DIFF
--- a/caching/private_api/management.py
+++ b/caching/private_api/management.py
@@ -151,11 +151,7 @@ class CacheManagement:
             case "POST":
                 data = request.data
             case "GET":
-                data = {
-                    k: v
-                    for k, v in request.query_params.dict().items()
-                    if k.lower() != "body"
-                }
+                data = request.query_params.dict()
             case _:
                 raise ValueError
 

--- a/tests/unit/caching/private_api/test_management.py
+++ b/tests/unit/caching/private_api/test_management.py
@@ -562,36 +562,6 @@ class TestCacheManagement:
             endpoint_path=mocked_request.path, data=mocked_request.query_params.dict()
         )
 
-    @mock.patch.object(CacheManagement, "build_cache_entry_key_for_data")
-    def test_build_cache_entry_key_for_request_get_which_filters_out_body_key_value_pair(
-        self,
-        spy_build_cache_entry_key_for_data: mock.MagicMock,
-        cache_management_with_in_memory_cache: CacheManagement,
-    ):
-        """
-        Given a mocked GET request which includes a query param for `body`
-        When `build_cache_entry_key_for_request()` is called
-            from an instance of `CacheManagement`
-        Then the call is delegated to `build_cache_entry_key_for_data()`
-            with the correct args
-        """
-        # Given
-        mocked_request = mock.MagicMock(method="GET")
-        mocked_request.query_params.dict.return_value = {
-            "param_a": "query_a",
-            "body": "some string",
-        }
-
-        # When
-        cache_management_with_in_memory_cache.build_cache_entry_key_for_request(
-            request=mocked_request
-        )
-
-        # Then
-        spy_build_cache_entry_key_for_data.assert_called_once_with(
-            endpoint_path=mocked_request.path, data={"param_a": "query_a"}
-        )
-
     @pytest.mark.parametrize(
         "invalid_http_method",
         (


### PR DESCRIPTION
# Description

This PR includes the following:

- Remove unused filtering of `"body"` from requests made to headlines & trend endpoints from build of cache key

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
