### PR TITLE
Task/publish api and ingestion images to central ecrs in tools account dual running with dev ecr/cdd 1774

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -161,8 +161,8 @@ jobs:
   # Build image
   ###############################################################################
 
-  publish-main-image:
-    name: Publish main image
+  publish-main-image-to-deprecated-ecr:
+    name: Publish main image to deprecated ECR
     needs: [
       quality-checks,
       unit-tests,
@@ -191,6 +191,8 @@ jobs:
 
   publish-ingestion-image:
     name: Publish ingestion image
+  publish-ingestion-image-to-deprecated-ecr:
+    name: Publish ingestion image to deprecated ECR
     needs: [
       quality-checks,
       unit-tests,

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -260,6 +260,7 @@ jobs:
           ecr-repository: "data-dashboard/ingestion"
           role-to-assume: ${{ secrets.AWS_TOOLS_ACCOUNT_ROLE }}
           dockerfile: Dockerfile-ingestion
+          architecture: arm64
 
   ###############################################################################
   # Deploy

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -208,9 +208,6 @@ jobs:
         with:
           ecr-repository: "data-dashboard/api"
           role-to-assume: ${{ secrets.AWS_TOOLS_ACCOUNT_ROLE }}
-          build-command: |
-            docker build \
-              -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
 
   publish-ingestion-image-to-deprecated-ecr:
     name: Publish ingestion image to deprecated ECR
@@ -261,8 +258,7 @@ jobs:
         with:
           ecr-repository: "data-dashboard/ingestion"
           role-to-assume: ${{ secrets.AWS_TOOLS_ACCOUNT_ROLE }}
-          build-command: |
-            docker build --platform linux/amd64 -f Dockerfile-ingestion -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          dockerfile: Dockerfile-ingestion
 
   ###############################################################################
   # Deploy

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -191,7 +191,16 @@ jobs:
 
   publish-main-image:
     name: Publish main image to central ECR
-    needs: [ publish-main-image-to-deprecated-ecr ]
+    needs: [
+      quality-checks,
+      unit-tests,
+      integration-tests,
+      system-tests,
+      migration-tests,
+      test-coverage,
+      vulnerabilities,
+      architecture-checks
+    ]
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
@@ -236,7 +245,16 @@ jobs:
 
   publish-ingestion-image:
     name: Publish ingestion image to central ECR
-    needs: [ publish-ingestion-image-to-deprecated-ecr ]
+    needs: [
+      quality-checks,
+      unit-tests,
+      integration-tests,
+      system-tests,
+      migration-tests,
+      test-coverage,
+      vulnerabilities,
+      architecture-checks
+    ]
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -189,8 +189,23 @@ jobs:
             docker build \
               -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
 
-  publish-ingestion-image:
-    name: Publish ingestion image
+  publish-main-image:
+    name: Publish main image to central ECR
+    needs: [ publish-main-image-to-deprecated-ecr ]
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Build and publish docker image
+        uses: ./.github/actions/publish-image
+        with:
+          ecr-repository: "data-dashboard/api"
+          role-to-assume: ${{ secrets.AWS_TOOLS_ACCOUNT_ROLE }}
+          build-command: |
+            docker build \
+              -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+
   publish-ingestion-image-to-deprecated-ecr:
     name: Publish ingestion image to deprecated ECR
     needs: [
@@ -218,6 +233,23 @@ jobs:
           build-command: |
             docker build --platform linux/amd64 -f Dockerfile-ingestion -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           # The current self-hosted CI runners are X64 based. Hence, the need to build with AMD 64
+
+  publish-ingestion-image:
+    name: Publish ingestion image to central ECR
+    needs: [ publish-ingestion-image-to-deprecated-ecr ]
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Build and publish docker image
+        uses: ./.github/actions/publish-image
+        with:
+          ecr-repository: "data-dashboard/ingestion"
+          role-to-assume: ${{ secrets.AWS_TOOLS_ACCOUNT_ROLE }}
+          build-command: |
+            docker build --platform linux/amd64 -f Dockerfile-ingestion -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
 
   ###############################################################################
   # Deploy


### PR DESCRIPTION
# Description

This PR includes the following:

- Renames the original image publish jobs because they are publishing to a deprecated ECR which will soon be removed.
- Dual runs the publishing of the images to a new set of centralised ECRs which are instead located in the tools account 

Fixes #CDD-1774

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
