### PR TITLE
Chore/hide show in menus

### DIFF
--- a/cms/dashboard/management/commands/build_cms_site_helpers/pages.py
+++ b/cms/dashboard/management/commands/build_cms_site_helpers/pages.py
@@ -51,7 +51,6 @@ def create_landing_dashboard_page(*, parent_page: Page) -> HomePage:
         slug=data["meta"]["slug"],
         seo_title=data["meta"]["seo_title"],
         search_description=data["meta"]["search_description"],
-        show_in_menus=data["meta"]["show_in_menus"],
     )
     _add_page_to_parent(page=page, parent_page=parent_page)
 
@@ -75,7 +74,6 @@ def create_topic_page(*, name: str, parent_page: Page) -> TopicPage:
         date_posted=data["meta"]["first_published_at"].split("T")[0],
         seo_title=data["meta"]["seo_title"],
         search_description=data["meta"]["search_description"],
-        show_in_menus=data["meta"]["show_in_menus"],
     )
     _add_page_to_parent(page=page, parent_page=parent_page)
 
@@ -98,7 +96,6 @@ def create_common_page(*, name: str, parent_page: Page) -> CommonPage:
         date_posted=data["meta"]["first_published_at"].split("T")[0],
         seo_title=data["meta"]["seo_title"],
         search_description=data["meta"]["search_description"],
-        show_in_menus=data["meta"]["show_in_menus"],
     )
     _add_page_to_parent(page=page, parent_page=parent_page)
 
@@ -146,7 +143,6 @@ def create_bulk_downloads_page(*, name: str, parent_page: Page) -> CompositePage
         date_posted=data["meta"]["first_published_at"].split("T")[0],
         seo_title=data["meta"]["seo_title"],
         search_description=data["meta"]["search_description"],
-        show_in_menus=data["meta"]["show_in_menus"],
     )
 
     _add_page_to_parent(page=page, parent_page=parent_page)
@@ -170,7 +166,6 @@ def create_composite_page(*, name: str, parent_page: Page) -> CompositePage:
         date_posted=data["meta"]["first_published_at"].split("T")[0],
         seo_title=data["meta"]["seo_title"],
         search_description=data["meta"]["search_description"],
-        show_in_menus=data["meta"]["show_in_menus"],
     )
 
     _add_page_to_parent(page=page, parent_page=parent_page)
@@ -194,7 +189,6 @@ def create_whats_new_parent_page(*, name: str, parent_page: Page) -> WhatsNewPar
         date_posted=data["meta"]["first_published_at"].split("T")[0],
         seo_title=data["meta"]["seo_title"],
         search_description=data["meta"]["search_description"],
-        show_in_menus=data["meta"]["show_in_menus"],
     )
     _add_page_to_parent(page=page, parent_page=parent_page)
 
@@ -220,7 +214,6 @@ def create_whats_new_child_entry(*, name: str, parent_page: Page) -> WhatsNewChi
         date_posted=data["meta"]["first_published_at"].split("T")[0],
         seo_title=data["meta"]["seo_title"],
         search_description=data["meta"]["search_description"],
-        show_in_menus=data["meta"]["show_in_menus"],
         additional_details=data["additional_details"],
         badge=badge,
     )

--- a/cms/dashboard/models.py
+++ b/cms/dashboard/models.py
@@ -4,6 +4,7 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from rest_framework.templatetags.rest_framework import render_markdown
 from wagtail.admin.panels.field_panel import FieldPanel
+from wagtail.admin.panels.group import MultiFieldPanel
 from wagtail.api import APIField
 from wagtail.models import Page, SiteRootPath
 
@@ -45,9 +46,17 @@ class UKHSAPage(Page):
         APIField("seo_priority"),
     ]
 
-    promote_panels = Page.promote_panels + [
-        FieldPanel("seo_change_frequency"),
-        FieldPanel("seo_priority"),
+    promote_panels = [
+        MultiFieldPanel(
+            children=[
+                FieldPanel("slug"),
+                FieldPanel("seo_title"),
+                FieldPanel("search_description"),
+                FieldPanel("seo_change_frequency"),
+                FieldPanel("seo_priority"),
+            ],
+            heading="For search engines",
+        ),
     ]
 
     class Meta:

--- a/tests/system/test_build_cms_site.py
+++ b/tests/system/test_build_cms_site.py
@@ -95,10 +95,6 @@ class TestBuildCMSSite:
             response_data["meta"]["search_description"]
             == home_page_response_template["meta"]["search_description"]
         )
-        assert (
-            response_data["meta"]["show_in_menus"]
-            == home_page_response_template["meta"]["show_in_menus"]
-        )
 
         # Check that the related links have been populated correctly
         related_links_from_response = response_data["related_links"]
@@ -147,10 +143,6 @@ class TestBuildCMSSite:
         assert (
             response_data["meta"]["search_description"]
             == topic_page_response_template["meta"]["search_description"]
-        )
-        assert (
-            response_data["meta"]["show_in_menus"]
-            == topic_page_response_template["meta"]["show_in_menus"]
         )
         assert response_data["meta"]["parent"]["id"] == parent_home_page.id
         assert response_data["meta"]["parent"]["title"] == parent_home_page.title
@@ -202,10 +194,6 @@ class TestBuildCMSSite:
             response_data["meta"]["search_description"]
             == about_page_template["meta"]["search_description"]
         )
-        assert (
-            response_data["meta"]["show_in_menus"]
-            == about_page_template["meta"]["show_in_menus"]
-        )
         assert response_data["meta"]["parent"]["id"] == parent_page.id
         assert response_data["meta"]["parent"]["title"] == parent_page.title
 
@@ -250,10 +238,6 @@ class TestBuildCMSSite:
             response_data["meta"]["search_description"]
             == whats_new_page_template["meta"]["search_description"]
         )
-        assert (
-            response_data["meta"]["show_in_menus"]
-            == whats_new_page_template["meta"]["show_in_menus"]
-        )
         assert response_data["meta"]["parent"]["id"] == parent_home_page.id
         assert response_data["meta"]["parent"]["title"] == parent_home_page.title
 
@@ -296,10 +280,6 @@ class TestBuildCMSSite:
             response.data["meta"]["search_description"]
             == bulk_downloads_template["meta"]["search_description"]
         )
-        assert (
-            response.data["meta"]["show_in_menus"]
-            == bulk_downloads_template["meta"]["show_in_menus"]
-        )
         assert response.data["meta"]["parent"]["id"] == parent_page.id
         assert response.data["meta"]["parent"]["title"] == parent_page.title
 
@@ -338,10 +318,6 @@ class TestBuildCMSSite:
         assert (
             response.data["meta"]["search_description"]
             == access_our_data_parent_page_template["meta"]["search_description"]
-        )
-        assert (
-            response.data["meta"]["show_in_menus"]
-            == access_our_data_parent_page_template["meta"]["show_in_menus"]
         )
         assert response.data["meta"]["parent"]["id"] == parent_page.id
         assert response.data["meta"]["parent"]["title"] == parent_page.title
@@ -398,10 +374,6 @@ class TestBuildCMSSite:
             == access_our_data_getting_started_page_template["meta"][
                 "search_description"
             ]
-        )
-        assert (
-            response_data["meta"]["show_in_menus"]
-            == access_our_data_getting_started_page_template["meta"]["show_in_menus"]
         )
         assert response_data["meta"]["parent"]["id"] == parent_page.id
         assert response_data["meta"]["parent"]["title"] == parent_page.title

--- a/tests/unit/cms/dashboard/test_models.py
+++ b/tests/unit/cms/dashboard/test_models.py
@@ -1,0 +1,49 @@
+import pytest
+
+from cms.dashboard.models import UKHSAPage
+from tests.fakes.factories.cms.common_page_factory import FakeCommonPageFactory
+from tests.fakes.factories.cms.composite_page_factory import FakeCompositePageFactory
+from tests.fakes.factories.cms.home_page_factory import FakeHomePageFactory
+from tests.fakes.factories.cms.metrics_documentation_factory import (
+    FakeMetricsDocumentationParentPageFactory,
+)
+from tests.fakes.factories.cms.topic_page_factory import FakeTopicPageFactory
+from tests.fakes.factories.cms.whats_new_child_entry_factory import (
+    FakeWhatsNewChildEntryFactory,
+)
+from tests.fakes.factories.cms.whats_new_parent_page_factory import (
+    FakeWhatsNewParentPageFactory,
+)
+
+
+class TestUKHSAPage:
+    @pytest.mark.parametrize(
+        "fake_page",
+        [
+            FakeHomePageFactory.build_blank_page(),
+            FakeTopicPageFactory.build_influenza_page_from_template(),
+            FakeCommonPageFactory.build_blank_page(),
+            FakeCompositePageFactory.build_page_from_template(
+                page_name="access_our_data_getting_started"
+            ),
+            FakeMetricsDocumentationParentPageFactory.build_page_from_template(),
+            FakeWhatsNewChildEntryFactory.build_page_from_template(),
+            FakeWhatsNewParentPageFactory.build_page_from_template(),
+        ],
+    )
+    def test_show_in_menus_not_available_in_promote_panel(self, fake_page: UKHSAPage):
+        """
+        Given a blank page model which inherits from `UKHSAPage`
+        When `promote_panels` is called
+        Then `show_in_menus` is not available
+        """
+        # Given
+        child_page = fake_page
+
+        # When
+        promote_panels = child_page.promote_panels
+
+        # Then
+        multi_field_panel = promote_panels[0]
+        panel_names: list[str] = [p.clean_name for p in multi_field_panel.children]
+        assert "show_in_menus" not in panel_names

--- a/tests/unit/cms/home/test_models.py
+++ b/tests/unit/cms/home/test_models.py
@@ -89,6 +89,24 @@ class TestBlankHomePage:
         }
         assert sidebar_content_panel_names == expected_sidebar_content_panel_names
 
+    def test_show_in_menus_not_available_in_promote_panel(self):
+        """
+        Given a blank `HomePage` model
+        When `promote_panels` is called
+        Then `show_in_menus` is not available
+        """
+        # Given
+        blank_page = FakeHomePageFactory.build_blank_page()
+
+        # When
+        sidebar_content_panels: list[InlinePanel] = blank_page.sidebar_content_panels
+
+        # Then
+        sidebar_content_panel_names: set[str] = {
+            p.relation_name for p in sidebar_content_panels
+        }
+        assert "show_in_menus" not in sidebar_content_panel_names
+
     def test_is_previewable_returns_false(self):
         """
         Given a blank `HomePage` model


### PR DESCRIPTION
# Description

This PR includes the following:

- Hides the `show_in_menus` boolean from the pages in the CMS
- Stops settings the `show_in_menus` as part of the `build_cms_site` management command
- Does not remove the field in the API response so as to not bring about a breaking change for now.

Fixes #CDD-2146

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
