### PR TITLE
Add base templates for weather health alert pages

### DIFF
--- a/cms/dashboard/management/commands/build_cms_site.py
+++ b/cms/dashboard/management/commands/build_cms_site.py
@@ -318,6 +318,16 @@ class Command(BaseCommand):
 
         create_metrics_documentation_parent_page_and_child_entries()
 
+        weather_health_alerts_page = _create_composite_page(
+            name="weather_health_alerts", parent_page=root_page
+        )
+        _create_composite_page(
+            name="heat_health_alerts", parent_page=weather_health_alerts_page
+        )
+        _create_composite_page(
+            name="cold_health_alerts", parent_page=weather_health_alerts_page
+        )
+
     @staticmethod
     def _clear_cms() -> None:
         # Wipe the existing site, pages & badges

--- a/cms/dashboard/templates/cms_starting_pages/cold_health_alerts.json
+++ b/cms/dashboard/templates/cms_starting_pages/cold_health_alerts.json
@@ -1,0 +1,62 @@
+{
+  "id": 22,
+  "meta": {
+    "seo_title": "",
+    "search_description": "",
+    "type": "composite.CompositePage",
+    "detail_url": "http://localhost/api/pages/22/",
+    "html_url": null,
+    "slug": "cold",
+    "show_in_menus": false,
+    "first_published_at": "2024-06-13T14:46:10.806672+01:00",
+    "alias_of": null,
+    "parent": {
+      "id": 20,
+      "meta": {
+        "type": "composite.CompositePage",
+        "detail_url": "http://localhost/api/pages/20/",
+        "html_url": null
+      },
+      "title": "Weather health alerts"
+    }
+  },
+  "title": "Cold health alerts",
+  "date_posted": "2024-06-13",
+  "body": [
+    {
+      "type": "text",
+      "value": "<p data-block-key=\"v7ca2\">The Cold-health alerting systems core alerting seasons runs from 1  November to 31 March each year. However should an episode of cold occur  outside of this core period, an extraordinary alert will be issued. Make  sure you are registered to <a href=\"https://www.gov.uk/guidance/weather-health-alerting-system\">receive the alerts directly by email</a> by completing the registration form.</p>",
+      "id": "d87e7aaf-3ebc-4589-ab17-69ef19a0359f"
+    }
+  ],
+  "last_published_at": "2024-06-13T14:46:10.806672+01:00",
+  "related_links": [
+    {
+      "id": 7,
+      "meta": {
+        "type": "composite.CompositeRelatedLink"
+      },
+      "title": "Cold-Health Alert action card for the voluntary and community sector",
+      "url": "https://www.gov.uk/government/publications/cold-weather-plan-action-cards-for-cold-weather-alert-service/cold-health-alert-action-card-for-the-voluntary-and-community-sector",
+      "body": ""
+    },
+    {
+      "id": 8,
+      "meta": {
+        "type": "composite.CompositeRelatedLink"
+      },
+      "title": "Cold-Health Alert action card for commissioners",
+      "url": "https://www.gov.uk/government/publications/cold-weather-plan-action-cards-for-cold-weather-alert-service/cold-health-alert-action-card-for-commissioners",
+      "body": ""
+    },
+    {
+      "id": 9,
+      "meta": {
+        "type": "composite.CompositeRelatedLink"
+      },
+      "title": "Cold-Health Alert action card for health and social care providers",
+      "url": "https://www.gov.uk/government/publications/cold-weather-plan-action-cards-for-cold-weather-alert-service/cold-health-alert-action-card-for-health-and-social-care-providers",
+      "body": ""
+    }
+  ]
+}

--- a/cms/dashboard/templates/cms_starting_pages/heat_health_alerts.json
+++ b/cms/dashboard/templates/cms_starting_pages/heat_health_alerts.json
@@ -1,0 +1,71 @@
+{
+  "id": 21,
+  "meta": {
+    "seo_title": "",
+    "search_description": "",
+    "type": "composite.CompositePage",
+    "detail_url": "http://localhost/api/pages/21/",
+    "html_url": null,
+    "slug": "heat",
+    "show_in_menus": false,
+    "first_published_at": "2024-06-13T14:45:00.866817+01:00",
+    "alias_of": null,
+    "parent": {
+      "id": 20,
+      "meta": {
+        "type": "composite.CompositePage",
+        "detail_url": "http://localhost/api/pages/20/",
+        "html_url": null
+      },
+      "title": "Weather health alerts"
+    }
+  },
+  "title": "Heat health alerts",
+  "date_posted": "2024-06-13",
+  "body": [
+    {
+      "type": "text",
+      "value": "<p data-block-key=\"a2j7a\">The Heat-health alerting systems core alerting seasons runs from 1 June  to 30 September each year. However should an episode of heat occur  outside of this core period, an extraordinary alert will be issued. Make  sure you are registered to <a href=\"https://www.gov.uk/guidance/weather-health-alerting-system\">receive the alerts directly by email</a> by completing the registration form.</p>",
+      "id": "afe12fef-ad3d-4296-a037-c7dec27ae345"
+    }
+  ],
+  "last_published_at": "2024-06-13T14:45:00.866817+01:00",
+  "related_links": [
+    {
+      "id": 3,
+      "meta": {
+        "type": "composite.CompositeRelatedLink"
+      },
+      "title": "Heat-Health Alert action card for the voluntary and community sector",
+      "url": "https://www.gov.uk/government/publications/hot-weather-and-health-action-cards/heat-health-alert-action-card-for-the-voluntary-and-community-sector",
+      "body": ""
+    },
+    {
+      "id": 4,
+      "meta": {
+        "type": "composite.CompositeRelatedLink"
+      },
+      "title": "Heat-Health Alert action card for commissioners",
+      "url": "https://www.gov.uk/government/publications/hot-weather-and-health-action-cards/heat-health-alert-action-card-for-commissioners",
+      "body": ""
+    },
+    {
+      "id": 5,
+      "meta": {
+        "type": "composite.CompositeRelatedLink"
+      },
+      "title": "Heat-Health Alert action card for health and social care providers",
+      "url": "https://www.gov.uk/government/publications/hot-weather-and-health-action-cards/heat-health-alert-action-card-for-providers",
+      "body": ""
+    },
+    {
+      "id": 6,
+      "meta": {
+        "type": "composite.CompositeRelatedLink"
+      },
+      "title": "Heat-Health Alert action card for national government",
+      "url": "https://www.gov.uk/government/publications/hot-weather-and-health-action-cards/heat-health-alert-action-card-for-national-government",
+      "body": ""
+    }
+  ]
+}

--- a/cms/dashboard/templates/cms_starting_pages/weather_health_alerts.json
+++ b/cms/dashboard/templates/cms_starting_pages/weather_health_alerts.json
@@ -1,0 +1,53 @@
+{
+  "id": 20,
+  "meta": {
+    "seo_title": "",
+    "search_description": "",
+    "type": "composite.CompositePage",
+    "detail_url": "http://localhost/api/pages/20/",
+    "html_url": null,
+    "slug": "weather-health-alerts",
+    "show_in_menus": false,
+    "first_published_at": "2024-06-13T12:48:22.921116+01:00",
+    "alias_of": null,
+    "parent": {
+      "id": 3,
+      "meta": {
+        "type": "home.HomePage",
+        "detail_url": "http://localhost/api/pages/3/",
+        "html_url": null
+      },
+      "title": "UKHSA Dashboard Root"
+    }
+  },
+  "title": "Weather health alerts",
+  "date_posted": "2024-06-13",
+  "body": [
+    {
+      "type": "text",
+      "value": "<p data-block-key=\"twijc\">The alerting system provides an early warning when adverse temperatures are  likely to impact on the health and wellbeing of the population.</p><p data-block-key=\"dqqeg\">The  Weather health alerting system is provided by the UK Health Security  Agency (UKHSA) in partnership with the Met Office. It&#x27;s intended to  provide early warning to the health and social care sector, the  responder community, the voluntary and community sector and government  departments when adverse temperatures are likely to impact on the health  and wellbeing of the population. The Weather health alerting system is  made up of the Heat-Health Alerts (HHA) and Cold-Health Alerts (CHA).  The Weather health alerting system underpins the Adverse Weather and  Health Plan.</p><p data-block-key=\"4bsqg\">The core alerting season for the  HHA runs from 1 June to 30 September, with the core alerting season for  CHA running from 1 November to 31 March. Should a period of heat or cold  occur that meets alerting criteria outside of the core alerting  periods, an extraordinary alert will be issued.</p>",
+      "id": "900a4ddb-c79f-414f-b496-97b426b240df"
+    }
+  ],
+  "last_published_at": "2024-06-13T14:43:16.909480+01:00",
+  "related_links": [
+    {
+      "id": 1,
+      "meta": {
+        "type": "composite.CompositeRelatedLink"
+      },
+      "title": "Cold weather and Health: supporting vulnerable people",
+      "url": "https://www.gov.uk/government/publications/cold-weather-and-health-supporting-vulnerable-people",
+      "body": ""
+    },
+    {
+      "id": 2,
+      "meta": {
+        "type": "composite.CompositeRelatedLink"
+      },
+      "title": "Hot weather and Health: supporting vulnerable people",
+      "url": "https://www.gov.uk/government/publications/hot-weather-and-health-supporting-vulnerable-people",
+      "body": ""
+    }
+  ]
+}


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds the weather health alert pages to the templates so they are prepopulated when building dev/test envs

Fixes #CDD-2020

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
