### PR TITLE
Remove build for publishing AMD64 image

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -188,31 +188,6 @@ jobs:
       - name: Build and publish docker image
         uses: ./.github/actions/publish-image
         with:
-          ecr-repository: "data-dashboard/api"
-          role-to-assume: ${{ secrets.AWS_TOOLS_ACCOUNT_ROLE }}
-          architecture: amd64
-          image-tag: latest
-
-  publish-main-image-graviton:
-    name: Publish ARM64 main image to central ECR
-    needs: [
-      quality-checks,
-      unit-tests,
-      integration-tests,
-      system-tests,
-      migration-tests,
-      test-coverage,
-      vulnerabilities,
-      architecture-checks
-    ]
-    runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Build and publish docker image
-        uses: ./.github/actions/publish-image
-        with:
           ecr-repository: data-dashboard/api
           role-to-assume: ${{ secrets.AWS_TOOLS_ACCOUNT_ROLE }}
           architecture: arm64


### PR DESCRIPTION
# Description

This PR includes the following:

- Removes the build which publishes AMD 64 images. So now we only publish ARM 64 images

Fixes #CDD-1817

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
