### PR TITLE
CDD-1945: Update ingestion validation rules for metric value

### DIFF
--- a/ingestion/data_transfer_models/base.py
+++ b/ingestion/data_transfer_models/base.py
@@ -158,8 +158,11 @@ class IncomingBaseDataModel(BaseModel):
 
         """
         input_metric_group: str | None = validation_info.data.get("metric_group")
+        input_topic: str | None = validation_info.data.get("topic")
         return validation.validate_metric(
-            metric=metric, metric_group=input_metric_group
+            metric=metric,
+            metric_group=input_metric_group,
+            topic=input_topic,
         )
 
     @field_validator("refresh_date")

--- a/ingestion/data_transfer_models/validation/metric.py
+++ b/ingestion/data_transfer_models/validation/metric.py
@@ -1,27 +1,87 @@
-def validate_metric(*, metric: str, metric_group: str) -> str:
+MINIMUM_METRIC_SECTION_COUNT = 3
+METRIC_STRUCTURE_VALIDATION_ERROR = "Invalid metric format."
+METRIC_GROUP_VALIDATION_ERROR = "Metric group is not valid for this metric."
+TOPIC_NAME_VALIDATION_ERROR = "The topic name is not valid for this metric."
+METRIC_DETAIL_VALIDATION_ERROR = "Invalid metric, contains special characters."
+
+
+def validate_metric(*, metric: str, metric_group: str, topic: str) -> str:
     """Validates the `metric` value to check it conforms to the accepted format
 
     Args:
         metric: The name of the `metric` being checked
         metric_group: The metric group which was
             included in the payload alongside the metric
+        topic: The topic which was included in the payload
+            alongside the metric
 
     Returns:
-        The input `metric_group` unchanged if
+        The input `metric` unchanged if
         it has passed the validation checks.
 
     Raises:
          `ValueError`: If any of the validation checks fail
-
     """
-    return _validate_metric_group_in_metric(metric=metric, metric_group=metric_group)
+    _validate_metric_structure(metric=metric)
+    _validate_topic_in_metric(metric=metric, topic=topic)
+    _validate_metric_group_in_metric(metric=metric, metric_group=metric_group)
+
+    return metric
 
 
-def _validate_metric_group_in_metric(*, metric: str, metric_group: str) -> str:
+def _validate_metric_structure(*, metric: str) -> None:
+    """Split metric string into sections and validates metric structure.
+        There should be at least 3 parts. `<topic>_<metric_group>_<metric_detail>`
+        and the metric_detail should be alphanumeric.
+
+    Args:
+        metric: the current metric provided as a string
+
+    Returns:
+        None
+    """
+    metric_sections = metric.split("_")
+
+    if len(metric_sections) < MINIMUM_METRIC_SECTION_COUNT:
+        raise ValueError(METRIC_STRUCTURE_VALIDATION_ERROR)
+
+    if not "".join(metric_sections[2:]).isalnum():
+        raise ValueError(METRIC_STRUCTURE_VALIDATION_ERROR)
+
+
+def _validate_topic_in_metric(*, metric: str, topic: str) -> None:
+    """Checks that the provided `topic` is in the `metric` name.
+        This check is made case insensitive because some topic names
+        are capitalised.
+
+    Args:
+        metric: The name of the metric being checked
+        topic: The `topic` provided in the payload that
+            the metric is being checked against.
+
+    Returns:
+        None
+    """
     try:
-        if metric_group in metric:
-            return metric
-    except TypeError:
-        raise ValueError
+        if topic.lower() not in metric.lower():
+            raise ValueError(TOPIC_NAME_VALIDATION_ERROR)
+    except (AttributeError, TypeError):
+        raise ValueError(TOPIC_NAME_VALIDATION_ERROR)
 
-    raise ValueError
+
+def _validate_metric_group_in_metric(*, metric: str, metric_group: str) -> None:
+    """Checks that the `metric` contains the provided `metric_group`
+
+    Args:
+        metric: The name of the metric being checked
+        metric_group: The `metric_group` provided in the payload that
+            the metric is being checked against.
+
+    Returns:
+        None
+    """
+    try:
+        if metric_group not in metric:
+            raise ValueError(METRIC_GROUP_VALIDATION_ERROR)
+    except (AttributeError, TypeError):
+        raise ValueError(METRIC_GROUP_VALIDATION_ERROR)

--- a/tests/unit/ingestion/consumer/test_properties.py
+++ b/tests/unit/ingestion/consumer/test_properties.py
@@ -26,15 +26,20 @@ class TestConsumerProperties:
         assert is_headline_data
 
     @pytest.mark.parametrize(
-        "metric, metric_group",
+        "metric, metric_group, topic",
         (
-            ("COVID-19_deaths_ONSByDay", DataSourceFileType.deaths.value),
-            ("COVID-19_cases_casesByDay", DataSourceFileType.cases.value),
-            ("RSV_healthcare_admissionRateByWeek", DataSourceFileType.healthcare.value),
-            ("hMPV_testing_positivityByWeek", DataSourceFileType.testing.value),
+            ("COVID-19_deaths_ONSByDay", DataSourceFileType.deaths.value, "COVID-19"),
+            ("COVID-19_cases_casesByDay", DataSourceFileType.cases.value, "COVID-19"),
+            (
+                "RSV_healthcare_admissionRateByWeek",
+                DataSourceFileType.healthcare.value,
+                "RSV",
+            ),
+            ("hMPV_testing_positivityByWeek", DataSourceFileType.testing.value, "hMPV"),
             (
                 "COVID-19_vaccinations_autumn22_dosesByDay",
                 DataSourceFileType.vaccinations.value,
+                "COVID-19",
             ),
         ),
     )
@@ -42,6 +47,7 @@ class TestConsumerProperties:
         self,
         metric: str,
         metric_group: str,
+        topic: str,
         example_time_series_data: type_hints.INCOMING_DATA_TYPE,
     ):
         """
@@ -54,6 +60,7 @@ class TestConsumerProperties:
         fake_data = example_time_series_data
         fake_data["metric_group"] = metric_group
         fake_data["metric"] = metric
+        fake_data["topic"] = topic
         consumer = Consumer(source_data=fake_data)
 
         # When

--- a/tests/unit/ingestion/data_transfer_models/base/test_validate_child_theme.py
+++ b/tests/unit/ingestion/data_transfer_models/base/test_validate_child_theme.py
@@ -7,11 +7,29 @@ from ingestion.utils.enums import DataSourceFileType, Topic
 
 class TestIncomingBaseValidationForChildTheme:
     @pytest.mark.parametrize(
-        "parent_theme, child_theme, topic",
+        "parent_theme, child_theme, topic, metric, metric_group",
         (
-            ("infectious_disease", "respiratory", "COVID-19"),
-            ("infectious_disease", "vaccine_preventable", "Measles"),
-            ("extreme_event", "weather_alert", "Heat-alert"),
+            (
+                "infectious_disease",
+                "respiratory",
+                "COVID-19",
+                "COVID-19_testing_PCRcountByDay",
+                "testing",
+            ),
+            (
+                "infectious_disease",
+                "vaccine_preventable",
+                "Measles",
+                "measles_cases_casesByOnsetWeek",
+                "cases",
+            ),
+            (
+                "extreme_event",
+                "weather_alert",
+                "Heat-alert",
+                "heat-alert_headline_matrixNumber",
+                "headline",
+            ),
         ),
     )
     def test_child_theme_deemed_valid_infectious_disease(
@@ -19,6 +37,8 @@ class TestIncomingBaseValidationForChildTheme:
         parent_theme: str,
         child_theme: str,
         topic: str,
+        metric: str,
+        metric_group: str,
         valid_payload_for_base_model: dict[str, str],
     ):
         """
@@ -32,6 +52,8 @@ class TestIncomingBaseValidationForChildTheme:
         payload["parent_theme"] = parent_theme
         payload["child_theme"] = child_theme
         payload["topic"] = topic
+        payload["metric"] = metric
+        payload["metric_group"] = metric_group
 
         # When
         incoming_base_validation = IncomingBaseDataModel(**payload)
@@ -40,11 +62,29 @@ class TestIncomingBaseValidationForChildTheme:
         incoming_base_validation.model_validate(incoming_base_validation, strict=True)
 
     @pytest.mark.parametrize(
-        "parent_theme, child_theme, topic",
+        "parent_theme, child_theme, topic, metric, metric_group",
         (
-            ("infectious_disease", "weather_alert", "COVID-19"),
-            ("extreme_event", "respiratory", "Measles"),
-            ("extreme_event", "vaccine_preventable", "Heat-alert"),
+            (
+                "infectious_disease",
+                "weather_alert",
+                "COVID-19",
+                "COVID-19_testing_PCRcountByDay",
+                "testing",
+            ),
+            (
+                "extreme_event",
+                "respiratory",
+                "Measles",
+                "measles_cases_casesByOnsetWeek",
+                "cases",
+            ),
+            (
+                "extreme_event",
+                "vaccine_preventable",
+                "Heat-alert",
+                "heat-alert_headline_matrixNumber",
+                "headline",
+            ),
         ),
     )
     def test_raises_error_when_child_theme_invalid_choice_for_parent_theme(
@@ -52,6 +92,8 @@ class TestIncomingBaseValidationForChildTheme:
         parent_theme: str,
         child_theme: str,
         topic: str,
+        metric: str,
+        metric_group: str,
         valid_payload_for_base_model: dict[str, str],
     ):
         """
@@ -65,6 +107,8 @@ class TestIncomingBaseValidationForChildTheme:
         payload["parent_theme"] = parent_theme
         payload["child_theme"] = child_theme
         payload["topic"] = topic
+        payload["metric"] = metric
+        payload["metric_group"] = metric_group
 
         # When / Then
         with pytest.raises(ValidationError):

--- a/tests/unit/ingestion/data_transfer_models/base/test_validate_metric.py
+++ b/tests/unit/ingestion/data_transfer_models/base/test_validate_metric.py
@@ -5,40 +5,98 @@ from ingestion.data_transfer_models.base import IncomingBaseDataModel
 from ingestion.utils.enums import DataSourceFileType
 
 
-class TestIncomingBaseValidationForMetric:
+class TestIncomingBaseValidationForMetricProperty:
     @pytest.mark.parametrize(
-        "metric, metric_group",
+        "metric, topic, metric_group, parent_theme, child_theme",
         (
-            ("COVID-19_deaths_ONSByDay", DataSourceFileType.deaths.value),
-            ("influenza_headline_positivityLatest", DataSourceFileType.headline.value),
-            ("RSV_healthcare_admissionRateByWeek", DataSourceFileType.healthcare.value),
-            ("hMPV_testing_positivityByWeek", DataSourceFileType.testing.value),
             (
-                "parainfluenza_headline_positivityLatest",
-                DataSourceFileType.headline.value,
+                "COVID-19_deaths_ONSByDay",
+                "COVID-19",
+                DataSourceFileType.deaths.value,
+                "infectious_disease",
+                "respiratory",
             ),
-            ("adenovirus_testing_positivityByWeek", DataSourceFileType.testing.value),
-            ("rhinovirus_headline_positivityLatest", DataSourceFileType.headline.value),
+            (
+                "influenza_headline_positivityLatest",
+                "Influenza",
+                DataSourceFileType.headline.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "RSV_healthcare_admissionRateByWeek",
+                "RSV",
+                DataSourceFileType.healthcare.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "hMPV_testing_positivityByWeek",
+                "hMPV",
+                DataSourceFileType.testing.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "parainfluenza_headline_postitivityLatest",
+                "Parainfluenza",
+                DataSourceFileType.headline.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "adenovirus_testing_positivityByWeek",
+                "Adenovirus",
+                DataSourceFileType.testing.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "rhinovirus_headline_positivityLatest",
+                "Rhinovirus",
+                DataSourceFileType.headline.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "heat-alert_headline_matrixNumber",
+                "Heat-alert",
+                DataSourceFileType.headline.value,
+                "extreme_event",
+                "weather_alert",
+            ),
+            (
+                "cold-alert_headline_matrixNumber",
+                "Cold-alert",
+                DataSourceFileType.headline.value,
+                "extreme_event",
+                "weather_alert",
+            ),
         ),
     )
-    def test_metric_group_in_metric_name_is_deemed_valid(
+    def test_valid_payload_is_deemed_valid(
         self,
         metric: str,
+        topic: str,
         metric_group: str,
+        parent_theme: str,
+        child_theme: str,
         valid_payload_for_base_model: dict[str, str],
     ):
         """
-        Given a payload containing valid `metric` and `metric_group` values
-            where the `metric_group` is in the `metric` name
+        Given a valid payload including matching `topic` and `metric_group`
         When the `IncomingBaseDataModel` model is initialized
         Then model is deemed valid
         """
         # Given
         payload = valid_payload_for_base_model
         payload["metric"] = metric
+        payload["topic"] = topic
         payload["metric_group"] = metric_group
+        payload["parent_theme"] = parent_theme
+        payload["child_theme"] = child_theme
 
-        # / When
+        # When
         incoming_base_validation = IncomingBaseDataModel(**payload)
 
         # Then
@@ -48,40 +106,223 @@ class TestIncomingBaseValidationForMetric:
         )
 
     @pytest.mark.parametrize(
-        "metric, metric_group",
+        "metric, topic, metric_group, parent_theme, child_theme",
         (
-            ("COVID-19_deaths_ONSByDay", DataSourceFileType.cases.value),
-            ("influenza_headline_positivityLatest", DataSourceFileType.testing.value),
-            ("RSV_healthcare_admissionRateByWeek", DataSourceFileType.deaths.value),
-            ("hMPV_testing_positivityByWeek", DataSourceFileType.headline.value),
-            ("parainfluenza_headline_positivityLatest", DataSourceFileType.cases.value),
             (
-                "adenovirus_testing_positivityByWeek",
-                DataSourceFileType.healthcare.value,
+                "COVID-19_deaths_ONSByDay",
+                "Influenza",
+                DataSourceFileType.deaths.value,
+                "infectious_disease",
+                "respiratory",
             ),
             (
-                "rhinovirus_headline_positivityLatest",
-                DataSourceFileType.vaccinations.value,
+                "influenza_headline_positivityLatest",
+                "COVID-19",
+                DataSourceFileType.headline.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "RSV_healthcare_admissionRateByWeek",
+                "Influenza",
+                DataSourceFileType.healthcare.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "heat-alert_headline_matrixNumber",
+                "Cold-alert",
+                DataSourceFileType.headline.value,
+                "extreme_event",
+                "weather_alert",
             ),
         ),
     )
-    def test_when_metric_group_not_in_metric_name_error_is_thrown(
+    def test_when_topic_not_in_metric_an_error_is_thrown(
         self,
         metric: str,
+        topic: str,
         metric_group: str,
+        parent_theme: str,
+        child_theme: str,
         valid_payload_for_base_model: dict[str, str],
     ):
         """
-        Given a payload containing a `metric` name
-            which does not include the given `metric_group`
+        Given a `metric` that does not contain the given `topic` name
         When the `IncomingBaseDataModel` model is initialized
-        Then a `ValidationError` is raised
+        Then and `ValueError` is thrown
         """
         # Given
         payload = valid_payload_for_base_model
         payload["metric"] = metric
+        payload["topic"] = topic
         payload["metric_group"] = metric_group
+        payload["parent_theme"] = parent_theme
+        payload["child_theme"] = child_theme
 
-        # When
+        # When / Then
+        with pytest.raises(ValidationError):
+            IncomingBaseDataModel(**payload)
+
+    @pytest.mark.parametrize(
+        "metric, topic, metric_group, parent_theme, child_theme",
+        (
+            (
+                "COVID-19_deaths_ONSByDay",
+                "COVID-19",
+                DataSourceFileType.headline.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "influenza_headline_positivityLatest",
+                "Influenza",
+                DataSourceFileType.cases.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "RSV_healthcare_admissionRateByWeek",
+                "RSV",
+                DataSourceFileType.headline.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "heat-alert_headline_matrixNumber",
+                "Heat-alert",
+                DataSourceFileType.deaths.value,
+                "extreme_event",
+                "weather_alert",
+            ),
+        ),
+    )
+    def test_when_metric_group_not_in_metric_an_error_is_thrown(
+        self,
+        metric: str,
+        topic: str,
+        metric_group: str,
+        parent_theme: str,
+        child_theme: str,
+        valid_payload_for_base_model: dict[str, str],
+    ):
+        """
+        Given a `metric` that does not contain the given `metric_group`
+        When the `IncomingBaseDataModel` model is initialized
+        Then and `ValueError` is thrown
+        """
+        # Given
+        payload = valid_payload_for_base_model
+        payload["metric"] = metric
+        payload["topic"] = topic
+        payload["metric_group"] = metric_group
+        payload["parent_theme"] = parent_theme
+        payload["child_theme"] = child_theme
+
+        # When / Then
+        with pytest.raises(ValidationError):
+            IncomingBaseDataModel(**payload)
+
+    @pytest.mark.parametrize(
+        "metric, topic, metric_group, parent_theme, child_theme",
+        (
+            (
+                "COVID-19_deaths_ONS-ByDay",
+                "COVID-19",
+                DataSourceFileType.deaths.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "influenza_headline_positivity&Latest",
+                "Influenza",
+                DataSourceFileType.headline.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "RSV_healthcare_admissionRateByWeek$!_invalid",
+                "RSV",
+                DataSourceFileType.healthcare.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "heat-alert_headline_matrix-Number",
+                "Heat-alert",
+                DataSourceFileType.headline.value,
+                "extreme_event",
+                "weather_alert",
+            ),
+        ),
+    )
+    def test_when_metric_includes_special_characters_an_error_is_thrown(
+        self,
+        metric: str,
+        topic: str,
+        metric_group: str,
+        parent_theme: str,
+        child_theme: str,
+        valid_payload_for_base_model: dict[str, str],
+    ):
+        """
+        Given an invalid `metric` where the `metric_detail` is not alphanumeric
+            and includes special characters apart from `_`.
+        When the `IncomingBaseDataModel` model is initialized
+        Then and `ValueError` is thrown
+        """
+        # Given
+        payload = valid_payload_for_base_model
+        payload["metric"] = metric
+        payload["topic"] = topic
+        payload["metric_group"] = metric_group
+        payload["parent_theme"] = parent_theme
+        payload["child_theme"] = child_theme
+
+        # When / Then
+        with pytest.raises(ValidationError):
+            IncomingBaseDataModel(**payload)
+
+    @pytest.mark.parametrize(
+        "metric, topic, metric_group, parent_theme, child_theme",
+        (
+            (
+                "COVID-19_deaths",
+                "COVID-19",
+                DataSourceFileType.deaths.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+            (
+                "influenza_headline",
+                "Influenza",
+                DataSourceFileType.headline.value,
+                "infectious_disease",
+                "respiratory",
+            ),
+        ),
+    )
+    def test_when_incorrect_metric_structure_error_is_thrown(
+        self,
+        metric: str,
+        topic: str,
+        metric_group: str,
+        parent_theme: str,
+        child_theme: str,
+        valid_payload_for_base_model: dict[str, str],
+    ):
+        """
+        Given an invalid metric that does not include 3 or more sections
+        When the `IncomingBaseDataModel` model is initialized
+        Then and `ValueError` is thrown
+        """
+        payload = valid_payload_for_base_model
+        payload["metric"] = metric
+        payload["topic"] = topic
+        payload["metric_group"] = metric_group
+        payload["parent_theme"] = parent_theme
+        payload["child_theme"] = child_theme
+
+        # When / Then
         with pytest.raises(ValidationError):
             IncomingBaseDataModel(**payload)

--- a/tests/unit/ingestion/test_file_ingestion.py
+++ b/tests/unit/ingestion/test_file_ingestion.py
@@ -45,15 +45,20 @@ class TestDataIngester:
         spy_create_core_and_api_timeseries.assert_not_called()
 
     @pytest.mark.parametrize(
-        "metric, metric_group",
+        "metric, metric_group, topic",
         (
-            ("COVID-19_deaths_ONSByDay", DataSourceFileType.deaths.value),
-            ("COVID-19_cases_casesByDay", DataSourceFileType.cases.value),
-            ("RSV_healthcare_admissionRateByWeek", DataSourceFileType.healthcare.value),
-            ("hMPV_testing_positivityByWeek", DataSourceFileType.testing.value),
+            ("COVID-19_deaths_ONSByDay", DataSourceFileType.deaths.value, "COVID-19"),
+            ("COVID-19_cases_casesByDay", DataSourceFileType.cases.value, "COVID-19"),
+            (
+                "RSV_healthcare_admissionRateByWeek",
+                DataSourceFileType.healthcare.value,
+                "RSV",
+            ),
+            ("hMPV_testing_positivityByWeek", DataSourceFileType.testing.value, "hMPV"),
             (
                 "COVID-19_vaccinations_autumn22_dosesByDay",
                 DataSourceFileType.vaccinations.value,
+                "COVID-19",
             ),
         ),
     )
@@ -65,6 +70,7 @@ class TestDataIngester:
         spy_create_core_headlines: mock.MagicMock,
         metric: str,
         metric_group: str,
+        topic: str,
         example_time_series_data: type_hints.INCOMING_DATA_TYPE,
     ):
         """
@@ -78,6 +84,7 @@ class TestDataIngester:
         fake_data = example_time_series_data
         fake_data["metric"] = metric
         fake_data["metric_group"] = metric_group
+        fake_data["topic"] = topic
 
         # When
         data_ingester(data=fake_data)


### PR DESCRIPTION
# Description

This PR includes: Updates to ingestion pipeline validation for metric field

- Checks the metric conforms to the correct structure `<topic>_<metric_group>_<metric_detail>`
- Checks the provided `topic` is part of the metric
- Checks the provided `metric_group` is part of the metric
- Checks the metric doesn't contain special characters apart from underscores `_`

Fixes #CDD-1945

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
