### PR TITLE
Update CLI modules with granular naming convention to avoid name clashes between modules

### DIFF
--- a/scripts/_bootstrap.sh
+++ b/scripts/_bootstrap.sh
@@ -22,22 +22,22 @@ function _bootstrap() {
     local args=(${@:2})
 
     case $verb in
-        "all") _all $args ;;
-        "admin-user") _admin_user $args ;;
-        "test-content") _test_content $args ;;
-        "test-data") _test_data $args ;;
+        "all") _bootstrap_all $args ;;
+        "admin-user") __bootstrap_admin_user $args ;;
+        "test-content") _bootstrap_test_content $args ;;
+        "test-data") _bootstrap_test_data $args ;;
 
         *) _bootstrap_help ;;
     esac
 }
 
-function _all() {
+function _bootstrap_all() {
     uhd bootstrap admin-user $1
     uhd bootstrap test-content
     uhd bootstrap test-data
 }
 
-function _admin_user() {
+function __bootstrap_admin_user() {
     local admin_password=$1
     if [[ -z ${admin_password} ]]; then
         echo "Password for admin user is required" >&2
@@ -49,13 +49,13 @@ function _admin_user() {
     python manage.py shell -c "from django.contrib.auth.models import User; User.objects.create_superuser('testadmin', '', '$admin_password')"
 }
 
-function _test_content() {
+function _bootstrap_test_content() {
     echo "Creating CMS content"
     uhd venv activate
     python manage.py build_cms_site
 }
 
-function _test_data() {
+function _bootstrap_test_data() {
     echo "Uploading truncated test data"
     uhd venv activate
     python manage.py upload_truncated_test_data

--- a/scripts/_bootstrap.sh
+++ b/scripts/_bootstrap.sh
@@ -23,7 +23,7 @@ function _bootstrap() {
 
     case $verb in
         "all") _bootstrap_all $args ;;
-        "admin-user") __bootstrap_admin_user $args ;;
+        "admin-user") _bootstrap_admin_user $args ;;
         "test-content") _bootstrap_test_content $args ;;
         "test-data") _bootstrap_test_data $args ;;
 
@@ -37,7 +37,7 @@ function _bootstrap_all() {
     uhd bootstrap test-data
 }
 
-function __bootstrap_admin_user() {
+function _bootstrap_admin_user() {
     local admin_password=$1
     if [[ -z ${admin_password} ]]; then
         echo "Password for admin user is required" >&2

--- a/scripts/_cache.sh
+++ b/scripts/_cache.sh
@@ -17,13 +17,13 @@ function _cache() {
     local args=(${@:2})
 
     case $verb in
-        "flush-redis") _flush_redis $args ;;
+        "flush-redis") _cache_flush_redis $args ;;
 
         *) _cache_help ;;
     esac
 }
 
-function _flush_redis() {
+function _cache_flush_redis() {
     uhd venv activate
     python manage.py hydrate_private_api_cache
 }

--- a/scripts/_django.sh
+++ b/scripts/_django.sh
@@ -20,25 +20,25 @@ function _django() {
     local args=(${@:2})
 
     case $verb in
-        "makemigrations") _make_migrations $args ;;
-        "migrate") _migrate $args ;;
-        "shell") _shell $args ;;
+        "makemigrations") _django_make_migrations $args ;;
+        "migrate") _django_migrate $args ;;
+        "shell") _django_shell $args ;;
 
         *) _django_help ;;
     esac
 }
 
-function _make_migrations() {
+function _django_make_migrations() {
     uhd venv activate
     python manage.py makemigrations
 }
 
-function _migrate() {
+function _django_migrate() {
     uhd venv activate
     python manage.py migrate
 }
 
-function _shell() {
+function _django_shell() {
     uhd venv activate
     python manage.py shell
 }

--- a/scripts/_quality.sh
+++ b/scripts/_quality.sh
@@ -21,20 +21,20 @@ function _quality() {
     local args=(${@:2})
 
     case $verb in
-        "architecture") _architecture $args ;;
-        "format") _format $args ;;
-        "format-check") _format_check $args ;;
+        "architecture") _quality_architecture $args ;;
+        "format") _quality_format $args ;;
+        "format-check") _quality_format_check $args ;;
 
         *) _quality_help ;;
     esac
 }
 
-function _architecture() {
+function _quality_architecture() {
     uhd venv activate
     lint-imports
 }
 
-function _format() {
+function _quality_format() {
     uhd venv activate
     _ruff_formatter
     _black_formatter
@@ -50,7 +50,7 @@ function _black_formatter() {
   black .
 }
 
-function _format_check() {
+function _quality_format_check() {
     uhd quality format
     changed_files=$(git diff --name-only | grep "\.py" || true)
 

--- a/scripts/_security.sh
+++ b/scripts/_security.sh
@@ -18,19 +18,19 @@ function _security() {
     local args=(${@:2})
 
     case $verb in
-        "dependencies") _dependencies $args ;;
-        "vulnerabilities") _vulnerabilities $args ;;
+        "dependencies") _security_dependencies $args ;;
+        "vulnerabilities") _security_vulnerabilities $args ;;
 
         *) _security_help ;;
     esac
 }
 
-function _dependencies() {
+function _security_dependencies() {
     uhd venv activate
     pip-audit -r requirements.txt
 }
 
-function _vulnerabilities() {
+function _security_vulnerabilities() {
     uhd venv activate
     bandit -c pyproject.toml -r .
 }

--- a/scripts/_server.sh
+++ b/scripts/_server.sh
@@ -21,23 +21,23 @@ function _server() {
     local args=(${@:2})
 
     case $verb in
-        "run-local") _run_local_server  $args ;;
-        "run-production") _run_production_server  $args ;;
-        "setup-all") _setup_all  $args ;;
-        "setup-static-files") _setup_static_files  $args ;;
+        "run-local") _server_run_local  $args ;;
+        "run-production") _server_run_production  $args ;;
+        "setup-all") _server_setup_all  $args ;;
+        "setup-static-files") _server_setup_static_files  $args ;;
 
         *) _server_help ;;
     esac
 }
 
-function _run_local_server() {
+function _server_run_local() {
     local port=$1
 
     uhd venv activate
     python manage.py runserver localhost:${port:-8000}
 }
 
-function _run_production_server() {
+function _server_run_production() {
     local port=$1
 
     uhd venv activate
@@ -49,12 +49,12 @@ function _run_production_server() {
       --bind=0.0.0.0:${port:-80}
 }
 
-function _setup_all() {
+function _server_setup_all() {
     uhd django migrate
     _setup_static_files
 }
 
-function _setup_static_files() {
+function _server_setup_static_files() {
     uhd venv activate
 
     echo "Collecting static files"

--- a/scripts/_tests.sh
+++ b/scripts/_tests.sh
@@ -23,43 +23,43 @@ function _tests() {
     local args=(${@:2})
 
     case $verb in
-        "unit") _unit $args ;;
-        "integration") _integration $args ;;
-        "system") _system $args ;;
-        "migrations") _migrations $args ;;
-        "coverage") _coverage $args ;;
-        "all") _all $args ;;
+        "unit") _tests_unit $args ;;
+        "integration") _tests_integration $args ;;
+        "system") _tests_system $args ;;
+        "migrations") _tests_migrations $args ;;
+        "coverage") _tests_coverage $args ;;
+        "all") _tests_all $args ;;
 
         *) _tests_help ;;
     esac
 }
 
-function _unit() {
+function _tests_unit() {
     uhd venv activate
     pytest tests/unit
 }
 
-function _integration() {
+function _tests_integration() {
     uhd venv activate
     python -m pytest tests/integration
 }
 
-function _system() {
+function _tests_system() {
     uhd venv activate
     pytest tests/system
 }
 
-function _migrations() {
+function _tests_migrations() {
     uhd venv activate
     pytest tests/migrations
 }
 
-function _coverage() {
+function _tests_coverage() {
     uhd venv activate
     pytest --cov
 }
 
-function _all() {
+function _tests_all() {
     _unit
     _integration
     _system

--- a/scripts/_tests.sh
+++ b/scripts/_tests.sh
@@ -60,8 +60,8 @@ function _tests_coverage() {
 }
 
 function _tests_all() {
-    _unit
-    _integration
-    _system
-    _migrations
+    uhd tests unit
+    uhd tests integration
+    uhd tests system
+    uhd tests migrations
 }

--- a/scripts/_venv.sh
+++ b/scripts/_venv.sh
@@ -22,15 +22,15 @@ function _venv() {
     local args=(${@:2})
 
     case $verb in
-        "activate") _activate $args ;;
-        "create") _create $args ;;
-        "deactivate") _deactivate $args ;;
+        "activate") _venv_activate $args ;;
+        "create") _venv_create $args ;;
+        "deactivate") _venv_deactivate $args ;;
 
         *) _venv_help ;;
     esac
 }
 
-function _activate() {
+function _venv_activate() {
     local no_venv_found_message="
     There is no venv available.
     If this is for local development,
@@ -40,11 +40,11 @@ function _activate() {
     source .venv/bin/activate || echo ${no_venv_found_message}
 }
 
-function _deactivate() {
+function _venv_deactivate() {
     deactivate
 }
 
-function _create() {
+function _venv_create() {
     local python_version=`cat .python-version`
     python${python_version} -m venv --upgrade-deps .venv
     _activate

--- a/scripts/boot.sh
+++ b/scripts/boot.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
-#set -x
 
 function run_script() {
     echo "Running bootstrap script to populate application"
-    echo "Argument received: $1"
+    local admin_password=$1
 
     source uhd.sh
     uhd django migrate
-    uhd bootstrap all "$1" 2>&1
+    uhd bootstrap admin-user $admin_password
+    uhd bootstrap test-data
+    uhd bootstrap test-content
 
     echo "Completed running bootstrap script"
 }

--- a/scripts/boot.sh
+++ b/scripts/boot.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
+#set -x
 
 function run_script() {
     echo "Running bootstrap script to populate application"
-    local admin_password=$1
+    echo "Argument received: $1"
 
     source uhd.sh
     uhd django migrate
-    uhd bootstrap admin-user $admin_password
-    uhd bootstrap test-data
-    uhd bootstrap test-content
+    uhd bootstrap all "$1" 2>&1
 
     echo "Completed running bootstrap script"
 }

--- a/uhd.sh
+++ b/uhd.sh
@@ -49,7 +49,7 @@ function uhd() {
     cd $root
 
     case $command in
-        "bootstrap") _bootstrap $args ;;
+        "bootstrap") _bootstrap "${args[@]}" ;;
         "cache") _cache $args ;;
         "django") _django $args ;;
         "security") _security $args ;;

--- a/uhd.sh
+++ b/uhd.sh
@@ -38,10 +38,6 @@ function _uhd_commands_help() {
 }
 
 function uhd() {
-    if [ $CI ]; then
-        echo $0 $@
-    fi
-
     local current=$(pwd)
     local command=$1
     local args=(${@:2}) 


### PR DESCRIPTION
# Description

This PR includes the following:

- Updates the CLI modules so that they don't clash between namespaces i.e. `_all` was shared between the bootsrap all command and the tests all command
- Rejigs how the args are given to the `uhd bootstrap admin-user` command so that we can still provide args to the wrapper script `boot.sh` either via `source scripts/boot.sh abc` or `./scripts/boot.sh abc`. Note that the ECS job uses the latter which mean the arg was not being passed in correctly since we switched to implementing the CLI across the board

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
