### PR TITLE
Validate UTLA and LTLA with same set of prefixes against `geography_code` field

### DIFF
--- a/ingestion/data_transfer_models/validation/geography_code.py
+++ b/ingestion/data_transfer_models/validation/geography_code.py
@@ -1,9 +1,8 @@
 from ingestion.utils import enums
 
 NATION_GEOGRAPHY_CODE_PREFIX = "E92"
-LOWER_TIER_LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIXES = ("E06", "E07", "E08", "E09")
+LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIXES = ("E06", "E07", "E08", "E09", "E10")
 NHS_REGION_GEOGRAPHY_CODE_PREFIX = "E40"
-UPPER_TIER_LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIX = "E10"
 UKHSA_REGION_GEOGRAPHY_CODE_PREFIX = "E45"
 GOVERNMENT_OFFICE_REGION_GEOGRAPHY_CODE_PREFIX = "E12"
 
@@ -28,7 +27,11 @@ def validate_geography_code(*, geography_code: str, geography_type: str) -> str 
         case enums.GeographyType.NATION.value:
             return _validate_nation_geography_code(geography_code=geography_code)
         case enums.GeographyType.UPPER_TIER_LOCAL_AUTHORITY.value:
-            return _validate_upper_tier_local_authority_geography_code(
+            return _validate_local_authority_geography_code(
+                geography_code=geography_code
+            )
+        case enums.GeographyType.LOWER_TIER_LOCAL_AUTHORITY.value:
+            return _validate_local_authority_geography_code(
                 geography_code=geography_code
             )
         case enums.GeographyType.UKHSA_REGION.value:
@@ -37,10 +40,6 @@ def validate_geography_code(*, geography_code: str, geography_type: str) -> str 
             return _validate_nhs_region_geography_code(geography_code=geography_code)
         case enums.GeographyType.GOVERNMENT_OFFICE_REGION.value:
             return _validate_government_office_region_geography_code(
-                geography_code=geography_code
-            )
-        case enums.GeographyType.LOWER_TIER_LOCAL_AUTHORITY.value:
-            return _validate_lower_tier_local_authority_geography_code(
                 geography_code=geography_code
             )
         case enums.GeographyType.NHS_TRUST.value:
@@ -53,16 +52,10 @@ def _validate_nation_geography_code(*, geography_code: str) -> str:
     raise ValueError
 
 
-def _validate_upper_tier_local_authority_geography_code(*, geography_code: str) -> str:
-    if geography_code.startswith(UPPER_TIER_LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIX):
-        return geography_code
-    raise ValueError
-
-
-def _validate_lower_tier_local_authority_geography_code(*, geography_code: str) -> str:
+def _validate_local_authority_geography_code(*, geography_code: str) -> str:
     if any(
         geography_code.startswith(prefix)
-        for prefix in LOWER_TIER_LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIXES
+        for prefix in LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIXES
     ):
         return geography_code
 

--- a/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_code.py
+++ b/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_code.py
@@ -6,9 +6,9 @@ from ingestion.utils import enums
 
 VALID_NATION_CODE = "E92000001"
 VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE = "E06000059"
+VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE = "E10000024"
 VALID_NHS_REGION_CODE = "E40000003"
 VALID_NHS_TRUST_CODE = "RY6"
-VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE = "E10000024"
 VALID_UKHSA_REGION_CODE = "E45000017"
 VALID_GOVERNMENT_OFFICE_REGION_CODE = "E12000003"
 
@@ -136,6 +136,7 @@ class TestIncomingBaseValidationForLowerTierLocalAuthorityGeographyCode:
             "E08000005",
             "E09000025",
             "E09000009",
+            VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE,
         ),
     )
     def test_valid_geography_code_validates_successfully(
@@ -167,7 +168,6 @@ class TestIncomingBaseValidationForLowerTierLocalAuthorityGeographyCode:
             VALID_NATION_CODE,
             VALID_NHS_TRUST_CODE,
             VALID_NHS_REGION_CODE,
-            VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE,
             VALID_UKHSA_REGION_CODE,
             VALID_GOVERNMENT_OFFICE_REGION_CODE,
         ),
@@ -185,6 +185,74 @@ class TestIncomingBaseValidationForLowerTierLocalAuthorityGeographyCode:
         # Given
         payload = valid_payload_for_base_model
         payload["geography_type"] = enums.GeographyType.LOWER_TIER_LOCAL_AUTHORITY.value
+        payload["geography_code"] = geography_code
+
+        # When / Then
+        with pytest.raises(ValidationError):
+            IncomingBaseDataModel(**payload)
+
+
+class TestIncomingBaseValidationForUpperTierLocalAuthorityGeographyCode:
+    @pytest.mark.parametrize(
+        "geography_code",
+        (
+            VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE,
+            "E06000024",
+            "E07000090",
+            "E07000127",
+            "E08000025",
+            "E08000005",
+            "E09000025",
+            "E09000009",
+            VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE,
+        ),
+    )
+    def test_valid_geography_code_validates_successfully(
+        self, geography_code: str, valid_payload_for_base_model: dict[str, str]
+    ):
+        """
+        Given a payload containing a valid `geography_code` value
+            for a `geography_type` of "Upper Tier Local Authority"
+        When the `IncomingBaseDataModel` model is initialized
+        Then model is deemed valid
+        """
+        # Given
+        payload = valid_payload_for_base_model
+        payload["geography_type"] = enums.GeographyType.UPPER_TIER_LOCAL_AUTHORITY.value
+        payload["geography_code"] = geography_code
+
+        # When
+        incoming_base_validation = IncomingBaseDataModel(**payload)
+
+        # Then
+        incoming_base_validation.model_validate(
+            incoming_base_validation,
+            strict=True,
+        )
+
+    @pytest.mark.parametrize(
+        "geography_code",
+        (
+            VALID_NATION_CODE,
+            VALID_NHS_TRUST_CODE,
+            VALID_NHS_REGION_CODE,
+            VALID_UKHSA_REGION_CODE,
+            VALID_GOVERNMENT_OFFICE_REGION_CODE,
+        ),
+    )
+    def test_invalid_geography_code_throws_error(
+        self, geography_code: str, valid_payload_for_base_model: dict[str, str]
+    ):
+        """
+        Given a payload containing a `geography_code`
+            which is not valid for
+            the "Upper Tier Local Authority" `geography_type`
+        When the `IncomingBaseDataModel` model is initialized
+        Then a `ValidationError` is raised
+        """
+        # Given
+        payload = valid_payload_for_base_model
+        payload["geography_type"] = enums.GeographyType.UPPER_TIER_LOCAL_AUTHORITY.value
         payload["geography_code"] = geography_code
 
         # When / Then
@@ -362,71 +430,6 @@ class TestIncomingBaseValidationForGovernmentOfficeRegionGeographyCode:
         # Given
         payload = valid_payload_for_base_model
         payload["geography_type"] = enums.GeographyType.GOVERNMENT_OFFICE_REGION.value
-        payload["geography_code"] = geography_code
-
-        # When / Then
-        with pytest.raises(ValidationError):
-            IncomingBaseDataModel(**payload)
-
-
-class TestIncomingBaseValidationForUpperTierLocalAuthorityGeographyCode:
-    @pytest.mark.parametrize(
-        "geography_code",
-        (
-            VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE,
-            "E10000032",
-            "E10000030",
-            "E10000016",
-            "E10000031",
-        ),
-    )
-    def test_valid_geography_code_validates_successfully(
-        self, geography_code: str, valid_payload_for_base_model: dict[str, str]
-    ):
-        """
-        Given a payload containing a valid `geography_code` value
-            for a `geography_type` of "Upper Tier Local Authority"
-        When the `IncomingBaseDataModel` model is initialized
-        Then model is deemed valid
-        """
-        # Given
-        payload = valid_payload_for_base_model
-        payload["geography_type"] = enums.GeographyType.UPPER_TIER_LOCAL_AUTHORITY.value
-        payload["geography_code"] = geography_code
-
-        # When
-        incoming_base_validation = IncomingBaseDataModel(**payload)
-
-        # Then
-        incoming_base_validation.model_validate(
-            incoming_base_validation,
-            strict=True,
-        )
-
-    @pytest.mark.parametrize(
-        "geography_code",
-        (
-            VALID_NATION_CODE,
-            VALID_NHS_TRUST_CODE,
-            VALID_NHS_REGION_CODE,
-            VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE,
-            VALID_UKHSA_REGION_CODE,
-            VALID_GOVERNMENT_OFFICE_REGION_CODE,
-        ),
-    )
-    def test_invalid_geography_code_throws_error(
-        self, geography_code: str, valid_payload_for_base_model: dict[str, str]
-    ):
-        """
-        Given a payload containing a `geography_code`
-            which is not valid for
-            the "Upper Tier Local Authority" `geography_type`
-        When the `IncomingBaseDataModel` model is initialized
-        Then a `ValidationError` is raised
-        """
-        # Given
-        payload = valid_payload_for_base_model
-        payload["geography_type"] = enums.GeographyType.UPPER_TIER_LOCAL_AUTHORITY.value
         payload["geography_code"] = geography_code
 
         # When / Then


### PR DESCRIPTION
# Description

This PR includes the following:

- Updates geography code rules so that UTLA & LTLA get validated for the same set of prefixes

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
