### PR TITLE
Chore/enforce key word arguments in cms module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # This is the venv location. Typically this is set as either `.venv` or `venv`.
 # Here it is set as `venv`
-VENV=venv
+VENV=.venv
 
 # Grab the current python version associated with the project (3.12)
 # Note this is currently also used in the CI

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # This is the venv location. Typically this is set as either `.venv` or `venv`.
 # Here it is set as `venv`
-VENV=.venv
+VENV=venv
 
 # Grab the current python version associated with the project (3.12)
 # Note this is currently also used in the CI

--- a/cms/dashboard/management/commands/build_cms_site.py
+++ b/cms/dashboard/management/commands/build_cms_site.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 FILE_PATH = f"{ROOT_LEVEL_BASE_DIR}/cms/dashboard/templates/cms_starting_pages/"
 
 
-def make_slug(page_title: str) -> str:
+def make_slug(*, page_title: str) -> str:
     """
     Make a CMS Slug from the page title
 
@@ -42,13 +42,13 @@ def make_slug(page_title: str) -> str:
     return page_title.lower().replace("'", "").replace(" ", "-")
 
 
-def open_example_page_response(page_name: str):
+def open_example_page_response(*, page_name: str):
     path = f"{FILE_PATH}{page_name}.json"
     with open(path, "rb") as f:
         return json.load(f)
 
 
-def _create_related_links(related_link_class, response_data, page) -> None:
+def _create_related_links(*, related_link_class, response_data, page) -> None:
     for related_link_response_data in response_data["related_links"]:
         related_link_model = related_link_class(
             page=page,
@@ -59,12 +59,12 @@ def _create_related_links(related_link_class, response_data, page) -> None:
         related_link_model.save()
 
 
-def _add_page_to_parent(page: Page, parent_page: HomePage) -> None:
+def _add_page_to_parent(*, page: Page, parent_page: HomePage) -> None:
     page = parent_page.add_child(instance=page)
     page.save_revision().publish()
 
 
-def _create_landing_dashboard_page(parent_page: Page) -> HomePage:
+def _create_landing_dashboard_page(*, parent_page: Page) -> HomePage:
     data = open_example_page_response(page_name="ukhsa_data_dashboard")
 
     page = HomePage(
@@ -87,7 +87,7 @@ def _create_landing_dashboard_page(parent_page: Page) -> HomePage:
     return page
 
 
-def _create_topic_page(name: str, parent_page: Page) -> TopicPage:
+def _create_topic_page(*, name: str, parent_page: Page) -> TopicPage:
     data = open_example_page_response(page_name=name)
 
     page = TopicPage(
@@ -111,7 +111,7 @@ def _create_topic_page(name: str, parent_page: Page) -> TopicPage:
     return page
 
 
-def _create_common_page(name: str, parent_page: Page) -> CommonPage:
+def _create_common_page(*, name: str, parent_page: Page) -> CommonPage:
     data = open_example_page_response(page_name=name)
 
     page = CommonPage(
@@ -134,7 +134,7 @@ def _create_common_page(name: str, parent_page: Page) -> CommonPage:
     return page
 
 
-def _remove_comment_from_body(body: dict[list[dict]]) -> dict[list[dict]]:
+def _remove_comment_from_body(*, body: dict[list[dict]]) -> list[dict]:
     return [item for item in body if "_comment" not in item]
 
 
@@ -143,7 +143,9 @@ def _get_or_create_button_id() -> int:
     return button_snippet.id
 
 
-def _add_download_button_to_composite_body(body: dict[list[dict]]) -> dict[list[dict]]:
+def _add_download_button_to_composite_body(
+    *, body: dict[list[dict]]
+) -> dict[list[dict]]:
     body.append(
         {
             "type": "button",
@@ -154,7 +156,7 @@ def _add_download_button_to_composite_body(body: dict[list[dict]]) -> dict[list[
     return body
 
 
-def _create_bulk_downloads_page(name: str, parent_page: Page) -> CompositePage:
+def _create_bulk_downloads_page(*, name: str, parent_page: Page) -> CompositePage:
     data = open_example_page_response(page_name=name)
 
     body = _remove_comment_from_body(body=data["body"])
@@ -181,7 +183,7 @@ def _create_bulk_downloads_page(name: str, parent_page: Page) -> CompositePage:
     return page
 
 
-def _create_composite_page(name: str, parent_page: Page) -> CompositePage:
+def _create_composite_page(*, name: str, parent_page: Page) -> CompositePage:
     data = open_example_page_response(page_name=name)
 
     page = CompositePage(
@@ -205,7 +207,9 @@ def _create_composite_page(name: str, parent_page: Page) -> CompositePage:
     return page
 
 
-def _create_whats_new_parent_page(name: str, parent_page: Page) -> WhatsNewParentPage:
+def _create_whats_new_parent_page(
+    *, name: str, parent_page: Page
+) -> WhatsNewParentPage:
     data = open_example_page_response(page_name=name)
 
     page = WhatsNewParentPage(
@@ -228,7 +232,9 @@ def _create_whats_new_parent_page(name: str, parent_page: Page) -> WhatsNewParen
     return page
 
 
-def _create_whats_new_child_entry(name: str, parent_page: Page) -> WhatsNewChildEntry:
+def _create_whats_new_child_entry(
+    *, name: str, parent_page: Page
+) -> WhatsNewChildEntry:
     data = open_example_page_response(page_name=name)
 
     badge = Badge(text=data["badge"]["text"], colour=data["badge"]["colour"])

--- a/cms/dynamic_content/blocks_deconstruction.py
+++ b/cms/dynamic_content/blocks_deconstruction.py
@@ -24,7 +24,7 @@ class CMSBlockParser:
 
     @classmethod
     def get_all_chart_blocks_from_section_for_geography(
-        cls, section: CMS_COMPONENT_BLOCK_TYPE, geography_data
+        cls, *, section: CMS_COMPONENT_BLOCK_TYPE, geography_data
     ) -> list[CMS_COMPONENT_BLOCK_TYPE]:
         """Extracts a list of all chart cards from the given `section` for the specific `geography_data`
 
@@ -55,7 +55,7 @@ class CMSBlockParser:
 
     @classmethod
     def get_chart_blocks_from_chart_row_cards(
-        cls, chart_row_cards: list[CMS_COMPONENT_BLOCK_TYPE]
+        cls, *, chart_row_cards: list[CMS_COMPONENT_BLOCK_TYPE]
     ) -> list[CMS_COMPONENT_BLOCK_TYPE]:
         """Extracts all chart blocks from the given list of `chart_row_cards`
 
@@ -79,7 +79,7 @@ class CMSBlockParser:
 
     @classmethod
     def get_all_chart_blocks_from_section(
-        cls, section: CMS_COMPONENT_BLOCK_TYPE
+        cls, *, section: CMS_COMPONENT_BLOCK_TYPE
     ) -> list[CMS_COMPONENT_BLOCK_TYPE]:
         """Extracts a list of all chart cards from the given `section`
 
@@ -97,7 +97,7 @@ class CMSBlockParser:
 
     @classmethod
     def rebuild_chart_block_for_geography(
-        cls, chart_block: CMS_COMPONENT_BLOCK_TYPE, geography_data: "GeographyData"
+        cls, *, chart_block: CMS_COMPONENT_BLOCK_TYPE, geography_data: "GeographyData"
     ) -> CMS_COMPONENT_BLOCK_TYPE:
         """Builds a copy of the given `chart_block` with the `geography_data` applied
 
@@ -128,7 +128,7 @@ class CMSBlockParser:
 
     @classmethod
     def get_all_headline_blocks_from_section(
-        cls, section: CMS_COMPONENT_BLOCK_TYPE
+        cls, *, section: CMS_COMPONENT_BLOCK_TYPE
     ) -> list[CMS_COMPONENT_BLOCK_TYPE]:
         """Extracts a list of all headline number blocks from the given `section`
 
@@ -165,6 +165,7 @@ class CMSBlockParser:
     @classmethod
     def get_content_cards_from_section(
         cls,
+        *,
         section: dict[list[CMS_COMPONENT_BLOCK_TYPE]],
     ) -> list[CMS_COMPONENT_BLOCK_TYPE]:
         """Filters for a list of content cards from the given `section`
@@ -181,6 +182,7 @@ class CMSBlockParser:
     @classmethod
     def get_chart_row_cards_from_content_cards(
         cls,
+        *,
         content_cards: list[CMS_COMPONENT_BLOCK_TYPE],
     ) -> list[CMS_COMPONENT_BLOCK_TYPE]:
         """Filters for a list of chart row from the given `content_cards`
@@ -202,6 +204,7 @@ class CMSBlockParser:
     @classmethod
     def get_chart_row_cards_from_page_section(
         cls,
+        *,
         section: dict[list[CMS_COMPONENT_BLOCK_TYPE]],
     ) -> list[CMS_COMPONENT_BLOCK_TYPE]:
         """Get chart row cards from page section.
@@ -217,7 +220,7 @@ class CMSBlockParser:
 
     @classmethod
     def get_headline_blocks_from_chart_blocks(
-        cls, chart_blocks: list[CMS_COMPONENT_BLOCK_TYPE]
+        cls, *, chart_blocks: list[CMS_COMPONENT_BLOCK_TYPE]
     ) -> list[CMS_COMPONENT_BLOCK_TYPE]:
         """Extracts all headline number blocks from the given list of `chart_blocks`
 
@@ -241,6 +244,7 @@ class CMSBlockParser:
     @classmethod
     def get_headline_numbers_row_cards_from_content_cards(
         cls,
+        *,
         content_cards: list[CMS_COMPONENT_BLOCK_TYPE],
     ) -> list[CMS_COMPONENT_BLOCK_TYPE]:
         """Filters for a list of headliner number row cards from the given `content_cards`
@@ -263,6 +267,7 @@ class CMSBlockParser:
     @classmethod
     def get_headline_blocks_from_headline_number_row_cards(
         cls,
+        *,
         headline_numbers_row_cards: list[CMS_COMPONENT_BLOCK_TYPE],
     ) -> list[CMS_COMPONENT_BLOCK_TYPE]:
         """Extracts all headline number blocks from the given list of `headline_numbers_row_cards`
@@ -288,7 +293,7 @@ class CMSBlockParser:
     # Extraction of selected topics
 
     @classmethod
-    def get_all_selected_topics_from_sections(cls, sections) -> set[str]:
+    def get_all_selected_topics_from_sections(cls, *, sections) -> set[str]:
         """Extracts a set of topics from all headline & chart blocks in the given `sections`
 
         Args:
@@ -317,7 +322,7 @@ class CMSBlockParser:
 
     @classmethod
     def _get_all_selected_topics_in_chart_blocks_from_sections(
-        cls, sections: list[dict[list[CMS_COMPONENT_BLOCK_TYPE]]]
+        cls, *, sections: list[dict[list[CMS_COMPONENT_BLOCK_TYPE]]]
     ) -> set[str]:
         """Extracts a set of topics from all chart blocks in the given `sections`
 
@@ -339,7 +344,7 @@ class CMSBlockParser:
 
     @classmethod
     def _get_all_selected_topics_in_headline_blocks_from_sections(
-        cls, sections: list[dict[list[CMS_COMPONENT_BLOCK_TYPE]]]
+        cls, *, sections: list[dict[list[CMS_COMPONENT_BLOCK_TYPE]]]
     ) -> set[str]:
         """Extracts a set of topics from all headline blocks in the given `sections`
 
@@ -363,7 +368,7 @@ class CMSBlockParser:
 
     @classmethod
     def get_all_selected_topics_from_chart_blocks(
-        cls, chart_blocks: list[CMS_COMPONENT_BLOCK_TYPE]
+        cls, *, chart_blocks: list[CMS_COMPONENT_BLOCK_TYPE]
     ) -> set[str]:
         """Extracts a set of topics from the given `chart_blocks`
 
@@ -384,7 +389,7 @@ class CMSBlockParser:
 
     @classmethod
     def get_all_selected_topics_from_headline_blocks(
-        cls, headline_blocks: list[CMS_COMPONENT_BLOCK_TYPE]
+        cls, *, headline_blocks: list[CMS_COMPONENT_BLOCK_TYPE]
     ) -> set[str]:
         """Extracts a set of topics from the given `headline_blocks`
 

--- a/cms/metrics_documentation/data_migration/child_entries.py
+++ b/cms/metrics_documentation/data_migration/child_entries.py
@@ -5,7 +5,7 @@ from openpyxl import load_workbook
 from openpyxl.worksheet.worksheet import Worksheet
 
 
-def build_sections(sections: list[tuple[str, str]]) -> list[dict]:
+def build_sections(*, sections: list[tuple[str, str]]) -> list[dict]:
     """Build metric documentation page sections.
 
     Args:
@@ -27,7 +27,7 @@ def build_sections(sections: list[tuple[str, str]]) -> list[dict]:
     ]
 
 
-def build_entry_from_row_data(row: tuple[str, ...]) -> dict[str, str | list[dict]]:
+def build_entry_from_row_data(*, row: tuple[str, ...]) -> dict[str, str | list[dict]]:
     """Build a metrics documentation page entry.
 
     Args:
@@ -51,7 +51,9 @@ def build_entry_from_row_data(row: tuple[str, ...]) -> dict[str, str | list[dict
     }
 
 
-def gather_sections_and_omit_if_needed(row: tuple[str, ...]) -> list[tuple[str, str]]:
+def gather_sections_and_omit_if_needed(
+    *, row: tuple[str, ...]
+) -> list[tuple[str, str]]:
     """Builds a list of sections which can be parsed by the `build_sections()` function
 
     Notes:

--- a/cms/metrics_documentation/data_migration/operations.py
+++ b/cms/metrics_documentation/data_migration/operations.py
@@ -38,7 +38,7 @@ def load_metric_documentation_parent_page() -> dict:
         return json.load(file)
 
 
-def add_page_as_subpage_to_parent(subpage: Page, parent_page: HomePage) -> None:
+def add_page_as_subpage_to_parent(*, subpage: Page, parent_page: HomePage) -> None:
     """Adds the given `subpage` as a child to the `parent_page`
 
     Args:
@@ -54,6 +54,7 @@ def add_page_as_subpage_to_parent(subpage: Page, parent_page: HomePage) -> None:
 
 
 def get_or_create_metrics_documentation_parent_page(
+    *,
     metrics_documentation_parent_page_manager: Manager = DEFAULT_METRICS_DOCUMENTATION_PARENT_PAGE_MANAGER,
 ) -> MetricsDocumentationParentPage:
     """Creates parent page for data migration if one doesn't exist.

--- a/cms/metrics_documentation/models/child.py
+++ b/cms/metrics_documentation/models/child.py
@@ -86,7 +86,7 @@ class MetricsDocumentationChildEntry(Page):
         super().__init__(*args, **kwargs)
         self._meta.get_field("metric").choices = get_all_unique_metric_names()
 
-    def find_topic(self, topics: list[str]) -> str:
+    def find_topic(self, *, topics: list[str]) -> str:
         """Finds the required topic from a list of strings based on the metric name.
 
         Args:
@@ -119,7 +119,7 @@ class MetricsDocumentationChildEntry(Page):
             a topic name as a string
         """
         topics = get_a_list_of_all_topic_names()
-        return self.find_topic(topics)
+        return self.find_topic(topics=topics)
 
     def save(self, *args, **kwargs):
         """Retrieves a topic based on the selected metric

--- a/cms/metrics_interface/field_choices_callables.py
+++ b/cms/metrics_interface/field_choices_callables.py
@@ -15,7 +15,9 @@ from cms.metrics_interface import MetricsAPIInterface
 LIST_OF_TWO_STRING_ITEM_TUPLES = list[tuple[str, str]]
 
 
-def _build_two_item_tuple_choices(choices: list[str]) -> LIST_OF_TWO_STRING_ITEM_TUPLES:
+def _build_two_item_tuple_choices(
+    *, choices: list[str]
+) -> LIST_OF_TWO_STRING_ITEM_TUPLES:
     return [(choice, choice) for choice in choices]
 
 
@@ -58,7 +60,7 @@ def get_all_unique_metric_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
     """
     metrics_interface = MetricsAPIInterface()
     return _build_two_item_tuple_choices(
-        metrics_interface.get_all_unique_metric_names()
+        choices=metrics_interface.get_all_unique_metric_names()
     )
 
 
@@ -140,7 +142,9 @@ def get_all_topic_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
 
     """
     metrics_interface = MetricsAPIInterface()
-    return _build_two_item_tuple_choices(metrics_interface.get_all_topic_names())
+    return _build_two_item_tuple_choices(
+        choices=metrics_interface.get_all_topic_names()
+    )
 
 
 def get_a_list_of_all_topic_names():
@@ -180,7 +184,7 @@ def get_all_unique_change_type_metric_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
     """
     metrics_interface = MetricsAPIInterface()
     return _build_two_item_tuple_choices(
-        metrics_interface.get_all_unique_change_type_metric_names()
+        choices=metrics_interface.get_all_unique_change_type_metric_names()
     )
 
 
@@ -206,7 +210,7 @@ def get_all_unique_percent_change_type_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES
     """
     metrics_interface = MetricsAPIInterface()
     return _build_two_item_tuple_choices(
-        metrics_interface.get_all_unique_percent_change_type_names()
+        choices=metrics_interface.get_all_unique_percent_change_type_names()
     )
 
 
@@ -228,7 +232,9 @@ def get_all_stratum_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
 
     """
     metrics_interface = MetricsAPIInterface()
-    return _build_two_item_tuple_choices(metrics_interface.get_all_stratum_names())
+    return _build_two_item_tuple_choices(
+        choices=metrics_interface.get_all_stratum_names()
+    )
 
 
 def get_all_geography_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
@@ -249,7 +255,9 @@ def get_all_geography_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
 
     """
     metrics_interface = MetricsAPIInterface()
-    return _build_two_item_tuple_choices(metrics_interface.get_all_geography_names())
+    return _build_two_item_tuple_choices(
+        choices=metrics_interface.get_all_geography_names()
+    )
 
 
 def get_all_geography_type_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
@@ -271,7 +279,7 @@ def get_all_geography_type_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
     """
     metrics_interface = MetricsAPIInterface()
     return _build_two_item_tuple_choices(
-        metrics_interface.get_all_geography_type_names()
+        choices=metrics_interface.get_all_geography_type_names()
     )
 
 
@@ -293,7 +301,7 @@ def get_all_sex_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
 
     """
     names = ["all", "f", "m"]
-    return _build_two_item_tuple_choices(names)
+    return _build_two_item_tuple_choices(choices=names)
 
 
 def get_all_age_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
@@ -314,4 +322,4 @@ def get_all_age_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
 
     """
     metrics_interface = MetricsAPIInterface()
-    return _build_two_item_tuple_choices(metrics_interface.get_all_age_names())
+    return _build_two_item_tuple_choices(choices=metrics_interface.get_all_age_names())

--- a/cms/metrics_interface/interface.py
+++ b/cms/metrics_interface/interface.py
@@ -49,6 +49,7 @@ class MetricsAPIInterface:
 
     def __init__(
         self,
+        *,
         topic_manager: Manager = DEFAULT_TOPIC_MANAGER,
         metric_manager: Manager = DEFAULT_METRIC_MANAGER,
         stratum_manager: Manager = DEFAULT_STRATUM_MANAGER,

--- a/tests/integration/cms/dashboard/management/commands/test_build_cms_site.py
+++ b/tests/integration/cms/dashboard/management/commands/test_build_cms_site.py
@@ -79,7 +79,9 @@ class TestBuildCMSSite:
         response_data = response.data
 
         # Compare the response from the endpoint to the template used to build the page
-        home_page_response_template = open_example_page_response("ukhsa_data_dashboard")
+        home_page_response_template = open_example_page_response(
+            page_name="ukhsa_data_dashboard"
+        )
         assert response_data["title"] == home_page_response_template["title"]
         assert (
             response_data["page_description"]
@@ -133,7 +135,7 @@ class TestBuildCMSSite:
 
         # Compare the response from the endpoint to the template used to build the page
         page_name = slug.replace("-", "_")
-        topic_page_response_template = open_example_page_response(page_name)
+        topic_page_response_template = open_example_page_response(page_name=page_name)
         assert response_data["title"] == topic_page_response_template["title"]
         assert (
             response_data["page_description"]
@@ -185,7 +187,7 @@ class TestBuildCMSSite:
         response_data = response.data
 
         # Compare the response from the endpoint to the template used to build the page
-        about_page_template = open_example_page_response("about")
+        about_page_template = open_example_page_response(page_name="about")
         assert response_data["title"] == about_page_template["title"]
         assert response_data["body"] == about_page_template["body"]
         assert (
@@ -233,7 +235,7 @@ class TestBuildCMSSite:
         response_data = response.data
 
         # Compare the response from the endpoint to the template used to build the page
-        whats_new_page_template = open_example_page_response("whats_new")
+        whats_new_page_template = open_example_page_response(page_name="whats_new")
         assert response_data["title"] == whats_new_page_template["title"]
         assert response_data["body"] == whats_new_page_template["body"]
         assert (
@@ -277,7 +279,7 @@ class TestBuildCMSSite:
         # When
         response = api_client.get(path=f"/api/pages/{bulk_downloads.id}/")
         response_button_snippet = response.data["body"][1]["value"]
-        bulk_downloads_template = open_example_page_response("bulk_downloads")
+        bulk_downloads_template = open_example_page_response(page_name="bulk_downloads")
         button_snippet = Button.objects.get(text="download (zip)")
 
         # Then

--- a/tests/unit/cms/metrics_documentation/data_migration/test_child_entries.py
+++ b/tests/unit/cms/metrics_documentation/data_migration/test_child_entries.py
@@ -109,7 +109,7 @@ class TestBuildEntryFromRowData:
         }
 
         # When
-        response = build_entry_from_row_data(fake_row)
+        response = build_entry_from_row_data(row=fake_row)
 
         # Then
         assert response == expected_response

--- a/tests/unit/cms/metrics_documentation/models/test_child.py
+++ b/tests/unit/cms/metrics_documentation/models/test_child.py
@@ -199,7 +199,7 @@ class TestMetricsDocumentationChildEntry:
 
         # When
         return_topic = fake_metrics_documentation_child_entry_page.find_topic(
-            fake_topics
+            topics=fake_topics
         )
 
         # Then
@@ -235,4 +235,4 @@ class TestMetricsDocumentationChildEntry:
 
         # When / Then
         with pytest.raises(InvalidTopicForChosenMetricForChildEntryError):
-            fake_metrics_documentation_child_entry_page.find_topic(fake_topics)
+            fake_metrics_documentation_child_entry_page.find_topic(topics=fake_topics)


### PR DESCRIPTION
# Description

This PR includes the following:

- Enforces the use of key word arguments throughout the `cms/` module


---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
