### PR TITLE
Cache global banner and menu endpoints in redis cache

### DIFF
--- a/cms/snippets/views/global_banner.py
+++ b/cms/snippets/views/global_banner.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from rest_framework.utils.serializer_helpers import ReturnDict
 from rest_framework.views import APIView
 
+from caching.private_api.decorators import cache_response
 from cms.snippets.serializers import (
     GlobalBannerResponseSerializer,
     GlobalBannerSerializer,
@@ -18,6 +19,7 @@ class GlobalBannerView(APIView):
     @extend_schema(
         tags=["cms"], responses={HTTPStatus.OK: GlobalBannerResponseSerializer}
     )
+    @cache_response
     def get(cls, request, *args, **kwargs) -> Response:
         """
         This endpoint returns data associated with the currently active global banner

--- a/cms/snippets/views/global_banner.py
+++ b/cms/snippets/views/global_banner.py
@@ -19,7 +19,7 @@ class GlobalBannerView(APIView):
     @extend_schema(
         tags=["cms"], responses={HTTPStatus.OK: GlobalBannerResponseSerializer}
     )
-    @cache_response
+    @cache_response()
     def get(cls, request, *args, **kwargs) -> Response:
         """
         This endpoint returns data associated with the currently active global banner

--- a/cms/snippets/views/menu.py
+++ b/cms/snippets/views/menu.py
@@ -4,6 +4,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from caching.private_api.decorators import cache_response
 from cms.snippets.serializers import (
     MenuResponseSerializer,
     MenuSerializer,
@@ -15,6 +16,7 @@ class MenuView(APIView):
 
     @classmethod
     @extend_schema(tags=["cms"], responses={HTTPStatus.OK: MenuResponseSerializer})
+    @cache_response
     def get(cls, request, *args, **kwargs) -> Response:
         """
         This endpoint returns the state of the currently active `Menu`

--- a/cms/snippets/views/menu.py
+++ b/cms/snippets/views/menu.py
@@ -16,7 +16,7 @@ class MenuView(APIView):
 
     @classmethod
     @extend_schema(tags=["cms"], responses={HTTPStatus.OK: MenuResponseSerializer})
-    @cache_response
+    @cache_response()
     def get(cls, request, *args, **kwargs) -> Response:
         """
         This endpoint returns the state of the currently active `Menu`


### PR DESCRIPTION
# Description

This PR includes the following:

- Caches the global banner and menu snippet endpoints in redis

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
