### PR TITLE
Bug/bootstrap command should populate data before content

### DIFF
--- a/scripts/_bootstrap.sh
+++ b/scripts/_bootstrap.sh
@@ -33,8 +33,8 @@ function _bootstrap() {
 
 function _bootstrap_all() {
     uhd bootstrap admin-user $1
-    uhd bootstrap test-content
     uhd bootstrap test-data
+    uhd bootstrap test-content
 }
 
 function _bootstrap_admin_user() {

--- a/scripts/_bootstrap.sh
+++ b/scripts/_bootstrap.sh
@@ -32,6 +32,7 @@ function _bootstrap() {
 }
 
 function _bootstrap_all() {
+    uhd django migrate
     uhd bootstrap admin-user $1
     uhd bootstrap test-data
     uhd bootstrap test-content

--- a/scripts/boot.sh
+++ b/scripts/boot.sh
@@ -5,10 +5,7 @@ function run_script() {
     local admin_password=$1
 
     source uhd.sh
-    uhd django migrate
-    uhd bootstrap admin-user $admin_password
-    uhd bootstrap test-data
-    uhd bootstrap test-content
+    uhd bootstrap all $admin_password
 
     echo "Completed running bootstrap script"
 }


### PR DESCRIPTION
# Description

This PR includes the following:

- Migrates tables at the start of the `uhd bootstrap all` command so that it can be on its own as a 1-size fits all starting command.
- Populates test data before content as some content depends on data being present

---

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
