### PR TITLE
Stub out problematic `geography_code` field on `WeatherAlertButton` model

### DIFF
--- a/cms/metrics_interface/field_choices_callables.py
+++ b/cms/metrics_interface/field_choices_callables.py
@@ -279,10 +279,7 @@ def get_all_geography_names_and_codes_for_alerts() -> LIST_OF_TWO_STRING_ITEM_TU
             [('North East', 'E06000001'), ('North West', 'E06000002')]
 
     """
-    metrics_interface = MetricsAPIInterface()
-    return metrics_interface.get_all_geography_names_and_codes_by_geography_type(
-        geography_type=GEOGRAPHY_TYPE_NAME_FOR_ALERTS,
-    )
+    return []
 
 
 def get_all_geography_type_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:

--- a/cms/metrics_interface/field_choices_callables.py
+++ b/cms/metrics_interface/field_choices_callables.py
@@ -261,7 +261,7 @@ def get_all_geography_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
     )
 
 
-def get_all_geography_names_and_codes_for_alerts() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
+def get_all_geography_names_and_codes_for_alerts() -> list:
     """This field has been stubbed out to prevent the caller from preemptively referencing the `Geography` table"""
     return []
 

--- a/cms/metrics_interface/field_choices_callables.py
+++ b/cms/metrics_interface/field_choices_callables.py
@@ -262,23 +262,7 @@ def get_all_geography_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
 
 
 def get_all_geography_names_and_codes_for_alerts() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
-    """Callable for the `choices` on the `geography_code` fields of the CMS blocks.
-
-    Notes:
-        This callable wraps the `MetricsAPIInterface`
-        and is passed to a migration for the CMS blocks.
-        This means that we don't need to create a new migration
-        whenever a new `Geography` is added to that table.
-        Instead, the 1-off migration is pointed at this callable.
-        So Wagtail will pull the choices by invoking this function.
-
-    Returns:
-        A list of 2-item tuples of `geography_name` used for human readable
-        value and the `geography_code` used as the value stored in the db.
-        Examples:
-            [('North East', 'E06000001'), ('North West', 'E06000002')]
-
-    """
+    """This field has been stubbed out to prevent the caller from preemptively referencing the `Geography` table"""
     return []
 
 

--- a/cms/snippets/models/wha_button.py
+++ b/cms/snippets/models/wha_button.py
@@ -33,17 +33,12 @@ class WeatherAlertButton(models.Model):
     panels = [
         FieldPanel("text"),
         FieldPanel("button_type"),
-        FieldPanel("geography_code"),
     ]
 
     api_fields = [
         APIField("text"),
         APIField("button_type"),
-        APIField("geography_code"),
     ]
 
     def __str__(self) -> str:
-        if not self.geography_code:
-            return f"Text: {self.text} | Type: {self.button_type}"
-
-        return f"Text: {self.text} | Type: {self.button_type} | {self.geography_code}"
+        return f"Text: {self.text} | Type: {self.button_type}"

--- a/tests/unit/cms/metrics_interface/test_field_choices_callables.py
+++ b/tests/unit/cms/metrics_interface/test_field_choices_callables.py
@@ -254,6 +254,35 @@ class TestGetAllGeographyNames:
         assert geographies_names == [(x, x) for x in retrieved_geography_names]
 
 
+class TestGetAllGeographyNamesAndCodesForAlerts:
+    @mock.patch.object(
+        interface.MetricsAPIInterface,
+        "get_all_geography_names_and_codes_by_geography_type",
+    )
+    def test_delegates_call_correctly(
+        self,
+        mocked_get_all_geography_names_and_codes_by_geography_type: mock.MagicMock,
+    ):
+        """
+        Given an instance of the `MetricsAPIInterface` which returns geography types and codes
+        When `get_all_geography_names_and_codes_for_alerts()` is called
+        Then an empty list is returned for the stubbed call.
+        """
+        # Given
+        retrieved_geography_names_and_codes = []
+        mocked_get_all_geography_names_and_codes_by_geography_type.return_value = (
+            retrieved_geography_names_and_codes
+        )
+
+        # When
+        geography_names_and_codes = (
+            field_choices_callables.get_all_geography_names_and_codes_for_alerts()
+        )
+
+        # Then
+        assert geography_names_and_codes == retrieved_geography_names_and_codes
+
+
 class TestGetAllGeographyTypeNames:
     @mock.patch.object(interface.MetricsAPIInterface, "get_all_geography_type_names")
     def test_delegates_call_correctly(

--- a/tests/unit/cms/metrics_interface/test_field_choices_callables.py
+++ b/tests/unit/cms/metrics_interface/test_field_choices_callables.py
@@ -254,38 +254,6 @@ class TestGetAllGeographyNames:
         assert geographies_names == [(x, x) for x in retrieved_geography_names]
 
 
-class TestGetAllGeographyNamesAndCodesForAlerts:
-    @mock.patch.object(
-        interface.MetricsAPIInterface,
-        "get_all_geography_names_and_codes_by_geography_type",
-    )
-    def test_delegates_call_correctly(
-        self,
-        mocked_get_all_geography_names_and_codes_by_geography_type: mock.MagicMock,
-    ):
-        """
-        Given an instance of the `MetricsAPIInterface` which returns geography types and codes
-        When `get_all_geography_names_and_codes_for_alerts()` is called
-        Then the geography names and codes are returned as a list of tuples.
-        """
-        # Given
-        retrieved_geography_names_and_codes = [
-            ("North East", "E12000001"),
-            ("North West", "E12000002"),
-        ]
-        mocked_get_all_geography_names_and_codes_by_geography_type.return_value = (
-            retrieved_geography_names_and_codes
-        )
-
-        # When
-        geography_names_and_codes = (
-            field_choices_callables.get_all_geography_names_and_codes_for_alerts()
-        )
-
-        # Then
-        assert geography_names_and_codes == retrieved_geography_names_and_codes
-
-
 class TestGetAllGeographyTypeNames:
     @mock.patch.object(interface.MetricsAPIInterface, "get_all_geography_type_names")
     def test_delegates_call_correctly(

--- a/tests/unit/cms/snippets/models/test_wha_button.py
+++ b/tests/unit/cms/snippets/models/test_wha_button.py
@@ -46,7 +46,6 @@ class TestWeatherAlertButton:
 
         assert "text" in panel_names
         assert "button_type" in panel_names
-        assert "geography_code" in panel_names
 
     def test_button_is_set_as_snippet(self):
         """


### PR DESCRIPTION
# Description

This PR includes the following:

- Stubs out the callable used for the geography code choices in the WHA button model
- Removes references to the `geography_code` in the WHA button model
- This is currently resulting in a problematic migration whereby django is trying to apply the migration for the choices on the `geography_code` field but the `Geography` table has not yet been migrated since that lives in the metrics app.

Fixes #CDD-2044

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
