### PR TITLE
Set `html_url` of homepage to be the root of the site

### DIFF
--- a/cms/home/models.py
+++ b/cms/home/models.py
@@ -59,6 +59,38 @@ class HomePage(UKHSAPage):
         """Returns False. Since this is a headless CMS the preview panel is not supported"""
         return False
 
+    def get_url_parts(self, request=None) -> tuple[int, str, str]:
+        """Builds the full URL for the home page
+
+         Notes:
+             Page url parts are returned as a tuple of
+                (site_id, site_root_url, page_url_relative_to_site_root)
+            The base implementation of this method assumes Wagtail
+            is running in full app mode i.e not in headless,
+            because the building of page paths is handed off to
+            the `wagtail-serve` route which does not exist in headless mode.
+            Hence, the need to override and provide the url here.
+
+        Args:
+            `request`: Optional request object which is not to
+                be used for our implementation.
+
+        Returns:
+            Tuple containing the URL parts:
+                1) ID of the corresponding `Site` record
+                2) The root URL of the site
+                    e.g. `https://ukhsa-dashboard.data.gov.uk`
+                3) The path of the current page.
+                    This always returns an empty string
+                    e.g. `""`
+                    This is because the homepage is assumed
+                    to be at the root of the visible page tree.
+
+        """
+        site_id, root_url, page_path = super().get_url_parts(request=request)
+        page_path = ""
+        return site_id, root_url, page_path
+
 
 class HomePageRelatedLink(Orderable):
     page = ParentalKey(

--- a/tests/unit/cms/home/test_models.py
+++ b/tests/unit/cms/home/test_models.py
@@ -116,13 +116,15 @@ class TestBlankHomePage:
         expected_site_id = 123
         root_url = "https://my-prefix.dev.ukhsa-data-dashboard.gov.uk"
         page_path = "topics"
-        mocked_super_get_url_parts.return_value = (expected_site_id, root_url, page_path)
+        mocked_super_get_url_parts.return_value = (
+            expected_site_id,
+            root_url,
+            page_path,
+        )
         blank_page = FakeHomePageFactory.build_blank_page()
 
         # When
-        url_parts: tuple[int, str, str] = blank_page.get_url_parts(
-            request=mock.Mock()
-        )
+        url_parts: tuple[int, str, str] = blank_page.get_url_parts(request=mock.Mock())
 
         # Then
         assert url_parts[0] == expected_site_id

--- a/tests/unit/cms/home/test_models.py
+++ b/tests/unit/cms/home/test_models.py
@@ -1,8 +1,11 @@
+from unittest import mock
+
 import pytest
 from wagtail.admin.panels.field_panel import FieldPanel
 from wagtail.admin.panels.inline_panel import InlinePanel
 from wagtail.api.conf import APIField
 
+from cms.dashboard.models import UKHSAPage
 from metrics.domain.common.utils import ChartTypes
 from tests.fakes.factories.cms.home_page_factory import FakeHomePageFactory
 
@@ -100,6 +103,31 @@ class TestBlankHomePage:
 
         # Then
         assert not page_is_previewable
+
+    @mock.patch.object(UKHSAPage, "get_url_parts")
+    def test_get_url_parts(self, mocked_super_get_url_parts: mock.MagicMock):
+        """
+        Given a `HomePage` model
+        When `get_url_parts()` is called
+        Then the url parts are returned with
+            an empty string representing the page path
+        """
+        # Given
+        expected_site_id = 123
+        root_url = "https://my-prefix.dev.ukhsa-data-dashboard.gov.uk"
+        page_path = "topics"
+        mocked_super_get_url_parts.return_value = (expected_site_id, root_url, page_path)
+        blank_page = FakeHomePageFactory.build_blank_page()
+
+        # When
+        url_parts: tuple[int, str, str] = blank_page.get_url_parts(
+            request=mock.Mock()
+        )
+
+        # Then
+        assert url_parts[0] == expected_site_id
+        assert url_parts[1] == root_url
+        assert url_parts[2] == "" != page_path
 
 
 class TestTemplateHomePage:


### PR DESCRIPTION
# Description

This PR includes the following:

- Sets the html url of the homepage to be the root of the site

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
