### PR TITLE
Add validation for `in_reporting_delay_period` values

### DIFF
--- a/ingestion/data_transfer_models/time_series.py
+++ b/ingestion/data_transfer_models/time_series.py
@@ -59,6 +59,22 @@ class TimeSeriesDTO(IncomingBaseDataModel):
         """
         return validation.validate_metric_frequency(metric_frequency=metric_frequency)
 
+    @field_validator("time_series")
+    @classmethod
+    def validate_in_reporting_delay_period_has_trailing_section_only(
+        cls, time_series: list[InboundTimeSeriesSpecificFields]
+    ) -> list[InboundTimeSeriesSpecificFields]:
+        """Validates the `in_reporting_delay_period` values only contain a trailing section."""
+        in_reporting_delay_period_values: list[bool] = [
+            model.in_reporting_delay_period for model in time_series
+        ]
+
+        validation.validate_in_reporting_delay_period(
+            in_reporting_delay_period_values=in_reporting_delay_period_values
+        )
+
+        return time_series
+
 
 def _build_time_series_dto(
     *,

--- a/ingestion/data_transfer_models/validation/__init__.py
+++ b/ingestion/data_transfer_models/validation/__init__.py
@@ -6,3 +6,4 @@ from .metric_frequency import validate_metric_frequency
 from .metric import validate_metric
 from .child_theme import validate_child_theme
 from .topic import validate_topic
+from .in_reporting_delay_period import validate_in_reporting_delay_period

--- a/ingestion/data_transfer_models/validation/in_reporting_delay_period.py
+++ b/ingestion/data_transfer_models/validation/in_reporting_delay_period.py
@@ -16,10 +16,12 @@ def validate_in_reporting_delay_period(
             in the leading section of the list.
 
     """
-    if True not in in_reporting_delay_period_values:
+    try:
+        first_true_index = in_reporting_delay_period_values.index(True)
+    except ValueError:
+        # Raised when there is no `True` value in the list
         return
 
-    first_true_index = in_reporting_delay_period_values.index(True)
     is_valid: bool = all(in_reporting_delay_period_values[first_true_index:])
     if is_valid:
         return

--- a/ingestion/data_transfer_models/validation/in_reporting_delay_period.py
+++ b/ingestion/data_transfer_models/validation/in_reporting_delay_period.py
@@ -1,0 +1,27 @@
+def validate_in_reporting_delay_period(
+    *, in_reporting_delay_period_values: list[bool]
+) -> None:
+    """Validates the `in_reporting_delay_period_values` only contains trailing True values
+
+    Args:
+        in_reporting_delay_period_values: List of booleans
+            which represent the in reporting delay period values
+            associated with each timeseries
+
+    Returns:
+        None
+
+    Raises:
+        `ValueError`: If there are any True values
+            in the leading section of the list.
+
+    """
+    if True not in in_reporting_delay_period_values:
+        return
+
+    first_true_index = in_reporting_delay_period_values.index(True)
+    is_valid: bool = all(in_reporting_delay_period_values[first_true_index:])
+    if is_valid:
+        return
+
+    raise ValueError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,12 +171,14 @@ def example_time_series_data() -> dict[str, str | list[dict[str, str | float]]]:
                 "date": "2022-11-01",
                 "metric_value": 4141.43,
                 "embargo": "2023-11-16 17:30:00",
+                "in_reporting_delay_period": False,
             },
             {
                 "epiweek": 44,
                 "date": "2022-11-02",
                 "metric_value": 3952.14,
                 "embargo": "2023-11-16 17:30:00",
+                "in_reporting_delay_period": False,
             },
         ],
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,14 +171,12 @@ def example_time_series_data() -> dict[str, str | list[dict[str, str | float]]]:
                 "date": "2022-11-01",
                 "metric_value": 4141.43,
                 "embargo": "2023-11-16 17:30:00",
-                "in_reporting_delay_period": False,
             },
             {
                 "epiweek": 44,
                 "date": "2022-11-02",
                 "metric_value": 3952.14,
                 "embargo": "2023-11-16 17:30:00",
-                "in_reporting_delay_period": False,
             },
         ],
     }

--- a/tests/unit/ingestion/data_transfer_models/time_series/test_time_series.py
+++ b/tests/unit/ingestion/data_transfer_models/time_series/test_time_series.py
@@ -294,3 +294,122 @@ class TestTimeSeriesDTO:
                 refresh_date=source_data["refresh_date"],
                 time_series=lower_level_fields,
             )
+
+    def test_in_reporting_delay_period_with_no_true_values_is_deemed_valid(
+        self, example_time_series_data
+    ):
+        """
+        Given a payload containing only False values
+            for the `in_reporting_delay_period` fields
+        When the `TimeSeriesDTO` model is initialized
+        Then the model is deemed valid
+        """
+        # Given
+        source_data = example_time_series_data
+        time_series_data = source_data["time_series"]
+        for data in time_series_data:
+            data["in_reporting_delay_period"] = False
+
+        lower_level_fields = [
+            InboundTimeSeriesSpecificFields(**individual_source_data)
+            for individual_source_data in time_series_data
+        ]
+
+        # When
+        time_series_dto = TimeSeriesDTO(
+            metric_frequency=source_data["metric_frequency"],
+            parent_theme=source_data["parent_theme"],
+            child_theme=source_data["child_theme"],
+            topic=source_data["topic"],
+            metric_group=source_data["metric_group"],
+            metric=source_data["metric"],
+            geography_type=source_data["geography_type"],
+            geography=source_data["geography"],
+            geography_code=source_data["geography_code"],
+            age=source_data["age"],
+            sex=source_data["sex"],
+            stratum=source_data["stratum"],
+            refresh_date=source_data["refresh_date"],
+            time_series=lower_level_fields,
+        )
+
+        # Then
+        time_series_dto.model_validate(time_series_dto)
+
+    def test_in_reporting_delay_period_with_trailing_section_is_deemed_valid(
+        self, example_time_series_data
+    ):
+        """
+        Given a payload containing False values
+            along with trailing True values
+            for the `in_reporting_delay_period` fields
+        When the `TimeSeriesDTO` model is initialized
+        Then the model is deemed valid
+        """
+        # Given
+        source_data = example_time_series_data
+        time_series_data = source_data["time_series"]
+        time_series_data[-1]["in_reporting_delay_period"] = True
+        lower_level_fields = [
+            InboundTimeSeriesSpecificFields(**individual_source_data)
+            for individual_source_data in time_series_data
+        ]
+
+        # When
+        time_series_dto = TimeSeriesDTO(
+            metric_frequency=source_data["metric_frequency"],
+            parent_theme=source_data["parent_theme"],
+            child_theme=source_data["child_theme"],
+            topic=source_data["topic"],
+            metric_group=source_data["metric_group"],
+            metric=source_data["metric"],
+            geography_type=source_data["geography_type"],
+            geography=source_data["geography"],
+            geography_code=source_data["geography_code"],
+            age=source_data["age"],
+            sex=source_data["sex"],
+            stratum=source_data["stratum"],
+            refresh_date=source_data["refresh_date"],
+            time_series=lower_level_fields,
+        )
+
+        # Then
+        time_series_dto.model_validate(time_series_dto)
+
+    def test_in_reporting_delay_period_with_leading_section_is_deemed_invalid(
+        self, example_time_series_data
+    ):
+        """
+        Given a payload containing False values
+            along with leading True values
+            for the `in_reporting_delay_period` fields
+        When the `TimeSeriesDTO` model is initialized
+        Then a `ValidationError` is raised
+        """
+        # Given
+        source_data = example_time_series_data
+        time_series_data = source_data["time_series"]
+        time_series_data[0]["in_reporting_delay_period"] = True
+        lower_level_fields = [
+            InboundTimeSeriesSpecificFields(**individual_source_data)
+            for individual_source_data in time_series_data
+        ]
+
+        # When / Then
+        with pytest.raises(ValidationError):
+            TimeSeriesDTO(
+                metric_frequency=source_data["metric_frequency"],
+                parent_theme=source_data["parent_theme"],
+                child_theme=source_data["child_theme"],
+                topic=source_data["topic"],
+                metric_group=source_data["metric_group"],
+                metric=source_data["metric"],
+                geography_type=source_data["geography_type"],
+                geography=source_data["geography"],
+                geography_code=source_data["geography_code"],
+                age=source_data["age"],
+                sex=source_data["sex"],
+                stratum=source_data["stratum"],
+                refresh_date=source_data["refresh_date"],
+                time_series=lower_level_fields,
+            )

--- a/tests/unit/ingestion/data_transfer_models/validation/test_in_reporting_delay_period.py
+++ b/tests/unit/ingestion/data_transfer_models/validation/test_in_reporting_delay_period.py
@@ -1,0 +1,58 @@
+import pytest
+
+from ingestion.data_transfer_models.validation import validate_in_reporting_delay_period
+
+
+class TestValidateInReportingDelayPeriod:
+
+    @pytest.mark.parametrize(
+        "invalid_in_reporting_delay_period_values",
+        (
+            [True, False, False, True],
+            [True, False, False, False],
+            [False, True, True, False],
+        ),
+    )
+    def test_raises_error_for_invalid_sequences(
+        self, invalid_in_reporting_delay_period_values: list[bool]
+    ):
+        """
+        Given an invalid list of booleans
+            which represent the in reporting delay periods
+        When `validate_in_reporting_delay_period()` is called
+        Then a `ValueError` is raised
+        """
+        # Given
+        reporting_delay_period_values = invalid_in_reporting_delay_period_values
+
+        # When / Then
+        with pytest.raises(ValueError):
+            validate_in_reporting_delay_period(
+                in_reporting_delay_period_values=reporting_delay_period_values
+            )
+
+    @pytest.mark.parametrize(
+        "valid_in_reporting_delay_period_values",
+        (
+            [False, False, False, True],
+            [False, False, False, False],
+            [False, False, True, True],
+            [False, True, True, True],
+        ),
+    )
+    def test_passes_for_valid_sequences(
+        self, valid_in_reporting_delay_period_values: list[bool]
+    ):
+        """
+        Given a valid list of booleans
+            which represent the in reporting delay periods
+        When `validate_in_reporting_delay_period()` is called
+        Then no error is raised
+        """
+        # Given
+        reporting_delay_period_values = valid_in_reporting_delay_period_values
+
+        # When / Then
+        validate_in_reporting_delay_period(
+            in_reporting_delay_period_values=reporting_delay_period_values
+        )


### PR DESCRIPTION
# Description

This PR includes the following:

- Checks the incoming reporting delay period values are valid on ingestion. This will block any True values occuring anywhere except the final section of the list

Fixes #CDD-1993

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
