### PR TITLE
Set `CACHE_FORCE_REFRESH_HEADER_KEY` to True when hitting endpoint to ecalculate instead of fetching from cache

### DIFF
--- a/tests/integration/cms/snippets/views/test_global_banner.py
+++ b/tests/integration/cms/snippets/views/test_global_banner.py
@@ -31,7 +31,11 @@ class TestGlobalBannerView:
         active_global_banner = GlobalBannerFactory.create(**active_banner_info)
 
         # When
-        response: Response = client.get(path=self.path, format="json")
+        response: Response = client.get(
+            path=self.path,
+            format="json",
+            headers={"CACHE_FORCE_REFRESH_HEADER_KEY": True},
+        )
 
         # Then
         assert response.status_code == HTTPStatus.OK

--- a/tests/integration/cms/snippets/views/test_global_banner.py
+++ b/tests/integration/cms/snippets/views/test_global_banner.py
@@ -34,7 +34,7 @@ class TestGlobalBannerView:
         response: Response = client.get(
             path=self.path,
             format="json",
-            headers={"CACHE_FORCE_REFRESH_HEADER_KEY": True},
+            headers={"Cache-Force-Refresh": True},
         )
 
         # Then

--- a/tests/integration/cms/snippets/views/test_menu.py
+++ b/tests/integration/cms/snippets/views/test_menu.py
@@ -55,7 +55,11 @@ class TestMenuView:
         )
 
         # When
-        response: Response = client.get(path=self.path, format="json")
+        response: Response = client.get(
+            path=self.path,
+            format="json",
+            headers={"CACHE_FORCE_REFRESH_HEADER_KEY": True},
+        )
 
         # Then
         assert response.status_code == HTTPStatus.OK

--- a/tests/integration/cms/snippets/views/test_menu.py
+++ b/tests/integration/cms/snippets/views/test_menu.py
@@ -58,7 +58,7 @@ class TestMenuView:
         response: Response = client.get(
             path=self.path,
             format="json",
-            headers={"CACHE_FORCE_REFRESH_HEADER_KEY": True},
+            headers={"Cache-Force-Refresh": True},
         )
 
         # Then

--- a/tests/system/test_build_cms_site.py
+++ b/tests/system/test_build_cms_site.py
@@ -426,7 +426,7 @@ class TestBuildCMSSite:
         # When
         response = api_client.get(
             path="/api/menus/v1",
-            headers={"CACHE_FORCE_REFRESH_HEADER_KEY": True},
+            headers={"Cache-Force-Refresh": True},
         )
 
         # Then

--- a/tests/system/test_build_cms_site.py
+++ b/tests/system/test_build_cms_site.py
@@ -424,7 +424,10 @@ class TestBuildCMSSite:
         api_client = APIClient()
 
         # When
-        response = api_client.get(path="/api/menus/v1")
+        response = api_client.get(
+            path="/api/menus/v1",
+            headers={"CACHE_FORCE_REFRESH_HEADER_KEY": True},
+        )
 
         # Then
         menu_data = response.data["active_menu"]


### PR DESCRIPTION
# Description

This PR includes the following:

- Fix to a flaky test which was caching the GET endpoint call in the django in memory cache during CI runs

---

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
