### PR TITLE
Allow alphanumeric geography codes for NHS trust

### DIFF
--- a/ingestion/data_transfer_models/validation/geography_code.py
+++ b/ingestion/data_transfer_models/validation/geography_code.py
@@ -96,7 +96,7 @@ def _validate_nhs_trust_geography_code(*, geography_code: str) -> str:
     if len(geography_code) not in allowable_nhs_trust_code_lengths:
         raise ValueError
 
-    if not geography_code[0].isalpha():
+    if not geography_code.isalnum():
         raise ValueError
 
     return geography_code

--- a/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_code.py
+++ b/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_code.py
@@ -24,6 +24,7 @@ class TestIncomingBaseValidationForNHSTrustGeographyCode:
             "NRN01",
             "DN703",
             "NMJ0Y",
+            "8CM63"
         ),
     )
     def test_valid_geography_code_validates_successfully(
@@ -100,24 +101,6 @@ class TestIncomingBaseValidationForNHSTrustGeographyCode:
         payload = valid_payload_for_base_model
         payload["geography_type"] = enums.GeographyType.NHS_TRUST.value
         payload["geography_code"] = geography_code
-
-        # When / Then
-        with pytest.raises(ValidationError):
-            IncomingBaseDataModel(**payload)
-
-    def test_geography_code_must_start_with_letter(
-        self, valid_payload_for_base_model: dict[str, str]
-    ):
-        """
-        Given a `geography_code` which does not start with a letter
-            for the "NHS Trust" `geography_type`
-        When the `IncomingBaseDataModel` model is initialized
-        Then a `ValidationError` is raised
-        """
-        # Given
-        payload = valid_payload_for_base_model
-        payload["geography_type"] = enums.GeographyType.NHS_TRUST.value
-        payload["geography_code"] = "2M3"
 
         # When / Then
         with pytest.raises(ValidationError):


### PR DESCRIPTION
# Description

This PR includes the following:

- Updates validation rules to allow alphanumeric strings for the geography code of NHS trust geography types

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
