### PR TITLE
CDD-1959: Heat alert endpoint

### DIFF
--- a/metrics/api/enums.py
+++ b/metrics/api/enums.py
@@ -20,3 +20,9 @@ class AppMode(Enum):
     @classmethod
     def dependent_on_cache(cls) -> list[str]:
         return [cls.PRIVATE_API.value]
+
+
+class Alerts(Enum):
+    ALERT_GEOGRAPHY_TYPE_NAME = "Government Office Region"
+    HEAT_TOPIC_NAME = "Heat-alert"
+    HEAT_METRIC_NAME = "heat-alert_headline_matrixNumber"

--- a/metrics/api/serializers/__init__.py
+++ b/metrics/api/serializers/__init__.py
@@ -6,3 +6,4 @@ from .downloads import (
     BulkDownloadsSerializer,
 )
 from .timeseries import CoreTimeSeriesSerializer
+from .geographies_alerts import GeographiesForAlertsSerializer

--- a/metrics/api/serializers/geographies_alerts.py
+++ b/metrics/api/serializers/geographies_alerts.py
@@ -1,0 +1,32 @@
+from rest_framework import serializers
+
+from metrics.api.enums import Alerts
+from metrics.data.models.core_models import Geography
+
+
+class GeographiesForAlertsSerializer(serializers.Serializer):
+    geography_code = serializers.CharField()
+
+    def validate_geography_code(self, value) -> str:
+        if not self.geography_manager.does_geography_code_exist(
+            geography_code=value,
+            geography_type_name=Alerts.ALERT_GEOGRAPHY_TYPE_NAME.value,
+        ):
+            raise serializers.ValidationError(
+                {"name": "Please enter a valid geography code."}
+            )
+
+        return value
+
+    @property
+    def geography_manager(self):
+        """
+        Fetch the topic manager from the context if available.
+        If not get the Manager which has been declared on the `Geography` model.
+        """
+        return self.context.get("geography_manager", Geography.objects)
+
+    def data(self):
+        return self.geography_manager.get_geography_codes_and_names_by_geography_type(
+            geography_type_name=Alerts.ALERT_GEOGRAPHY_TYPE_NAME.value
+        )

--- a/metrics/api/urls_construction.py
+++ b/metrics/api/urls_construction.py
@@ -22,6 +22,7 @@ from metrics.api.views import (
     EncodedChartsView,
     HeadlinesView,
     HealthView,
+    HeatAlertViewSet,
     TablesView,
     TrendsView,
 )
@@ -108,10 +109,19 @@ def construct_public_api_urlpatterns(
 
 API_PREFIX = "api/"
 
+heat_alert_list = HeatAlertViewSet.as_view({"get": "list"})
+heat_alert_detail = HeatAlertViewSet.as_view({"get": "retrieve"})
+
 private_api_urlpatterns = [
     # Headless CMS API - pages + drafts endpoints
     path(API_PREFIX, cms_api_router.urls),
     path(f"{API_PREFIX}global-banners/v1", GlobalBannerView.as_view()),
+    path(f"{API_PREFIX}alerts/v1/heat", heat_alert_list, name="heat-alerts-list"),
+    path(
+        f"{API_PREFIX}alerts/v1/heat/<str:geography_code>",
+        heat_alert_detail,
+        name="heat-alerts-detail",
+    ),
     # Metrics/private content endpoints
     re_path(f"^{API_PREFIX}charts/v2", ChartsView.as_view()),
     re_path(f"^{API_PREFIX}charts/v3", EncodedChartsView.as_view()),

--- a/metrics/api/views/__init__.py
+++ b/metrics/api/views/__init__.py
@@ -1,3 +1,4 @@
+from .alerts import HeatAlertViewSet
 from .charts import ChartsView, EncodedChartsView
 from .headlines import HeadlinesView
 from .downloads import DownloadsView, BulkDownloadsView

--- a/metrics/api/views/alerts.py
+++ b/metrics/api/views/alerts.py
@@ -1,0 +1,67 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework import viewsets
+from rest_framework.response import Response
+
+from metrics.api.enums import Alerts
+from metrics.api.serializers.geographies_alerts import GeographiesForAlertsSerializer
+from metrics.interfaces.weather_health_alerts.access import (
+    get_detailed_data_for_alert,
+    get_summary_data_for_alerts,
+)
+
+ALERTS_API_TAG = "alerts"
+
+
+@extend_schema(tags=[ALERTS_API_TAG])
+class BaseAlertViewSet(viewsets.ReadOnlyModelViewSet):
+    permission_classes = []
+
+    @property
+    def topic_name(self) -> str:
+        raise NotImplementedError
+
+    @property
+    def metric_name(self) -> str:
+        raise NotImplementedError
+
+    def list(self, request, *args, **kwargs):
+        serializer = GeographiesForAlertsSerializer()
+        geography_data = serializer.data()
+        summary_data: list[dict[str, str]] = get_summary_data_for_alerts(
+            geography_data=geography_data,
+            topic_name=self.topic_name,
+            metric_name=self.metric_name,
+        )
+
+        return Response(data=summary_data)
+
+    def retrieve(self, request, *args, **kwargs):
+        serializer = GeographiesForAlertsSerializer()
+        geography_data = serializer.data()
+
+        geography_code = kwargs["geography_code"]
+        payload = {"geography_code": geography_code}
+        request_serializer = GeographiesForAlertsSerializer(data=payload)
+        request_serializer.is_valid(raise_exception=True)
+
+        geography_data = dict(filter(lambda x: geography_code in x, geography_data))
+
+        summary_data: dict[str, str] = get_detailed_data_for_alert(
+            geography_code=geography_code,
+            geography_name=geography_data[geography_code],
+            geography_type_name=Alerts.ALERT_GEOGRAPHY_TYPE_NAME.value,
+            topic_name=self.topic_name,
+            metric_name=self.metric_name,
+        )
+
+        return Response(data=summary_data)
+
+
+class HeatAlertViewSet(BaseAlertViewSet):
+    @property
+    def topic_name(self) -> str:
+        return Alerts.HEAT_TOPIC_NAME.value
+
+    @property
+    def metric_name(self) -> str:
+        return Alerts.HEAT_METRIC_NAME.value

--- a/metrics/data/managers/core_models/geography.py
+++ b/metrics/data/managers/core_models/geography.py
@@ -5,13 +5,15 @@ Note that the application layer should only call into the `Manager` class.
 The application should not interact directly with the `QuerySet` class.
 """
 
+from typing import Self
+
 from django.db import models
 
 
 class GeographyQuerySet(models.QuerySet):
     """Custom queryset which can be used by the `GeographyManager`"""
 
-    def get_all_names(self) -> models.QuerySet:
+    def get_all_names(self) -> Self:
         """Gets all available geography names as a flat list queryset.
 
         Returns:
@@ -22,6 +24,44 @@ class GeographyQuerySet(models.QuerySet):
 
         """
         return self.all().values_list("name", flat=True).distinct().order_by("name")
+
+    def get_all_geography_codes_by_geography_type(
+        self, geography_type_name: str
+    ) -> Self:
+        """Gets all available geography codes for the given `geography_type_name`.
+        Returns:
+            QuerySet: A queryset of the individual geography codes
+                which are related to the given geography_type:
+                Examples:
+                    `<GeographyQuerySet ['E06000001', 'E06000002']>`
+        """
+        return (
+            self.filter(geography_type__name=geography_type_name)
+            .values_list("geography_code", flat=True)
+            .order_by("geography_code")
+        )
+
+    def get_geography_codes_and_names_by_geography_type(
+        self,
+        geography_type_name: str,
+    ):
+        """Gets all available geography codes and names for the given `geography_type_name`
+
+        Args:
+            geography_type_name: string representation of `geography_type_name`
+
+        Returns:
+            QuerySet: A queryset of the individual geography codes
+                which are related to the given geography_type:
+                Examples:
+                    `<GeographyQuerySet [('E06000001', 'North East'), ('E06000002', 'North West')]>`
+
+        """
+        return (
+            self.filter(geography_type__name=geography_type_name)
+            .values_list("geography_code", "name")
+            .order_by("geography_code")
+        )
 
 
 class GeographyManager(models.Manager):
@@ -41,3 +81,58 @@ class GeographyManager(models.Manager):
 
         """
         return self.get_queryset().get_all_names()
+
+    def get_all_geography_codes_by_geography_type(self, geography_type_name: str):
+        """Gets all available geography codes for the given `geography_type_name`.
+
+        Args:
+            geography_type_name: string representation of `geography_type_name`
+
+        Returns:
+            QuerySet: A queryset of the individual geography codes
+                which are related to the given geography_type:
+                Examples:
+                    `<GeographyQuerySet ['E06000001', 'E06000002']>`
+
+        """
+        return self.get_queryset().get_all_geography_codes_by_geography_type(
+            geography_type_name=geography_type_name
+        )
+
+    def get_geography_codes_and_names_by_geography_type(
+        self,
+        geography_type_name: str,
+    ):
+        """Gets all available geography codes and names for a give `geography_type`
+
+        Args:
+            geography_type_name: string representation of `geography_type_name`
+
+        Returns:
+            QuerySet: A queryset of the individual geography codes
+                which are related to the given geography_type:
+                Examples:
+                    `<GeographyQuerySet [('E06000001', 'North East'), ('E06000002', 'North West')]>`
+
+        """
+        return self.get_queryset().get_geography_codes_and_names_by_geography_type(
+            geography_type_name=geography_type_name
+        )
+
+    def does_geography_code_exist(
+        self, *, geography_code: str, geography_type_name: str
+    ) -> bool:
+        """Given a `geography_code` it validates this against all geography_codes against
+           a given `geography_type`
+
+        Returns:
+            Bool: True or False based on provided `geography_code` being in the database.
+
+        """
+        return (
+            self.get_all_geography_codes_by_geography_type(
+                geography_type_name=geography_type_name
+            )
+            .filter(geography_code=geography_code)
+            .exists()
+        )

--- a/metrics/interfaces/weather_health_alerts/access.py
+++ b/metrics/interfaces/weather_health_alerts/access.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterable
 
 from django.db.models.manager import Manager
 from django.utils import timezone
@@ -17,7 +18,7 @@ class WeatherHealthAlertsInterface:
         self._core_headline_manager = core_headline_manager
 
     def build_summary_data_for_alerts(
-        self, geography_codes: list[str], topic_name: str, metric_name: str
+        self, geography_data: list[str], topic_name: str, metric_name: str
     ) -> dict[str, WEATHER_HEALTH_ALERT_DETAILED_DATA]:
         """Builds the exported summary data required for each current alert state associated with each `geography_code`
 
@@ -26,8 +27,8 @@ class WeatherHealthAlertsInterface:
                 associated with the alert
             metric_name: The name of the metric
                 associated with the alert
-            geography_codes: The codes for each of the geographies
-                being queried for.
+            geography_data: List of tuples containing the codes for
+                each of the geographies being queried.
 
         Returns:
             Dict keyed by the geography_code
@@ -39,7 +40,9 @@ class WeatherHealthAlertsInterface:
             self._core_headline_manager.get_latest_headlines_for_geography_codes(
                 topic_name=topic_name,
                 metric_name=metric_name,
-                geography_codes=geography_codes,
+                geography_codes=[
+                    geography_code for geography_code, geography_name in geography_data
+                ],
             )
         )
 
@@ -47,16 +50,30 @@ class WeatherHealthAlertsInterface:
             geography_code: self._parse_core_headline_as_alarm_state(
                 topic_name=topic_name, core_headline=core_headline
             )
-            for geography_code, core_headline in headlines_mapping.items()
+            for geography_code, core_headline, in headlines_mapping.items()
         }
 
-        return {
+        alarm_states = {
             geography_code: alarm_state.summary_data
             for geography_code, alarm_state in weather_health_alarm_states.items()
         }
 
+        return [
+            {
+                "geography_code": geography_code,
+                "geography_name": geography_name,
+                **alarm_states[geography_code],
+            }
+            for geography_code, geography_name in geography_data
+        ]
+
     def build_detailed_data_for_alert(
-        self, topic_name: str, metric_name: str, geography_code: str
+        self,
+        topic_name: str,
+        metric_name: str,
+        geography_code: str,
+        geography_name: str,
+        geography_type_name: str,
     ) -> WEATHER_HEALTH_ALERT_DETAILED_DATA:
         """Builds the exported data required for the alert associated with the given `core_headline`
 
@@ -67,10 +84,15 @@ class WeatherHealthAlertsInterface:
                 associated with the alert
             geography_code: The code of the geography
                 associated with the individual alert
+            geography_name: The name of the geography
+                associated with the individual alert
+            geography_type_name: The name of the geography type
+                associated with the individual alert
 
         Returns:
             Dict containing the exported data required to
-            represent the alert
+            represent the alert alongside the
+            `geography_code` and `geography_name`
 
         """
         weather_health_alarm_state: WeatherHealthAlarmState = (
@@ -78,18 +100,32 @@ class WeatherHealthAlertsInterface:
                 topic_name=topic_name,
                 metric_name=metric_name,
                 geography_code=geography_code,
+                geography_name=geography_name,
+                geography_type_name=geography_type_name,
             )
         )
-        return weather_health_alarm_state.detailed_data
+
+        return {
+            "geography_name": geography_name,
+            "geography_code": geography_code,
+            **weather_health_alarm_state.detailed_data,
+        }
 
     def _build_current_headline_state(
-        self, topic_name: str, metric_name: str, geography_code: str
+        self,
+        topic_name: str,
+        metric_name: str,
+        geography_code: str,
+        geography_name: str,
+        geography_type_name: str,
     ) -> WeatherHealthAlarmState:
         core_headline: CoreHeadline | None = (
             self._core_headline_manager.get_latest_headline(
                 topic_name=topic_name,
                 metric_name=metric_name,
                 geography_code=geography_code,
+                geography_name=geography_name,
+                geography_type_name=geography_type_name,
             )
         )
 
@@ -134,3 +170,33 @@ class WeatherHealthAlertsInterface:
             period_end=core_headline.period_end,
             refresh_date=core_headline.refresh_date,
         )
+
+
+def get_summary_data_for_alerts(
+    geography_data: Iterable[str],
+    topic_name: str,
+    metric_name: str,
+):
+    weather_health_alerts_interface = WeatherHealthAlertsInterface()
+    return weather_health_alerts_interface.build_summary_data_for_alerts(
+        geography_data=geography_data,
+        topic_name=topic_name,
+        metric_name=metric_name,
+    )
+
+
+def get_detailed_data_for_alert(
+    geography_code: str,
+    geography_name: str,
+    geography_type_name: str,
+    topic_name: str,
+    metric_name: str,
+):
+    weather_health_alerts_interface = WeatherHealthAlertsInterface()
+    return weather_health_alerts_interface.build_detailed_data_for_alert(
+        geography_code=geography_code,
+        geography_name=geography_name,
+        geography_type_name=geography_type_name,
+        topic_name=topic_name,
+        metric_name=metric_name,
+    )

--- a/tests/fakes/managers/geography_manager.py
+++ b/tests/fakes/managers/geography_manager.py
@@ -13,3 +13,20 @@ class FakeGeographyManager(GeographyManager):
 
     def get_all_names(self) -> list[str]:
         return list({geography.name for geography in self.geographies})
+
+    def get_geography_codes_and_names_by_geography_type(
+        self,
+        geography_type_name: str,
+    ):
+        return self.geographies
+
+    def does_geography_code_exist(
+        self, geography_code: str, geography_type_name
+    ) -> str:
+        for code, name in self.get_geography_codes_and_names_by_geography_type(
+            geography_type_name=geography_type_name
+        ):
+            if code == geography_code:
+                return True
+
+            return False

--- a/tests/integration/metrics/api/views/test_alerts.py
+++ b/tests/integration/metrics/api/views/test_alerts.py
@@ -1,0 +1,119 @@
+from unittest import mock
+from http import HTTPStatus
+
+import pytest
+from rest_framework.response import Response
+from django.urls import reverse
+from rest_framework.test import APIClient, APITestCase
+
+from metrics.api.serializers.geographies_alerts import GeographiesForAlertsSerializer
+from metrics.api.views.alerts import BaseAlertViewSet, HeatAlertViewSet
+
+
+class InvalidMetricExtendedBaseAlertViewSet(BaseAlertViewSet):
+    @property
+    def topic_name(self) -> str:
+        return "topic_name"
+
+
+class InvalidTopicExtendedBaseAlertViewSet(BaseAlertViewSet):
+    @property
+    def metric_name(self) -> str:
+        return "metric_name"
+
+
+class TestAlertsView:
+    @property
+    def path(self) -> str:
+        return reverse("heat-alerts-list")
+
+    @pytest.mark.django_db
+    def test_list_returns_correct_response(self):
+        """
+        Given a valid request to the `alerts` endpoint
+        When the `GET /api/alerts/v1` endpoint is hit.
+        Then the expected response is returned.
+        """
+        # Given
+        client = APIClient()
+
+        # When
+        response: Response = client.get(path=self.path)
+
+        # Then
+        assert response.status_code == HTTPStatus.OK
+        assert response.headers["Content-Type"] == "application/json"
+
+    @pytest.mark.django_db
+    @mock.patch.object(GeographiesForAlertsSerializer, "data")
+    @mock.patch.object(GeographiesForAlertsSerializer, "is_valid")
+    def test_retrieve_returns_correct_response(
+        self, mock_is_valid: mock.Mock(), mock_data: mock.Mock()
+    ):
+        """
+        Given a valid request `alerts` retrieve action endpoint
+        When the `GET /api/alerts/v1/{geography_code}` endpoint is hit.
+        Then the correct response is returned.
+        """
+        # Given
+        client = APIClient()
+        path = f"{self.path}/E12000001"
+        mock_data.return_value = [("E12000001", "North East")]
+        mock_is_valid.return_value = True
+
+        # When
+        response: Response = client.get(path=path)
+
+        # Then
+        assert response.status_code == HTTPStatus.OK
+        assert response.headers["Content-Type"] == "application/json"
+
+    @pytest.mark.django_db
+    def test_retrieve_returns_400_response(
+        self,
+    ):
+        """
+        Given an invalid request to the `alerts` retrieve action endpoint
+        When the `GET /api/alerts/v1/{geography_code}` endpoint is hit.
+        Then a 400 Bad Request is returned.
+        """
+        # Given
+        client = APIClient()
+        path = f"{self.path}/invalid-code"
+
+        # When
+        response: Response = client.get(path=path)
+
+        # Then
+        assert response.status_code == HTTPStatus.BAD_REQUEST
+
+
+class TestHeatAlertsView:
+
+    @pytest.mark.django_db
+    def test_raises_error_if_topic_name_not_implemented(self):
+        """
+        Given an instance of the `BaseAlertViewSet`
+        When the `topic_name` is not implemented in the child class
+        Then a `NotImplementedError` is raised.
+        """
+        # Given
+        extended_base_alert_view_set = InvalidTopicExtendedBaseAlertViewSet()
+
+        # When / Then
+        with pytest.raises(NotImplementedError):
+            extended_base_alert_view_set.list(request=mock.Mock())
+
+    @pytest.mark.django_db
+    def test_raises_error_if_metric_name_not_implemented(self):
+        """
+        Given an instance of the `BaseAlertViewSet`
+        When the `metric_name` is not implemented in the child class
+        Then a `NotImplementedError` is raised.
+        """
+        # Given
+        extended_base_alert_view_set = InvalidMetricExtendedBaseAlertViewSet()
+
+        # When / Then
+        with pytest.raises(NotImplementedError):
+            extended_base_alert_view_set.list(request=mock.Mock())

--- a/tests/integration/metrics/interfaces/weather_health_alerts/test_access.py
+++ b/tests/integration/metrics/interfaces/weather_health_alerts/test_access.py
@@ -1,0 +1,65 @@
+import pytest
+
+
+from metrics.interfaces.weather_health_alerts.access import (
+    WeatherHealthAlertsInterface,
+    WEATHER_HEALTH_ALERT_DETAILED_DATA,
+    get_summary_data_for_alerts,
+)
+
+from tests.fakes.factories.metrics.headline_factory import FakeCoreHeadlineFactory
+from tests.fakes.managers.headline_manager import FakeCoreHeadlineManager
+
+
+class TestAccessGetSummaryDataForAlerts:
+    @pytest.mark.parametrize(
+        "geography_data, topic, metric",
+        [
+            (
+                [("E06000001", "North East"), ("E06000002", "North West")],
+                "Heat-alert",
+                "heat-alert_headline_matrixNumber",
+            )
+        ],
+    )
+    @pytest.mark.django_db
+    def test_access_get_summary_data_for_alerts_returns_expected_response(
+        self,
+        geography_data: list[tuple[str, str]],
+        topic: str,
+        metric: str,
+    ):
+        """
+        Given A valid list of geography codes and names, a topic and metric name
+        When when the `get_summary_data_for_alerts()` method is called
+        Then then a list of alert summary details are returned.
+        """
+        # Given
+        fake_geography_data = geography_data
+        fake_topic = topic
+        fake_metric = metric
+
+        expected_output = [
+            {
+                "geography_code": "E06000001",
+                "geography_name": "North East",
+                "status": "Green",
+                "refresh_date": None,
+            },
+            {
+                "geography_code": "E06000002",
+                "geography_name": "North West",
+                "status": "Green",
+                "refresh_date": None,
+            },
+        ]
+
+        # When
+        summary_data = get_summary_data_for_alerts(
+            geography_data=fake_geography_data,
+            topic_name=fake_topic,
+            metric_name=fake_metric,
+        )
+
+        # then
+        assert len(summary_data) == len(expected_output)

--- a/tests/unit/metrics/api/serializers/test_geographies_alerts.py
+++ b/tests/unit/metrics/api/serializers/test_geographies_alerts.py
@@ -1,0 +1,77 @@
+from unittest import mock
+
+from metrics.api.serializers.geographies_alerts import GeographiesForAlertsSerializer
+from tests.fakes.factories.metrics.headline_factory import (
+    FakeCoreHeadlineFactory,
+)
+from tests.fakes.managers.geography_manager import FakeGeographyManager
+
+
+class TestGeographiesForAlertsSerializer:
+    def test_get_results(self):
+        """
+        Given a valid payload has been serialized
+        When `data()` is called from an instance of
+            `GeographiesForAlertsSerializer`
+        Then the returned results contain the correct `geography_codes`
+            and `geography_names`
+        """
+        # Given
+        fake_geography_manager = FakeGeographyManager(
+            geographies=[("E06000001", "North East"), ("E06000002", "North West")]
+        )
+
+        serializer = GeographiesForAlertsSerializer(
+            context={
+                "geography_manager": fake_geography_manager,
+            },
+        )
+
+        # When
+        expected_results = [("E06000001", "North East"), ("E06000002", "North West")]
+        results = serializer.data()
+
+        # Then
+        assert results == expected_results
+
+    def test_validate_geography_code_makes_correct_call(self):
+        """
+        Given a valid payload sent to the serializer
+        When the `is_valid()` method is called
+        Then True is returned
+        """
+        # Given
+        fake_geography_manager = FakeGeographyManager(
+            geographies=[("E06000001", "North East"), ("E06000002", "North West")]
+        )
+
+        request_serializer = GeographiesForAlertsSerializer(
+            context={
+                "geography_manager": fake_geography_manager,
+            },
+            data={"geography_code": "E06000001"},
+        )
+
+        # When / Then
+        assert request_serializer.is_valid() is True
+
+    def test_validate_geography_code_raise_error(self):
+        """
+        Given a valid payload sent to the serializer
+        When the `is_valid()` method is called
+        Then False is returned
+        """
+        # Given
+        fake_geography_manager = FakeGeographyManager(
+            geographies=[("E06000001", "North East"), ("E06000002", "North West")]
+        )
+
+        request_serializer = GeographiesForAlertsSerializer(
+            context={
+                "geography_manager": fake_geography_manager,
+            },
+            data={"geography_code": "invalid-code"},
+        )
+
+        # When / Then
+        assert request_serializer.is_valid() is False

--- a/tests/unit/metrics/api/views/test_alerts.py
+++ b/tests/unit/metrics/api/views/test_alerts.py
@@ -1,0 +1,21 @@
+from unittest import mock
+import pytest
+
+from metrics.api.views.alerts import BaseAlertViewSet, HeatAlertViewSet
+
+
+class TestBaseAlertsView:
+    def test_sets_no_api_key_restrictions(self):
+        """
+        Given an instance of the `BaseAlertViewSet`
+        When the `permission_classes` attribute is called
+        Then an empty list is returned
+        """
+        # Given
+        base_alert_view = BaseAlertViewSet()
+
+        # When
+        permission_classess = base_alert_view.permission_classes
+
+        # Then
+        assert permission_classess == []

--- a/tests/unit/metrics/interfaces/weather_health_alerts/test_access.py
+++ b/tests/unit/metrics/interfaces/weather_health_alerts/test_access.py
@@ -1,4 +1,8 @@
+from unittest import mock
+
 import datetime
+
+import pytest
 
 from metrics.domain.weather_health_alerts.mapping import (
     WeatherHealthAlertTopics,
@@ -7,6 +11,8 @@ from metrics.domain.weather_health_alerts.mapping import (
 from metrics.interfaces.weather_health_alerts.access import (
     WeatherHealthAlertsInterface,
     WEATHER_HEALTH_ALERT_DETAILED_DATA,
+    get_summary_data_for_alerts,
+    get_detailed_data_for_alert,
 )
 from tests.fakes.factories.metrics.headline_factory import FakeCoreHeadlineFactory
 from tests.fakes.managers.headline_manager import FakeCoreHeadlineManager
@@ -14,6 +20,8 @@ from django.utils import timezone
 from metrics.domain.weather_health_alerts.text_lookups import HEAT_ALERT_TEXT_LOOKUP
 
 from tests.fakes.models.metrics.headline import FakeCoreHeadline
+
+MODULE_PATH = "metrics.interfaces.weather_health_alerts.access"
 
 
 class TestWeatherHealthAlertsInterfaceBuildDetailedDataForAlert:
@@ -35,7 +43,10 @@ class TestWeatherHealthAlertsInterfaceBuildDetailedDataForAlert:
         # Given
         topic_name = WeatherHealthAlertTopics.HEAT_ALERT.value
         metric_name = "heat-alert_headline_matrixNumber"
-        geography_code = "E07000115"
+        geography_code = "E12000001"
+        geography_name = "North East"
+        geography_type_name = "Government Office Region"
+
         fake_core_headline_manager = FakeCoreHeadlineManager(headlines=[])
         weather_health_alerts_interface = WeatherHealthAlertsInterface(
             core_headline_manager=fake_core_headline_manager
@@ -47,6 +58,8 @@ class TestWeatherHealthAlertsInterfaceBuildDetailedDataForAlert:
                 topic_name=topic_name,
                 metric_name=metric_name,
                 geography_code=geography_code,
+                geography_name=geography_name,
+                geography_type_name=geography_type_name,
             )
         )
 
@@ -78,7 +91,9 @@ class TestWeatherHealthAlertsInterfaceBuildDetailedDataForAlert:
         # Given
         topic_name = WeatherHealthAlertTopics.HEAT_ALERT.value
         metric_name = "heat-alert_headline_matrixNumber"
-        geography_code = "E07000115"
+        geography_code = "E12000001"
+        geography_name = "North East"
+        geography_type_name = "Government Office Region"
         two_weeks_ago = timezone.now() - datetime.timedelta(days=14)
         one_week_ago = timezone.now() - datetime.timedelta(days=7)
         red_alert_metric_value = 16
@@ -87,6 +102,8 @@ class TestWeatherHealthAlertsInterfaceBuildDetailedDataForAlert:
             metric_name=metric_name,
             metric_value=red_alert_metric_value,
             geography_code=geography_code,
+            geography_name=geography_name,
+            geography_type_name=geography_type_name,
             period_end=one_week_ago,
             refresh_date=two_weeks_ago,
         )
@@ -104,6 +121,8 @@ class TestWeatherHealthAlertsInterfaceBuildDetailedDataForAlert:
                 topic_name=topic_name,
                 metric_name=metric_name,
                 geography_code=geography_code,
+                geography_name=geography_name,
+                geography_type_name=geography_type_name,
             )
         )
 
@@ -134,7 +153,9 @@ class TestWeatherHealthAlertsInterfaceBuildDetailedDataForAlert:
         # Given
         topic_name = WeatherHealthAlertTopics.HEAT_ALERT.value
         metric_name = "heat-alert_headline_matrixNumber"
-        geography_code = "E07000115"
+        geography_code = "E12000001"
+        geography_name = "North East"
+        geography_type_name = "Government Office Region"
         two_weeks_from_now = timezone.now() + datetime.timedelta(days=14)
         one_week_ago = timezone.now() - datetime.timedelta(days=7)
         red_alert_metric_value = 16
@@ -143,6 +164,8 @@ class TestWeatherHealthAlertsInterfaceBuildDetailedDataForAlert:
             metric_name=metric_name,
             metric_value=red_alert_metric_value,
             geography_code=geography_code,
+            geography_name=geography_name,
+            geography_type_name=geography_type_name,
             period_end=two_weeks_from_now,
             refresh_date=one_week_ago,
         )
@@ -160,6 +183,8 @@ class TestWeatherHealthAlertsInterfaceBuildDetailedDataForAlert:
                 topic_name=topic_name,
                 metric_name=metric_name,
                 geography_code=geography_code,
+                geography_name=geography_name,
+                geography_type_name=geography_type_name,
             )
         )
 
@@ -195,8 +220,13 @@ class TestWeatherHealthAlertsInterfaceBuildSummaryDataForAlerts:
         topic_name = WeatherHealthAlertTopics.HEAT_ALERT.value
         metric_name = "heat-alert_headline_matrixNumber"
         first_geography_code = "E07000115"
+        first_geography_name = "Tonbridge and Malling"
         second_geography_code = "E07000120"
-        geography_codes = [first_geography_code, second_geography_code]
+        second_geography_name = "Hyndburn"
+        geography_data = [
+            (first_geography_code, first_geography_name),
+            (second_geography_code, second_geography_name),
+        ]
 
         fake_core_headline_manager = FakeCoreHeadlineManager(headlines=[])
         weather_health_alerts_interface = WeatherHealthAlertsInterface(
@@ -208,22 +238,22 @@ class TestWeatherHealthAlertsInterfaceBuildSummaryDataForAlerts:
             weather_health_alerts_interface.build_summary_data_for_alerts(
                 topic_name=topic_name,
                 metric_name=metric_name,
-                geography_codes=geography_codes,
+                geography_data=geography_data,
             )
         )
 
         # Then
-        assert len(summary_alarm_data) == len(geography_codes)
+        assert len(summary_alarm_data) == len(geography_data)
         assert (
-            summary_alarm_data[first_geography_code]["status"]
+            summary_alarm_data[0]["status"]
             == WeatherHealthAlertStatusColour.GREEN.value
         )
-        assert summary_alarm_data[first_geography_code]["refresh_date"] is None
+        assert summary_alarm_data[0]["refresh_date"] is None
         assert (
-            summary_alarm_data[second_geography_code]["status"]
+            summary_alarm_data[1]["status"]
             == WeatherHealthAlertStatusColour.GREEN.value
         )
-        assert summary_alarm_data[second_geography_code]["refresh_date"] is None
+        assert summary_alarm_data[1]["refresh_date"] is None
 
     def test_for_alerts_which_have_expired(self):
         """
@@ -245,7 +275,13 @@ class TestWeatherHealthAlertsInterfaceBuildSummaryDataForAlerts:
         topic_name = WeatherHealthAlertTopics.HEAT_ALERT.value
         metric_name = "heat-alert_headline_matrixNumber"
         first_geography_code = "E07000115"
+        first_geography_name = "Tonbridge and Malling"
         second_geography_code = "E07000120"
+        second_geography_name = "Hyndburn"
+        geography_data = [
+            (first_geography_code, first_geography_name),
+            (second_geography_code, second_geography_name),
+        ]
         two_weeks_ago = timezone.now() - datetime.timedelta(days=14)
         one_week_ago = timezone.now() - datetime.timedelta(days=7)
         red_alert_metric_value = 16
@@ -285,26 +321,26 @@ class TestWeatherHealthAlertsInterfaceBuildSummaryDataForAlerts:
             weather_health_alerts_interface.build_summary_data_for_alerts(
                 topic_name=topic_name,
                 metric_name=metric_name,
-                geography_codes=[first_geography_code, second_geography_code],
+                geography_data=geography_data,
             )
         )
 
         # Then
-        assert len(summary_alarm_data) == 2
+        assert len(summary_alarm_data) == len(geography_data)
         assert (
-            summary_alarm_data[first_geography_code]["status"]
+            summary_alarm_data[0]["status"]
             == WeatherHealthAlertStatusColour.GREEN.value
         )
         assert (
-            summary_alarm_data[first_geography_code]["refresh_date"]
+            summary_alarm_data[0]["refresh_date"]
             == fake_expired_red_alert_for_first_geography.period_end
         )
         assert (
-            summary_alarm_data[second_geography_code]["status"]
+            summary_alarm_data[1]["status"]
             == WeatherHealthAlertStatusColour.GREEN.value
         )
         assert (
-            summary_alarm_data[second_geography_code]["refresh_date"]
+            summary_alarm_data[1]["refresh_date"]
             == fake_expired_red_alert_for_second_geography.period_end
         )
 
@@ -325,7 +361,13 @@ class TestWeatherHealthAlertsInterfaceBuildSummaryDataForAlerts:
         topic_name = WeatherHealthAlertTopics.HEAT_ALERT.value
         metric_name = "heat-alert_headline_matrixNumber"
         first_geography_code = "E07000115"
+        first_geography_name = "Tonbridge and Malling"
         second_geography_code = "E07000120"
+        second_geography_name = "Hyndburn"
+        geography_data = [
+            (first_geography_code, first_geography_name),
+            (second_geography_code, second_geography_name),
+        ]
 
         two_weeks_from_now = timezone.now() + datetime.timedelta(days=14)
         one_week_ago = timezone.now() - datetime.timedelta(days=7)
@@ -368,26 +410,113 @@ class TestWeatherHealthAlertsInterfaceBuildSummaryDataForAlerts:
             weather_health_alerts_interface.build_summary_data_for_alerts(
                 topic_name=topic_name,
                 metric_name=metric_name,
-                geography_codes=[first_geography_code, second_geography_code],
+                geography_data=geography_data,
             )
         )
 
         # Then
-        assert len(detailed_alarm_data) == 2
+        assert len(detailed_alarm_data) == len(geography_data)
 
         assert (
-            detailed_alarm_data[first_geography_code]["status"]
-            == WeatherHealthAlertStatusColour.RED.value
+            detailed_alarm_data[0]["status"] == WeatherHealthAlertStatusColour.RED.value
         )
         assert (
-            detailed_alarm_data[first_geography_code]["refresh_date"]
+            detailed_alarm_data[0]["refresh_date"]
             == fake_expired_red_alert_for_first_geography.refresh_date
         )
         assert (
-            detailed_alarm_data[second_geography_code]["status"]
+            detailed_alarm_data[1]["status"]
             == WeatherHealthAlertStatusColour.AMBER.value
         )
         assert (
-            detailed_alarm_data[second_geography_code]["refresh_date"]
+            detailed_alarm_data[1]["refresh_date"]
             == fake_expired_red_alert_for_first_geography.refresh_date
         )
+
+
+class TestAccessGetSummaryDataForAlerts:
+    @pytest.mark.parametrize(
+        "geography_data, topic, metric",
+        [
+            (
+                [("E06000001", "North East"), ("E06000002", "North West")],
+                "Heat-alert",
+                "heat-alert_headline_matrixNumber",
+            )
+        ],
+    )
+    @mock.patch.object(WeatherHealthAlertsInterface, "build_summary_data_for_alerts")
+    def test_access_get_summary_data_for_alerts_makes_correct_call(
+        self,
+        spy_build_summary_data_for_alerts: mock.MagicMock,
+        geography_data: list[tuple[str, str]],
+        topic: str,
+        metric: str,
+    ):
+        """
+        Given a valid payload including geography codes, geograpny names, topic and metric names
+        When when the `get_summary_data_for_alerts()` method is called
+        Then the `WeatherHealthAlertsInterface.build_summary_data_for_alerts()` method is called.
+        """
+        # Given
+        fake_geography_data = geography_data
+        fake_topic = topic
+        fake_metric = metric
+
+        # When
+        get_summary_data_for_alerts(
+            geography_data=fake_geography_data,
+            topic_name=fake_topic,
+            metric_name=fake_metric,
+        )
+
+        # Then
+        spy_build_summary_data_for_alerts.assert_called()
+
+
+class TestAccessGetDetailedDataForAlerts:
+    @pytest.mark.parametrize(
+        "geography_code, geography_name, geography_type_name, topic, metric",
+        [
+            (
+                "E06000001",
+                "North East",
+                "Government Office Region",
+                "Heat-alert",
+                "heat-alert_headline_matrixNumber",
+            )
+        ],
+    )
+    @mock.patch.object(WeatherHealthAlertsInterface, "build_detailed_data_for_alert")
+    def test_access_get_details_data_for_alert_makes_correct_call(
+        self,
+        spy_build_detailed_data_for_alert: mock.MagicMock,
+        geography_code: str,
+        geography_name: str,
+        geography_type_name: str,
+        topic: str,
+        metric: str,
+    ):
+        """
+        Given a valid payload including geography code, geograpny name, topic and metric names
+        When when the `get_detailed_data_for_alert()` method is called
+        Then the `WeatherHealthAlertsInterface.build_detailed_data_for_alert()` method is called.
+        """
+        # Given
+        fake_geography_code = geography_code
+        fake_geography_name = geography_name
+        fake_topic = topic
+        fake_metric = metric
+        fake_geography_type_name = geography_type_name
+
+        # When
+        get_detailed_data_for_alert(
+            geography_code=fake_geography_code,
+            geography_name=fake_geography_name,
+            geography_type_name=fake_geography_type_name,
+            topic_name=fake_topic,
+            metric_name=fake_metric,
+        )
+
+        # Then
+        spy_build_detailed_data_for_alert.assert_called()


### PR DESCRIPTION
# Description

This PR includes: the heat-alert endpoint for weather health alerts feature.

implements:
- /alerts/v1/heat - returns summary of alerts status for each support geography type
- /alerts/v2/heat/<geography_code> - returns a detailed alert for a specified geography

Fixes #CDD-1959

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [x] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
