### PR TITLE
Task/cdd 2098 integrate headline manager to tables endpoint

### DIFF
--- a/metrics/domain/common/utils.py
+++ b/metrics/domain/common/utils.py
@@ -3,7 +3,10 @@ from enum import Enum
 
 DEFAULT_CHART_HEIGHT = 220
 DEFAULT_CHART_WIDTH = 515
-DEFAULT_VALUE_ERROR_MESSAGE = "The metric provided doesn't appear to be valid."
+DEFAULT_METRIC_VALUE_ERROR = "The metric provided doesn't appear to be valid."
+DEFAULT_METRIC_GROUP_VALUE_ERROR = (
+    "The metric_group provided doesn't appear to be valid."
+)
 
 
 def get_last_day_of_month(*, date: datetime.datetime.date) -> datetime.datetime.date:
@@ -135,4 +138,4 @@ def extract_metric_group_from_metric(metric: str) -> str | None:
         if metric_group.value in metric:
             return metric_group.value
 
-    raise ValueError(DEFAULT_VALUE_ERROR_MESSAGE)
+    raise ValueError(DEFAULT_METRIC_VALUE_ERROR)

--- a/metrics/interfaces/charts/access.py
+++ b/metrics/interfaces/charts/access.py
@@ -66,18 +66,18 @@ class ChartsInterface:
 
         Notes:
             The charts interface can be used to generate charts for
-            either `CoreTimerseries` or `CoreHeadline` data.
+            either `CoreTimeSeries` or `CoreHeadline` data.
             this function returns the Django manager to match the
-            `metric_type` provided or defaults to `CoreTimeseries`
-            if the `metric_type` is not provided.
+            current `metric_group` or defaults to `CoreTimeseries`
+            manager
 
         Returns:
             Manager: either `CoreTimeseries` or `CoreHeadline`
         """
-        if DataSourceFileType[self.metric_group].is_timeseries:
-            return DEFAULT_CORE_TIME_SERIES_MANAGER
+        if DataSourceFileType[self.metric_group].is_headline:
+            return DEFAULT_CORE_HEADLINE_MANAGER
 
-        return DEFAULT_CORE_HEADLINE_MANAGER
+        return DEFAULT_CORE_TIME_SERIES_MANAGER
 
     def generate_chart_output(self) -> ChartOutput:
         """Generates a `plotly` chart figure and a corresponding description

--- a/metrics/interfaces/tables/access.py
+++ b/metrics/interfaces/tables/access.py
@@ -1,11 +1,17 @@
 from django.db.models import Manager
 
-from metrics.data.models.core_models import CoreTimeSeries
+from metrics.data.models.core_models import CoreHeadline, CoreTimeSeries
+from metrics.domain.common.utils import (
+    DataSourceFileType,
+    extract_metric_group_from_metric,
+)
 from metrics.domain.models import PlotsCollection
 from metrics.domain.tables.generation import TabularData
 from metrics.interfaces.plots.access import PlotsInterface
+from metrics.utils.type_hints import CORE_MODEL_MANAGER_TYPE
 
 DEFAULT_CORE_TIME_SERIES_MANAGER = CoreTimeSeries.objects
+DEFAULT_CORE_HEADLINE_MANAGER = CoreHeadline.objects
 
 
 class TablesInterface:
@@ -13,15 +19,37 @@ class TablesInterface:
         self,
         *,
         plots_collection: PlotsCollection,
-        core_time_series_manager: Manager = DEFAULT_CORE_TIME_SERIES_MANAGER,
+        core_model_manager: CORE_MODEL_MANAGER_TYPE | None = None,
         plots_interface: PlotsInterface | None = None,
     ):
         self.plots_collection = plots_collection
+        self.metric_group = extract_metric_group_from_metric(
+            metric=self.plots_collection.plots[0].metric
+        )
+        self.core_model_manager = core_model_manager or self._get_core_model_manager()
 
         self.plots_interface = plots_interface or PlotsInterface(
             plots_collection=self.plots_collection,
-            core_model_manager=core_time_series_manager,
+            core_model_manager=self.core_model_manager,
         )
+
+    def _get_core_model_manager(self) -> Manager:
+        """Returns `core_model_manager` based on the `metric_type`
+
+        Notes:
+            The tables interface can be used to generate tabular data for
+            either `CoreTimerSeries` or `CoreHeadline` data.
+            this function returns the Django manager to match the
+            current `metric_group` or defaults to `CoreTimeseries`
+            manager
+
+        Returns:
+            Manager: either `CoreTimeseries` or `CoreHeadline`
+        """
+        if DataSourceFileType[self.metric_group].is_headline:
+            return DEFAULT_CORE_HEADLINE_MANAGER
+
+        return DEFAULT_CORE_TIME_SERIES_MANAGER
 
     def _build_tabular_data_from_plots_data(self) -> TabularData:
         plots = self.plots_interface.build_plots_data()
@@ -76,5 +104,7 @@ def generate_table_for_full_plots(
         `DataNotFoundForAnyPlotError`: If no plots
             returned any data from the underlying queries
     """
-    tables_interface = TablesInterface(plots_collection=plots_collection)
+    tables_interface = TablesInterface(
+        plots_collection=plots_collection,
+    )
     return tables_interface.generate_full_plots_for_table()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,19 @@ def valid_plot_parameters() -> PlotParameters:
 
 
 @pytest.fixture
+def valid_plot_parameters_for_headline_data() -> PlotParameters:
+    return PlotParameters(
+        metric="COVID-19_headline_vaccines_spring24Uptake",
+        topic="COVID-19",
+        chart_type=ChartTypes.bar.value,
+        date_from="",
+        date_to="",
+        x_axis="age",
+        y_axis="metric",
+    )
+
+
+@pytest.fixture
 def fake_plot_data() -> PlotData:
     plot_params = PlotParameters(
         chart_type="line_multi_coloured",

--- a/tests/unit/metrics/domain/common/test_utils.py
+++ b/tests/unit/metrics/domain/common/test_utils.py
@@ -2,6 +2,8 @@ import datetime
 
 import pytest
 
+from metrics.data.models.core_models import CoreHeadline, CoreTimeSeries
+from metrics.utils.type_hints import CORE_MODEL_MANAGER_TYPE
 from metrics.domain.common.utils import (
     ChartAxisFields,
     ChartTypes,

--- a/tests/unit/metrics/domain/tables/test_tables_generation.py
+++ b/tests/unit/metrics/domain/tables/test_tables_generation.py
@@ -360,7 +360,7 @@ class TestTabularData:
 
 
 class TestAddPlotDataToCombinedPlots:
-    def test_basic_behaviour(self):
+    def test_basic_behaviour(self, valid_plot_parameters: PlotParameters):
         """
         Given a plot which is not by date
         When `add_plot_data_to_combined_plots()` is called
@@ -369,6 +369,11 @@ class TestAddPlotDataToCombinedPlots:
         """
         # Given
         first_chart_plots_data = dict(zip(["0-4", "5-8"], Y_AXIS_1_VALUES))
+        plot_data = PlotData(
+            parameters=valid_plot_parameters,
+            x_axis_values="",
+            y_axis_values="",
+        )
 
         expected_combined_plots = {
             "0-4": {PLOT_1_LABEL: "10", "in_reporting_delay_period": False},
@@ -376,7 +381,7 @@ class TestAddPlotDataToCombinedPlots:
         }
 
         # When
-        tabular_data = TabularData(plots=[])
+        tabular_data = TabularData(plots=[plot_data])
         tabular_data.add_plot_data_to_combined_plots(
             plot_data=first_chart_plots_data,
             plot_label=PLOT_1_LABEL,
@@ -385,7 +390,7 @@ class TestAddPlotDataToCombinedPlots:
         # Then
         assert tabular_data.combined_plots == expected_combined_plots
 
-    def test_two_plots(self):
+    def test_two_plots(self, valid_plot_parameters: PlotParameters):
         """
         Given two plot neither of which are by date
         When `add_plot_data_to_combined_plots()` is called
@@ -394,6 +399,11 @@ class TestAddPlotDataToCombinedPlots:
         """
         first_chart_plots_data = dict(zip(["0-4", "5-8"], Y_AXIS_1_VALUES))
         second_chart_plots_data = dict(zip(["0-4", "5-8"], Y_AXIS_2_VALUES))
+        plot_data = PlotData(
+            parameters=valid_plot_parameters,
+            x_axis_values="",
+            y_axis_values="",
+        )
 
         expected_combined_plots = {
             "0-4": {
@@ -409,7 +419,7 @@ class TestAddPlotDataToCombinedPlots:
         }
 
         # When
-        tabular_data = TabularData(plots=[])
+        tabular_data = TabularData(plots=[plot_data])
 
         tabular_data.add_plot_data_to_combined_plots(
             plot_data=first_chart_plots_data,
@@ -474,7 +484,7 @@ class TestCombineAllPlots:
 
 
 class TestCreateMultiPlotOutput:
-    def test_2_plots(self):
+    def test_2_plots(self, valid_plot_parameters: PlotParameters):
         """
         Given 2 plots with plot labels
         When `create_multi_plot_output()` is called
@@ -536,9 +546,14 @@ class TestCreateMultiPlotOutput:
                 ],
             },
         ]
+        plot_data = PlotData(
+            parameters=valid_plot_parameters,
+            x_axis_values="",
+            y_axis_values="",
+        )
 
         # When
-        tabular_data = TabularData(plots=[])
+        tabular_data = TabularData(plots=[plot_data])
         tabular_data.plot_labels = plot_labels
         tabular_data.combined_plots = combined_plots
         tabular_data.column_heading = "date"
@@ -547,7 +562,7 @@ class TestCreateMultiPlotOutput:
         # Then
         assert actual_output == expected_output
 
-    def test_plots_of_unequal_length(self):
+    def test_plots_of_unequal_length(self, valid_plot_parameters: PlotParameters):
         """
         Given 2 plots which are not the same length as each other
         When `create_multi_plot_output()` is called
@@ -624,12 +639,79 @@ class TestCreateMultiPlotOutput:
                 ],
             },
         ]
+        plot_data = PlotData(
+            parameters=valid_plot_parameters,
+            x_axis_values="",
+            y_axis_values="",
+        )
 
         # When
-        tabular_data = TabularData(plots=[])
+        tabular_data = TabularData(plots=[plot_data])
         tabular_data.plot_labels = plot_labels
         tabular_data.combined_plots = combined_plots
         tabular_data.column_heading = "date"
+        actual_output = tabular_data.create_multi_plot_output()
+
+        # Then
+        assert actual_output == expected_output
+
+    def test_plots_for_headline_data(
+        self, valid_plot_parameters_for_headline_data: PlotParameters
+    ):
+        """
+        Given a series of plots for a headline data chart
+        When `create_multi_plot_output()` is called
+        Then the correct output is returned.
+        """
+        # Given
+        plot_labels = ["01 - 04", "05 - 10", "11 - 14"]
+        combined_plots = {
+            "01 - 04": {"01 - 04": "55"},
+            "05 - 10": {"05 - 10": "65"},
+            "11 - 14": {"11 - 14": "75"},
+        }
+        expected_output = [
+            {
+                "reference": "01 - 04",
+                "values": [
+                    {
+                        "label": "Amount",
+                        "value": "55",
+                        "in_reporting_delay_period": False,
+                    }
+                ],
+            },
+            {
+                "reference": "05 - 10",
+                "values": [
+                    {
+                        "label": "Amount",
+                        "value": "65",
+                        "in_reporting_delay_period": False,
+                    }
+                ],
+            },
+            {
+                "reference": "11 - 14",
+                "values": [
+                    {
+                        "label": "Amount",
+                        "value": "75",
+                        "in_reporting_delay_period": False,
+                    }
+                ],
+            },
+        ]
+        plot_data = PlotData(
+            parameters=valid_plot_parameters_for_headline_data,
+            x_axis_values="",
+            y_axis_values="",
+        )
+
+        # When
+        tabular_data = TabularData(plots=[plot_data])
+        tabular_data.plot_labels = plot_labels
+        tabular_data.combined_plots = combined_plots
         actual_output = tabular_data.create_multi_plot_output()
 
         # Then

--- a/tests/unit/metrics/interfaces/tables/test_access.py
+++ b/tests/unit/metrics/interfaces/tables/test_access.py
@@ -1,12 +1,14 @@
 import datetime
 from unittest import mock
 
+from metrics.data.models.core_models import CoreHeadline, CoreTimeSeries
 from metrics.domain.models import PlotParameters, PlotsCollection
 from metrics.domain.tables.generation import TabularData
 from metrics.interfaces.tables.access import (
     TablesInterface,
     generate_table_for_full_plots,
 )
+from metrics.domain.common.utils import ChartTypes
 from tests.fakes.factories.metrics.core_time_series_factory import (
     FakeCoreTimeSeriesFactory,
 )
@@ -28,7 +30,10 @@ class TestTablesInterface:
             for i in range(10)
         ]
 
-    def test_plots_interface_is_created_with_correct_args_by_default(self):
+    def test_plots_interface_is_created_with_correct_args_by_default(
+        self,
+        fake_plots_collection: PlotsCollection,
+    ):
         """
         Given a `PlotsCollection` and a `CoreTimeSeriesManager`
         When an instance of the `TablesInterface` is created
@@ -36,22 +41,51 @@ class TestTablesInterface:
         Then an instance of the `PlotsInterface` is created with the correct args
         """
         # Given
-        mocked_plots_collection = mock.MagicMock()
+        fake_plots_collection.plots[0].chart_type = (
+            ChartTypes.line_with_shaded_section.value
+        )
         mocked_core_time_series_manager = mock.Mock()
 
         # When
         tables_interface = TablesInterface(
-            plots_collection=mocked_plots_collection,
-            core_time_series_manager=mocked_core_time_series_manager,
+            plots_collection=fake_plots_collection,
+            core_model_manager=mocked_core_time_series_manager,
         )
 
         # Then
         created_plots_interface = tables_interface.plots_interface
-        assert created_plots_interface.plots_collection == mocked_plots_collection
+        assert created_plots_interface.plots_collection == fake_plots_collection
         assert (
             created_plots_interface.core_model_manager
             == mocked_core_time_series_manager
         )
+
+    def test_plots_interface_is_created_with_headline_manager_when_provided_a_headline_metric(
+        self,
+        fake_plots_collection: PlotsCollection,
+    ):
+        """
+        Given a `PlotsCollection` and a `headline` metric
+        When an instance of the `TablesInterface` is created
+            without explicitly providing a `PlotsInterface`
+        Then an instance of the `PlotsInterface` is created with the correct args
+            and the `core_model_manager` is set to `CoreHeadline` manager
+        """
+        # Given
+        fake_plots_collection.plots[0].chart_type = (
+            ChartTypes.line_with_shaded_section.value
+        )
+        fake_plots_collection.plots[0].metric = "COVID-19_headline_tests_7DayChange"
+
+        # When
+        tables_interface = TablesInterface(
+            plots_collection=fake_plots_collection,
+        )
+
+        # Then
+        created_plots_interface = tables_interface.plots_interface
+        assert created_plots_interface.plots_collection == fake_plots_collection
+        assert created_plots_interface.core_model_manager == CoreHeadline.objects
 
     @mock.patch.object(TabularData, "create_tabular_plots")
     def test_generate_full_plots_for_table(
@@ -83,7 +117,7 @@ class TestTablesInterface:
 
         tables_interface = TablesInterface(
             plots_collection=plots_collection,
-            core_time_series_manager=fake_core_time_series_manager,
+            core_model_manager=fake_core_time_series_manager,
         )
 
         # When


### PR DESCRIPTION
# Description

This PR includes the the integration of the `CoreHeadline` manager in the tables endpoint to enable tabular data for headline charts.

Fixes #CDD-2098

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
