### PR TITLE
Create `Menu` snippet as part of `build_cms_site` management command

### DIFF
--- a/cms/dashboard/management/commands/build_cms_site.py
+++ b/cms/dashboard/management/commands/build_cms_site.py
@@ -117,6 +117,8 @@ class Command(BaseCommand):
             name="cold_health_alerts", parent_page=weather_health_alerts_page
         )
 
+        build_cms_site_helpers.create_menu_snippet()
+
     @staticmethod
     def _clear_cms() -> None:
         # Wipe the existing site, pages & badges

--- a/cms/dashboard/management/commands/build_cms_site_helpers/__init__.py
+++ b/cms/dashboard/management/commands/build_cms_site_helpers/__init__.py
@@ -7,3 +7,4 @@ from .pages import (
     create_whats_new_parent_page,
     create_whats_new_child_entry,
 )
+from .menu import create_menu_snippet

--- a/cms/dashboard/management/commands/build_cms_site_helpers/menu.py
+++ b/cms/dashboard/management/commands/build_cms_site_helpers/menu.py
@@ -1,0 +1,233 @@
+from cms.common.models import CommonPage
+from cms.composite.models import CompositePage
+from cms.home.models import HomePage
+from cms.metrics_documentation.models import MetricsDocumentationParentPage
+from cms.snippets.models import Menu
+from cms.topic.models import TopicPage
+from cms.whats_new.models import WhatsNewParentPage
+
+
+def create_menu_snippet():
+    Menu.objects.create(
+        internal_label="Primary navigation",
+        is_active=True,
+        body=_create_menu_data(),
+    )
+
+
+def _create_menu_data() -> list[dict]:
+    homepage = HomePage.objects.first()
+    covid_page = TopicPage.objects.get(slug="covid-19")
+    flu_page = TopicPage.objects.get(slug="influenza")
+    other_respiratory_viruses_page = TopicPage.objects.get(
+        slug="other-respiratory-viruses"
+    )
+
+    weather_health_alerts_page = CompositePage.objects.get(slug="weather-health-alerts")
+    about_page = CommonPage.objects.get(slug="about")
+    metrics_docs_page = MetricsDocumentationParentPage.objects.first()
+    whats_new_page = WhatsNewParentPage.objects.first()
+    whats_coming_page = CommonPage.objects.get(slug="whats-coming")
+    access_our_data_page = CompositePage.objects.get(slug="access-our-data")
+
+    return [
+        {
+            "type": "row",
+            "value": {
+                "columns": [
+                    {
+                        "type": "column",
+                        "value": {
+                            "heading": "",
+                            "links": {
+                                "primary_link": {
+                                    "title": "Homepage",
+                                    "body": "",
+                                    "page": homepage.id,
+                                    "html_url": homepage.full_url,
+                                },
+                                "secondary_links": [
+                                    {
+                                        "type": "secondary_link",
+                                        "value": {
+                                            "title": "COVID-19",
+                                            "body": "",
+                                            "page": covid_page.id,
+                                            "html_url": covid_page.full_url,
+                                        },
+                                        "id": "c14de8da-5852-41b2-80bb-aa7ea92ff9b1",
+                                    },
+                                    {
+                                        "type": "secondary_link",
+                                        "value": {
+                                            "title": "Influenza",
+                                            "body": "",
+                                            "page": flu_page.id,
+                                            "html_url": flu_page.full_url,
+                                        },
+                                        "id": "ebe1dcf7-bd06-485c-bd56-6b96ed639ef8",
+                                    },
+                                    {
+                                        "type": "secondary_link",
+                                        "value": {
+                                            "title": "Other respiratory viruses",
+                                            "body": "",
+                                            "page": other_respiratory_viruses_page.id,
+                                            "html_url": other_respiratory_viruses_page.full_url,
+                                        },
+                                        "id": "8f6fa7aa-8283-48ca-bb73-f8fecf059b78",
+                                    },
+                                ],
+                            },
+                        },
+                        "id": "9b1ea5e1-3a8e-4600-ac19-9a94ed0de509",
+                    }
+                ]
+            },
+            "id": "7c65b301-1226-4db1-8dbd-2a2342f8b523",
+        },
+        {
+            "type": "row",
+            "value": {
+                "columns": [
+                    {
+                        "type": "column",
+                        "value": {
+                            "heading": "",
+                            "links": {
+                                "primary_link": {
+                                    "title": "Weather health alerts",
+                                    "body": "",
+                                    "page": weather_health_alerts_page.id,
+                                    "html_url": weather_health_alerts_page.full_url,
+                                },
+                                "secondary_links": [],
+                            },
+                        },
+                        "id": "17120416-69d7-4ca7-88f4-f9c4752f0933",
+                    }
+                ]
+            },
+            "id": "8fc1b945-0c7d-440d-82df-5135efcd6082",
+        },
+        {
+            "type": "row",
+            "value": {
+                "columns": [
+                    {
+                        "type": "column",
+                        "value": {
+                            "heading": "",
+                            "links": {
+                                "primary_link": {
+                                    "title": "About",
+                                    "body": "",
+                                    "page": about_page.id,
+                                    "html_url": about_page.full_url,
+                                },
+                                "secondary_links": [],
+                            },
+                        },
+                        "id": "0c3514bb-bbe3-4047-a210-1ecd3e5704df",
+                    }
+                ]
+            },
+            "id": "5919756a-b432-4b56-8531-5cd58d00c86d",
+        },
+        {
+            "type": "row",
+            "value": {
+                "columns": [
+                    {
+                        "type": "column",
+                        "value": {
+                            "heading": "",
+                            "links": {
+                                "primary_link": {
+                                    "title": "Metrics documentation",
+                                    "body": "",
+                                    "page": metrics_docs_page.id,
+                                    "html_url": metrics_docs_page.full_url,
+                                },
+                                "secondary_links": [],
+                            },
+                        },
+                        "id": "6718fbcd-1d0f-457f-ba2a-af3db223000f",
+                    }
+                ]
+            },
+            "id": "0c0e6da8-abfe-4141-9145-80c65d1cd427",
+        },
+        {
+            "type": "row",
+            "value": {
+                "columns": [
+                    {
+                        "type": "column",
+                        "value": {
+                            "heading": "",
+                            "links": {
+                                "primary_link": {
+                                    "title": "What's new",
+                                    "body": "",
+                                    "page": whats_new_page.id,
+                                    "html_url": whats_new_page.full_url,
+                                },
+                                "secondary_links": [],
+                            },
+                        },
+                        "id": "15a86699-851a-48bd-b28b-7af51ac8d771",
+                    }
+                ]
+            },
+            "id": "fbf95d3d-e695-488a-a588-2df83bf789a0",
+        },
+        {
+            "type": "row",
+            "value": {
+                "columns": [
+                    {
+                        "type": "column",
+                        "value": {
+                            "heading": "",
+                            "links": {
+                                "primary_link": {
+                                    "title": "What's coming",
+                                    "body": "",
+                                    "page": whats_coming_page.id,
+                                    "html_url": whats_coming_page.full_url,
+                                },
+                                "secondary_links": [],
+                            },
+                        },
+                        "id": "6feddadb-b1c7-4bbf-8f4d-cafc5e222088",
+                    }
+                ]
+            },
+            "id": "6fded286-2cfc-47c8-91d1-a60995581ec0",
+        },
+        {
+            "type": "row",
+            "value": {
+                "columns": [
+                    {
+                        "type": "column",
+                        "value": {
+                            "heading": "",
+                            "links": {
+                                "primary_link": {
+                                    "title": "Access our data",
+                                    "body": "",
+                                    "page": access_our_data_page.id,
+                                    "html_url": access_our_data_page.full_url,
+                                },
+                                "secondary_links": [],
+                            },
+                        },
+                        "id": "95565e6e-1577-4b4e-a0ec-40b8f416f219",
+                    }
+                ]
+            },
+            "id": "7c6579b2-041d-4ef7-b4ca-d4fbe9d3387e",
+        },
+    ]

--- a/tests/system/test_build_cms_site.py
+++ b/tests/system/test_build_cms_site.py
@@ -410,3 +410,88 @@ class TestBuildCMSSite:
             response_data["body"][0]
             == access_our_data_getting_started_page_template["body"][0]
         )
+
+    @pytest.mark.django_db
+    def test_command_creates_menu_snippet(self):
+        """
+        Given a CMS site which has been created via the `build_cms_site` management command
+        When a GET request is made to `/api/menus/v1` list endpoint
+        Then the response contains the expected data
+        """
+        # Given
+        call_command("build_cms_site")
+
+        api_client = APIClient()
+
+        # When
+        response = api_client.get(path="/api/menus/v1")
+
+        # Then
+        menu_data = response.data["active_menu"]
+        # There should be 7 rows in the menu
+        assert len(menu_data) == 7
+
+        def extract_primary_link_info(row_index, column_index) -> dict:
+            return menu_data[row_index]["value"]["columns"][column_index]["value"][
+                "links"
+            ]["primary_link"]
+
+        def extract_secondary_link_info(
+            row_index, column_index, secondary_link_index
+        ) -> dict:
+            return menu_data[row_index]["value"]["columns"][column_index]["value"][
+                "links"
+            ]["secondary_links"][secondary_link_index]["value"]
+
+        home_page = HomePage.objects.last()
+        home_page_data = extract_primary_link_info(row_index=0, column_index=0)
+        assert home_page_data["title"] == "Homepage"
+        assert home_page_data["page"] == home_page.id
+        assert home_page_data["html_url"] == home_page.full_url
+
+        covid_page = TopicPage.objects.get(slug="covid-19")
+        covid_page_data = extract_secondary_link_info(
+            row_index=0, column_index=0, secondary_link_index=0
+        )
+        assert covid_page_data["title"] == "COVID-19"
+        assert covid_page_data["page"] == covid_page.id
+        assert covid_page_data["html_url"] == covid_page.full_url
+
+        flu_page = TopicPage.objects.get(slug="influenza")
+        flu_page_data = extract_secondary_link_info(
+            row_index=0, column_index=0, secondary_link_index=1
+        )
+        assert flu_page_data["title"] == "Influenza"
+        assert flu_page_data["page"] == flu_page.id
+        assert flu_page_data["html_url"] == flu_page.full_url
+
+        other_respiratory_viruses_page = TopicPage.objects.get(
+            slug="other-respiratory-viruses"
+        )
+        other_respiratory_viruses_page_data = extract_secondary_link_info(
+            row_index=0, column_index=0, secondary_link_index=2
+        )
+        assert (
+            other_respiratory_viruses_page_data["title"] == "Other respiratory viruses"
+        )
+        assert (
+            other_respiratory_viruses_page_data["page"]
+            == other_respiratory_viruses_page.id
+        )
+        assert (
+            other_respiratory_viruses_page_data["html_url"]
+            == other_respiratory_viruses_page.full_url
+        )
+
+        weather_health_alerts_page = CompositePage.objects.get(
+            slug="weather-health-alerts"
+        )
+        weather_health_alerts_page_data = extract_primary_link_info(
+            row_index=1, column_index=0
+        )
+        assert weather_health_alerts_page_data["title"] == "Weather health alerts"
+        assert weather_health_alerts_page_data["page"] == weather_health_alerts_page.id
+        assert (
+            weather_health_alerts_page_data["html_url"]
+            == weather_health_alerts_page.full_url
+        )


### PR DESCRIPTION
# Description

This PR includes the following:

- Create an active `Menu` snippet as part of the `build_cms_site` management command. This menu reflects the current side nav

Fixes #CDD-2105

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
