### PR TITLE
Build ingestion image with graviton ARM 64 base

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -214,8 +214,7 @@ jobs:
           ecr-repository: "wp-ingestion"
           role-to-assume: ${{ secrets.AWS_ROLE }}
           build-command: |
-            docker build --platform linux/amd64 -f Dockerfile-ingestion -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          # The current self-hosted CI runners are X64 based. Hence, the need to build with AMD 64
+            docker build --platform linux/arm64 -f Dockerfile-ingestion -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
 
   ###############################################################################
   # Deploy


### PR DESCRIPTION
# Description

This PR includes the following:

- Switches the ingestion image to be built with ARM 64 arch

Fixes #CDD-1818

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
