### PR TITLE
Task/draw reporting delay period from provided data on charts/cdd 1993

### DIFF
--- a/tests/unit/metrics/domain/models/test_plots.py
+++ b/tests/unit/metrics/domain/models/test_plots.py
@@ -416,14 +416,10 @@ class TestPlotData:
         Then a `ReportingDelayNotProvidedToPlotsError` is raised
         """
         # Given
-        reporting_delay_period_values = [False] * 5
         plot_data = PlotData(
             parameters=fake_chart_plot_parameters,
             x_axis_values=mock.Mock(),
             y_axis_values=mock.Mock(),
-            additional_values={
-                "in_reporting_delay_period": reporting_delay_period_values
-            },
         )
 
         # When / Then


### PR DESCRIPTION
# Description

This PR includes the following:

- When drawing the reporting delay period on charts, extract the first occurence of True i.e the start of the reporting delay period to signify the x point of the section

Fixes #CDD-1993

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
