### PR TITLE
Hit `/sitemap.xml` when crawling frontend cache

### DIFF
--- a/caching/frontend/crawler.py
+++ b/caching/frontend/crawler.py
@@ -175,10 +175,14 @@ class FrontEndCrawler:
         for page_item in all_page_items:
             self.process_page(page_item=page_item["meta"])
 
+        self._hit_ancillary_pages()
+        logger.info("Finished processing all regular pages for the frontend")
+
+    def _hit_ancillary_pages(self):
         self.hit_frontend_page(
             url=self._url_builder.build_url_for_feedback_confirmation_page()
         )
-        logger.info("Finished processing all regular pages for the frontend")
+        self.hit_frontend_page(url=self._url_builder.build_url_for_sitemap())
 
     def process_geography_page_combination(
         self, geography_data: GeographyData, page: TopicPage

--- a/caching/frontend/urls.py
+++ b/caching/frontend/urls.py
@@ -91,6 +91,15 @@ class FrontEndURLBuilder:
         """
         return urljoin(self._base_url, "/feedback/confirmation")
 
+    def build_url_for_sitemap(self) -> str:
+        """Builds the full URL for the sitemap page
+
+        Returns:
+            The full URL which can be passed to requests
+
+        """
+        return urljoin(self._base_url, "/sitemap.xml")
+
     @staticmethod
     def build_query_params_for_area_selector_page(
         *, geography_type_name: str, geography_name: str

--- a/tests/unit/caching/frontend/test_crawler.py
+++ b/tests/unit/caching/frontend/test_crawler.py
@@ -448,7 +448,40 @@ class TestFrontEndCrawler:
 
         # Then
         expected_url = frontend_url_builder.build_url_for_feedback_confirmation_page()
-        spy_hit_frontend_page.assert_called_with(url=expected_url)
+        spy_hit_frontend_page.assert_has_calls(
+            calls=[mock.call(url=expected_url)], any_order=True
+        )
+
+    @mock.patch.object(FrontEndCrawler, "hit_frontend_page")
+    def test_process_all_pages_hits_frontend_for_sitemap(
+        self,
+        spy_hit_frontend_page: mock.MagicMock,
+        frontend_crawler_with_mocked_internal_api_client: FrontEndCrawler,
+    ):
+        """
+        Given no input
+        When `process_all_pages()` is called from
+            an instance of `FrontEndCrawler`
+        Then `hit_frontend_page()` is called
+            with the URL for the sitemap
+
+        Patches:
+            `spy_hit_frontend_page`: For the main assertion
+
+        """
+        # Given
+        frontend_url_builder = (
+            frontend_crawler_with_mocked_internal_api_client._url_builder
+        )
+
+        # When
+        frontend_crawler_with_mocked_internal_api_client.process_all_pages()
+
+        # Then
+        expected_url = frontend_url_builder.build_url_for_sitemap()
+        spy_hit_frontend_page.assert_has_calls(
+            calls=[mock.call(url=expected_url)], any_order=True
+        )
 
     @mock.patch.object(FrontEndCrawler, "hit_frontend_page")
     def test_process_geography_page_combination(


### PR DESCRIPTION
# Description

This PR includes the following:

- Hits the `/sitemap.xml` page when crawling the frontend cloudfront cache

Fixes #CDD-2148

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
