### PR TITLE
Validate UTLA geographies with additional *E10* prefix compared to LTLA geographies

### DIFF
--- a/ingestion/data_transfer_models/validation/geography_code.py
+++ b/ingestion/data_transfer_models/validation/geography_code.py
@@ -1,7 +1,8 @@
 from ingestion.utils import enums
 
 NATION_GEOGRAPHY_CODE_PREFIX = "E92"
-LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIXES = ("E06", "E07", "E08", "E09", "E10")
+LOWER_TIER_LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIXES = ("E06", "E07", "E08", "E09")
+UPPER_TIER_LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIXES = ("E06", "E07", "E08", "E09", "E10")
 NHS_REGION_GEOGRAPHY_CODE_PREFIX = "E40"
 UKHSA_REGION_GEOGRAPHY_CODE_PREFIX = "E45"
 GOVERNMENT_OFFICE_REGION_GEOGRAPHY_CODE_PREFIX = "E12"
@@ -27,11 +28,11 @@ def validate_geography_code(*, geography_code: str, geography_type: str) -> str 
         case enums.GeographyType.NATION.value:
             return _validate_nation_geography_code(geography_code=geography_code)
         case enums.GeographyType.UPPER_TIER_LOCAL_AUTHORITY.value:
-            return _validate_local_authority_geography_code(
+            return _validate_upper_tier_local_authority_geography_code(
                 geography_code=geography_code
             )
         case enums.GeographyType.LOWER_TIER_LOCAL_AUTHORITY.value:
-            return _validate_local_authority_geography_code(
+            return _validate_lower_tier_local_authority_geography_code(
                 geography_code=geography_code
             )
         case enums.GeographyType.UKHSA_REGION.value:
@@ -52,10 +53,20 @@ def _validate_nation_geography_code(*, geography_code: str) -> str:
     raise ValueError
 
 
-def _validate_local_authority_geography_code(*, geography_code: str) -> str:
+def _validate_lower_tier_local_authority_geography_code(*, geography_code: str) -> str:
     if any(
         geography_code.startswith(prefix)
-        for prefix in LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIXES
+        for prefix in LOWER_TIER_LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIXES
+    ):
+        return geography_code
+
+    raise ValueError
+
+
+def _validate_upper_tier_local_authority_geography_code(*, geography_code: str) -> str:
+    if any(
+        geography_code.startswith(prefix)
+        for prefix in UPPER_TIER_LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIXES
     ):
         return geography_code
 

--- a/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_code.py
+++ b/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_code.py
@@ -136,7 +136,6 @@ class TestIncomingBaseValidationForLowerTierLocalAuthorityGeographyCode:
             "E08000005",
             "E09000025",
             "E09000009",
-            VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE,
         ),
     )
     def test_valid_geography_code_validates_successfully(


### PR DESCRIPTION
# Description

This PR includes the following:

- Validates UTLA with the prefix of `E10`.
- Invalidates LTLA with the prefix of `E10`.

Fixes #CDD-1941

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
