### PR TITLE
Removing redis caching on weather health alert endpoints

### DIFF
--- a/metrics/api/views/alerts.py
+++ b/metrics/api/views/alerts.py
@@ -2,7 +2,6 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import viewsets
 from rest_framework.response import Response
 
-from caching.private_api.decorators import cache_response
 from metrics.api.enums import Alerts
 from metrics.api.serializers.geographies_alerts import GeographiesForAlertsSerializer
 from metrics.interfaces.weather_health_alerts.access import (
@@ -11,7 +10,6 @@ from metrics.interfaces.weather_health_alerts.access import (
 )
 
 ALERTS_API_TAG = "alerts"
-FIVE_MINUTES_AS_SECONDS = 60 * 5
 
 
 @extend_schema(tags=[ALERTS_API_TAG])
@@ -26,7 +24,6 @@ class BaseAlertViewSet(viewsets.ReadOnlyModelViewSet):
     def metric_name(self) -> str:
         raise NotImplementedError
 
-    @cache_response(timeout=FIVE_MINUTES_AS_SECONDS)
     def list(self, request, *args, **kwargs):
         topic_name: str = self.topic_name
         metric_name: str = self.metric_name
@@ -41,7 +38,6 @@ class BaseAlertViewSet(viewsets.ReadOnlyModelViewSet):
 
         return Response(data=summary_data)
 
-    @cache_response(timeout=FIVE_MINUTES_AS_SECONDS)
     def retrieve(self, request, *args, **kwargs):
         topic_name: str = self.topic_name
         metric_name: str = self.metric_name


### PR DESCRIPTION
# Description

This PR includes the following:

- No longer caches the wha endpoints 

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
