### PR TITLE
Add `tag_manager_event_id` field to chart cards

### DIFF
--- a/cms/dynamic_content/cards.py
+++ b/cms/dynamic_content/cards.py
@@ -42,6 +42,11 @@ class HeadlineNumbersRowCard(blocks.StructBlock):
 class ChartWithHeadlineAndTrendCard(blocks.StructBlock):
     title = blocks.TextBlock(required=True, help_text=help_texts.TITLE_FIELD)
     body = blocks.TextBlock(required=False, help_text=help_texts.OPTIONAL_BODY_FIELD)
+    tag_manager_event_id = blocks.CharBlock(
+        required=False,
+        help_text=help_texts.TAG_MANAGER_EVENT_ID_FIELD,
+        label="Tag manager event ID",
+    )
     x_axis = blocks.ChoiceBlock(
         required=False,
         choices=get_possible_axis_choices,
@@ -69,6 +74,11 @@ class ChartWithHeadlineAndTrendCard(blocks.StructBlock):
 class ChartCard(blocks.StructBlock):
     title = blocks.TextBlock(required=True, help_text=help_texts.TITLE_FIELD)
     body = blocks.TextBlock(required=False, help_text=help_texts.OPTIONAL_BODY_FIELD)
+    tag_manager_event_id = blocks.CharBlock(
+        required=False,
+        help_text=help_texts.TAG_MANAGER_EVENT_ID_FIELD,
+        label="Tag manager event ID",
+    )
     x_axis = blocks.ChoiceBlock(
         required=False,
         choices=get_possible_axis_choices,

--- a/cms/dynamic_content/help_texts.py
+++ b/cms/dynamic_content/help_texts.py
@@ -214,3 +214,9 @@ Note that only 1 global banner can be active at a time.
 To switch from 1 active banner straight to another, 
 you must deactivate the 1st banner and save it before activating and saving the 2nd banner.
 """
+
+TAG_MANAGER_EVENT_ID_FIELD: str = """
+The ID to associate with this component. 
+This allows for tracking of events when users interact with this component.
+Note that changing this multiple times will result in the recording of different groups of events.
+"""


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds a new optional field, `tag_manager_event_id` to the chart cards in the CMS

Fixes #CDD-1934

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
