### PR TITLE
Add `repository` to `client_payload` posted to trigger deployments so that the workflow knows the name of the caller repo

### DIFF
--- a/.github/actions/trigger-deployments/action.yml
+++ b/.github/actions/trigger-deployments/action.yml
@@ -16,5 +16,5 @@ runs:
           -H "Accept: application/vnd.github+json" \
           -H "Authorization: Bearer ${{ inputs.token }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          -d '{"event_type":"trigger-deployments","client_payload":{"unit":false,"integration":true}}'
+          -d '{"event_type":"trigger-deployments","client_payload":{"unit":false,"integration":true, "repository":"UKHSA-data-dashboard/api"}}'
       shell: bash


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds the name of the caller repository to the payload posted to the github API when triggering deployments

Fixes #CDD-1856

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
