### PR TITLE
Chore/update private api crawler

### DIFF
--- a/caching/private_api/crawler/dynamic_block_crawler.py
+++ b/caching/private_api/crawler/dynamic_block_crawler.py
@@ -113,10 +113,6 @@ class DynamicContentBlockCrawler:
 
         """
         self._process_table_for_chart_block(chart_block=chart_block)
-        self.process_download_for_chart_block(
-            chart_block=chart_block, file_format="csv"
-        )
-
         self._process_chart_for_both_possible_widths(chart_block=chart_block)
 
     # Sub methods for processing charts

--- a/metrics/domain/charts/reporting_delay_period.py
+++ b/metrics/domain/charts/reporting_delay_period.py
@@ -34,7 +34,7 @@ def add_reporting_delay_period(
     figure: plotly.graph_objects.Figure,
     boundary_colour: str = CYAN,
     fill_colour: str = LIGHT_BLUE,
-):
+) -> None:
     """Adds a filled region representing the reporting delay period on the figure
 
     Args:
@@ -55,7 +55,6 @@ def add_reporting_delay_period(
             )
         )
     except (ReportingDelayNotProvidedToPlotsError, NoReportingDelayPeriodFoundError):
-        logger.info("No reporting delay could be determined for this chart")
         return
 
     last_x_of_reporting_delay: str = _get_last_x_value_at_end_of_reporting_delay_period(

--- a/tests/unit/caching/private_api/crawler/dynamic_block_crawler/test_process_individual_blocks.py
+++ b/tests/unit/caching/private_api/crawler/dynamic_block_crawler/test_process_individual_blocks.py
@@ -209,7 +209,7 @@ class TestCrawlerProcessIndividualBlocks:
             data=expected_tables_request_data
         )
 
-    def test_process_chart_block_hits_downloads_endpoint(
+    def test_process_chart_block_does_not_hit_downloads_endpoint(
         self,
         example_chart_block: dict[str, str | list[dict]],
         dynamic_content_block_crawler_with_mocked_internal_api_client: DynamicContentBlockCrawler,
@@ -218,11 +218,10 @@ class TestCrawlerProcessIndividualBlocks:
         Given a chart block
         When `process_chart_block()` is called
             from an instance of `DynamicContentBlockCrawler`
-        Then the call is delegated to the `hit_downloads_endpoint()`
+        Then the `hit_downloads_endpoint()` call is **not** made
             on the `InternalAPIClient`
         """
         # Given
-        file_format = "csv"
         spy_internal_api_client: mock.Mock = (
             dynamic_content_block_crawler_with_mocked_internal_api_client._internal_api_client
         )
@@ -233,18 +232,7 @@ class TestCrawlerProcessIndividualBlocks:
         )
 
         # Then
-        request_payload_builder = (
-            dynamic_content_block_crawler_with_mocked_internal_api_client._request_payload_builder
-        )
-        expected_downloads_request_data = (
-            request_payload_builder.build_downloads_request_data(
-                chart_block=example_chart_block,
-                file_format=file_format,
-            )
-        )
-        spy_internal_api_client.hit_downloads_endpoint.assert_called_once_with(
-            data=expected_downloads_request_data
-        )
+        spy_internal_api_client.hit_downloads_endpoint.assert_not_called()
 
     def test_process_chart_block_hits_charts_endpoint(
         self,

--- a/tests/unit/metrics/domain/charts/test_reporting_delay_period.py
+++ b/tests/unit/metrics/domain/charts/test_reporting_delay_period.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-from _pytest.logging import LogCaptureFixture
 from plotly.graph_objs import Scatter
 
 from metrics.domain.charts import reporting_delay_period
@@ -179,10 +178,9 @@ class TestAddReportingDelayPeriod:
         mocked_figure.add_trace.assert_called_once_with(trace=expected_scatter)
 
     @pytest.mark.parametrize("additional_values", [{}, None])
-    def test_records_log_when_no_reporting_delay_period_found(
+    def test_does_not_draw_section_when_no_reporting_delay_period_found(
         self,
         fake_plot_data: PlotData,
-        caplog: LogCaptureFixture,
         additional_values: dict | None,
     ):
         """
@@ -190,8 +188,7 @@ class TestAddReportingDelayPeriod:
             which contains nothing for its
             `additional_values`
         When `add_reporting_delay_period()` is called
-        Then the correct log statement is recorded
-        And the section is not drawn
+        Then the section is not drawn
         """
         # Given
         mocked_figure = mock.Mock()
@@ -204,22 +201,18 @@ class TestAddReportingDelayPeriod:
         )
 
         # Then
-        expected_log = "No reporting delay could be determined for this chart"
-        assert expected_log in caplog.text
-
         mocked_figure.add_vrect.assert_not_called()
         mocked_figure.add_vline.assert_not_called()
 
-    def test_records_log_when_reporting_delay_period_contains_no_valid_start_point(
-        self, fake_plot_data: PlotData, caplog: LogCaptureFixture
+    def test_does_not_draw_section_when_reporting_delay_period_contains_no_valid_start_point(
+        self, fake_plot_data: PlotData
     ):
         """
         Given an enriched `PlotData` model
             which contains a list of reporting delay period values
             which do not have 1 True value
         When `add_reporting_delay_period()` is called
-        Then the correct log statement is recorded
-        And the section is not drawn
+        Then the section is not drawn
         """
         # Given
         mocked_figure = mock.Mock()
@@ -232,8 +225,5 @@ class TestAddReportingDelayPeriod:
         )
 
         # Then
-        expected_log = "No reporting delay could be determined for this chart"
-        assert expected_log in caplog.text
-
         mocked_figure.add_vrect.assert_not_called()
         mocked_figure.add_vline.assert_not_called()


### PR DESCRIPTION
# Description

This PR includes the following:

- Removes the pre-emptive crawling of downloads for all chart cards. This is lazy-loaded so we'd only pay the penalty on the first request anyway. With this approach we'll only persist downloads in the cache after they've been used the first time instead of everytime by default regardless of usage. This should help reduce the amount that we need to cache.


---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
