### PR TITLE
Set `detail_only_fields` to empty list allow `parent` field to be queryable from list endpoint

### DIFF
--- a/cms/dashboard/viewsets.py
+++ b/cms/dashboard/viewsets.py
@@ -14,6 +14,7 @@ class CMSPagesAPIViewSet(PagesAPIViewSet):
     permission_classes = []
     base_serializer_class = ListablePageSerializer
     listing_default_fields = PagesAPIViewSet.listing_default_fields + ["show_in_menus"]
+    detail_only_fields = []
 
     @cache_response()
     def listing_view(self, request: Request) -> Response:


### PR DESCRIPTION
# Description

This PR includes the following:

- Allow the `parent` field to be queryable via `?fields=parent` on the list endpoint

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
