### PR TITLE
Bug/date timezones for data/cdd 2004

### DIFF
--- a/ingestion/data_transfer_models/validation/dates.py
+++ b/ingestion/data_transfer_models/validation/dates.py
@@ -1,10 +1,10 @@
 import datetime
 
-from django.utils import timezone
+import pytz
 
 
 def cast_date_to_uk_timezone(*, date_value: datetime.datetime) -> datetime.datetime:
-    """Casts the inbound `date_value` to the London timezone
+    """Casts the inbound `date_value`
 
     Args:
         date_value: The inbound date
@@ -12,15 +12,15 @@ def cast_date_to_uk_timezone(*, date_value: datetime.datetime) -> datetime.datet
 
     Returns:
         A `datetime` object which has the timezone
-        info set to the declared `TIMEZONE` as per
-        the main django settings
+        info set to UTC
 
     """
     if date_value is None:
         return date_value
 
+    utc_tz = pytz.timezone("UTC")
     try:
-        return timezone.make_aware(value=date_value)
+        return utc_tz.localize(dt=date_value).astimezone(tz=pytz.UTC)
     except ValueError:
         # This is already time zone aware
         return date_value

--- a/ingestion/data_transfer_models/validation/dates.py
+++ b/ingestion/data_transfer_models/validation/dates.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 
 
 def cast_date_to_uk_timezone(*, date_value: datetime.datetime) -> datetime.datetime:
-    """Casts the inbound `date_value`
+    """Casts the inbound `date_value` to the London timezone
 
     Args:
         date_value: The inbound date
@@ -12,7 +12,8 @@ def cast_date_to_uk_timezone(*, date_value: datetime.datetime) -> datetime.datet
 
     Returns:
         A `datetime` object which has the timezone
-        info set to UTC
+        info set to the declared `TIMEZONE` as per
+        the main django settings
 
     """
     if date_value is None:

--- a/ingestion/data_transfer_models/validation/dates.py
+++ b/ingestion/data_transfer_models/validation/dates.py
@@ -1,6 +1,6 @@
 import datetime
 
-import pytz
+from django.utils import timezone
 
 
 def cast_date_to_uk_timezone(*, date_value: datetime.datetime) -> datetime.datetime:
@@ -18,9 +18,8 @@ def cast_date_to_uk_timezone(*, date_value: datetime.datetime) -> datetime.datet
     if date_value is None:
         return date_value
 
-    utc_tz = pytz.timezone("UTC")
     try:
-        return utc_tz.localize(dt=date_value).astimezone(tz=pytz.UTC)
+        return timezone.make_aware(value=date_value)
     except ValueError:
         # This is already time zone aware
         return date_value

--- a/metrics/api/settings/backend_utility_worker.py
+++ b/metrics/api/settings/backend_utility_worker.py
@@ -2,6 +2,7 @@ import config
 
 CACHES = {
     "default": {
+        "TIME_ZONE": "Europe/London",
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
         "LOCATION": config.REDIS_HOST,
         "KEY_PREFIX": "ukhsa",

--- a/metrics/api/settings/default.py
+++ b/metrics/api/settings/default.py
@@ -147,6 +147,7 @@ ROOT_LEVEL_BASE_DIR = BASE_DIR.parent
 
 DATABASES = {
     "default": {
+        "TIME_ZONE": "Europe/London",
         "ENGINE": "dj_db_conn_pool.backends.postgresql",
         "NAME": config.POSTGRES_DB,
         "USER": config.POSTGRES_USER,

--- a/metrics/api/settings/ingestion.py
+++ b/metrics/api/settings/ingestion.py
@@ -2,6 +2,7 @@ import config
 
 DATABASES = {
     "default": {
+        "TIME_ZONE": "Europe/London",
         "ENGINE": "django.db.backends.postgresql",
         "NAME": config.POSTGRES_DB,
         "USER": config.POSTGRES_USER,

--- a/metrics/api/settings/local.py
+++ b/metrics/api/settings/local.py
@@ -6,6 +6,7 @@ DEBUG = True
 
 DATABASES = {
     "default": {
+        "TIME_ZONE": "Europe/London",
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": os.path.join(ROOT_LEVEL_BASE_DIR, "db.sqlite3"),
     }

--- a/metrics/api/settings/standalone.py
+++ b/metrics/api/settings/standalone.py
@@ -4,6 +4,7 @@ from metrics.api.settings import ROOT_LEVEL_BASE_DIR
 
 DATABASES = {
     "default": {
+        "TIME_ZONE": "Europe/London",
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": os.path.join(ROOT_LEVEL_BASE_DIR, "db.sqlite3"),
     }


### PR DESCRIPTION
# Description

This PR includes the following:

- Sets the timezone on the database to be europe/london. This means datetime objects which are stored as UTC are converted to the London timezone when accessed

Fixes #CDD-2004

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
