### PR TITLE
Remove unused `blocks_count` restriction for deprecated `button` stream field block

### DIFF
--- a/cms/dynamic_content/access.py
+++ b/cms/dynamic_content/access.py
@@ -51,6 +51,5 @@ ALLOWABLE_BODY_CONTENT_COMPOSITE = StreamField(
             ),
         ),
     ],
-    block_counts={"button": {"max_num": 1}},
     use_json_field=True,
 )


### PR DESCRIPTION
# Description

This PR includes the following:

- Fixes a key error being thrown when publishing composite pages in the CMS due to reference to deprecated `button` snippet

Fixes #CDD-2021

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
