### PR TITLE
Refactor `publish-image` composite action to take `dockerfile` input

### DIFF
--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -12,6 +12,9 @@ inputs:
   dockerfile:
     description: 'The selected dockerfile to build the image from.'
     default: Dockerfile
+  architecture:
+    description: 'The architecture to use when building the image.'
+    default: amd64
 
 runs:
   using: 'composite'
@@ -35,6 +38,6 @@ runs:
         ECR_REPOSITORY: ${{ inputs.ecr-repository }}
         IMAGE_TAG: latest
       run: |
-          docker build --platform linux/amd64 -f ${{ inputs.dockerfile }} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build --platform linux/${{ inputs.architecture }} -f ${{ inputs.dockerfile }} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
       shell: bash

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -6,12 +6,12 @@ inputs:
   ecr-repository:
     description: 'The name of the Amazon ECR repository to push the image to.'
     required: true
-  build-command:
-    description: 'The command for building the Docker image.'
-    required: true
   role-to-assume:
     description: 'The role to assume when publishing the image'
     required: true
+  dockerfile:
+    description: 'The selected dockerfile to build the image from.'
+    default: Dockerfile
 
 runs:
   using: 'composite'
@@ -35,6 +35,6 @@ runs:
         ECR_REPOSITORY: ${{ inputs.ecr-repository }}
         IMAGE_TAG: latest
       run: |
-          ${{ inputs.build-command }}
+          docker build --platform linux/amd64 -f ${{ inputs.dockerfile }} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
       shell: bash

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -185,9 +185,6 @@ jobs:
         with:
           ecr-repository: "wp-api"
           role-to-assume: ${{ secrets.AWS_ROLE }}
-          build-command: | 
-            docker build \
-              -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
 
   publish-ingestion-image:
     name: Publish ingestion image
@@ -213,9 +210,7 @@ jobs:
         with:
           ecr-repository: "wp-ingestion"
           role-to-assume: ${{ secrets.AWS_ROLE }}
-          build-command: |
-            docker build --platform linux/amd64 -f Dockerfile-ingestion -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          # The current self-hosted CI runners are X64 based. Hence, the need to build with AMD 64
+          dockerfile: Dockerfile-ingestion
 
   ###############################################################################
   # Deploy


### PR DESCRIPTION
# Description

This PR includes the following:

- Refactors the `publish-image` composite action so that it has near-full control over the build command, we just provide an input of:
  - which dockerfile to build
  - which repo to push to
  - the role to use

Fixes #CDD-1774

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
