### PR TITLE
Task/reduce public methods on consumer class/cdd 1443

### DIFF
--- a/ingestion/consumer.py
+++ b/ingestion/consumer.py
@@ -176,7 +176,7 @@ class Consumer:
             name=self.dto.parent_theme,
         )
 
-    def get_or_create_sub_theme(self, *, theme):
+    def _get_or_create_sub_theme(self, *, theme):
         """Returns the corresponding `SubTheme` record to be associated with the current `data`
 
         Args:
@@ -317,7 +317,7 @@ class Consumer:
 
         """
         theme = self._get_or_create_theme()
-        sub_theme = self.get_or_create_sub_theme(theme=theme)
+        sub_theme = self._get_or_create_sub_theme(theme=theme)
         topic = self.get_or_create_topic(sub_theme=sub_theme)
 
         geography_type = self.get_or_create_geography_type()

--- a/ingestion/consumer.py
+++ b/ingestion/consumer.py
@@ -240,7 +240,7 @@ class Consumer:
             geography_type_id=geography_type.id,
         )
 
-    def get_or_create_metric_group(self, *, topic):
+    def _get_or_create_metric_group(self, *, topic):
         """Returns the corresponding `MetricGroup` record to be associated with the current `data`
 
         Args:
@@ -323,7 +323,7 @@ class Consumer:
         geography_type = self._get_or_create_geography_type()
         geography = self._get_or_create_geography(geography_type=geography_type)
 
-        metric_group = self.get_or_create_metric_group(topic=topic)
+        metric_group = self._get_or_create_metric_group(topic=topic)
         metric = self.get_or_create_metric(metric_group=metric_group, topic=topic)
 
         stratum = self.get_or_create_stratum()

--- a/ingestion/consumer.py
+++ b/ingestion/consumer.py
@@ -257,7 +257,7 @@ class Consumer:
             topic_id=topic.id,
         )
 
-    def get_or_create_metric(self, *, metric_group, topic):
+    def _get_or_create_metric(self, *, metric_group, topic):
         """Returns the corresponding `Metric` record to be associated with the current `data`
 
         Args:
@@ -324,7 +324,7 @@ class Consumer:
         geography = self._get_or_create_geography(geography_type=geography_type)
 
         metric_group = self._get_or_create_metric_group(topic=topic)
-        metric = self.get_or_create_metric(metric_group=metric_group, topic=topic)
+        metric = self._get_or_create_metric(metric_group=metric_group, topic=topic)
 
         stratum = self.get_or_create_stratum()
         age = self.get_or_create_age()

--- a/ingestion/consumer.py
+++ b/ingestion/consumer.py
@@ -289,7 +289,7 @@ class Consumer:
             name=self.dto.stratum,
         )
 
-    def get_or_create_age(self):
+    def _get_or_create_age(self):
         """Returns the corresponding `Age` record to be associated with the current `data`
 
         Returns:
@@ -327,7 +327,7 @@ class Consumer:
         metric = self._get_or_create_metric(metric_group=metric_group, topic=topic)
 
         stratum = self._get_or_create_stratum()
-        age = self.get_or_create_age()
+        age = self._get_or_create_age()
 
         return SupportingModelsLookup(
             metric_id=metric.id,

--- a/ingestion/consumer.py
+++ b/ingestion/consumer.py
@@ -193,7 +193,7 @@ class Consumer:
             theme_id=theme.id,
         )
 
-    def get_or_create_topic(self, *, sub_theme):
+    def _get_or_create_topic(self, *, sub_theme):
         """Returns the corresponding `Topic` record to be associated with the current `data`
 
         Args:
@@ -318,7 +318,7 @@ class Consumer:
         """
         theme = self._get_or_create_theme()
         sub_theme = self._get_or_create_sub_theme(theme=theme)
-        topic = self.get_or_create_topic(sub_theme=sub_theme)
+        topic = self._get_or_create_topic(sub_theme=sub_theme)
 
         geography_type = self.get_or_create_geography_type()
         geography = self.get_or_create_geography(geography_type=geography_type)

--- a/ingestion/consumer.py
+++ b/ingestion/consumer.py
@@ -222,7 +222,7 @@ class Consumer:
             name=self.dto.geography_type,
         )
 
-    def get_or_create_geography(self, *, geography_type):
+    def _get_or_create_geography(self, *, geography_type):
         """Returns the corresponding `Geography` record to be associated with the current `data`
 
         Args:
@@ -321,7 +321,7 @@ class Consumer:
         topic = self._get_or_create_topic(sub_theme=sub_theme)
 
         geography_type = self._get_or_create_geography_type()
-        geography = self.get_or_create_geography(geography_type=geography_type)
+        geography = self._get_or_create_geography(geography_type=geography_type)
 
         metric_group = self.get_or_create_metric_group(topic=topic)
         metric = self.get_or_create_metric(metric_group=metric_group, topic=topic)

--- a/ingestion/consumer.py
+++ b/ingestion/consumer.py
@@ -277,7 +277,7 @@ class Consumer:
             topic_id=topic.id,
         )
 
-    def get_or_create_stratum(self):
+    def _get_or_create_stratum(self):
         """Returns the corresponding `Stratum` record to be associated with the current `data`
 
         Returns:
@@ -326,7 +326,7 @@ class Consumer:
         metric_group = self._get_or_create_metric_group(topic=topic)
         metric = self._get_or_create_metric(metric_group=metric_group, topic=topic)
 
-        stratum = self.get_or_create_stratum()
+        stratum = self._get_or_create_stratum()
         age = self.get_or_create_age()
 
         return SupportingModelsLookup(

--- a/ingestion/consumer.py
+++ b/ingestion/consumer.py
@@ -210,7 +210,7 @@ class Consumer:
             sub_theme_id=sub_theme.id,
         )
 
-    def get_or_create_geography_type(self):
+    def _get_or_create_geography_type(self):
         """Returns the corresponding `GeographyType` record to be associated with the current `data`
 
         Returns:
@@ -320,7 +320,7 @@ class Consumer:
         sub_theme = self._get_or_create_sub_theme(theme=theme)
         topic = self._get_or_create_topic(sub_theme=sub_theme)
 
-        geography_type = self.get_or_create_geography_type()
+        geography_type = self._get_or_create_geography_type()
         geography = self.get_or_create_geography(geography_type=geography_type)
 
         metric_group = self.get_or_create_metric_group(topic=topic)

--- a/ingestion/consumer.py
+++ b/ingestion/consumer.py
@@ -164,7 +164,7 @@ class Consumer:
         record, _ = model_manager.get_or_create(**kwargs)
         return record
 
-    def get_or_create_theme(self):
+    def _get_or_create_theme(self):
         """Returns the corresponding `Theme` record to be associated with the current `data`
 
         Returns:
@@ -316,7 +316,7 @@ class Consumer:
             when creating the `CoreHeadline` or `CoreTimeSeries` records
 
         """
-        theme = self.get_or_create_theme()
+        theme = self._get_or_create_theme()
         sub_theme = self.get_or_create_sub_theme(theme=theme)
         topic = self.get_or_create_topic(sub_theme=sub_theme)
 

--- a/tests/unit/ingestion/consumer/test_get_or_create.py
+++ b/tests/unit/ingestion/consumer/test_get_or_create.py
@@ -68,7 +68,7 @@ class TestConsumerGetOrCreateMethods:
     ):
         """
         Given incoming headline data
-        When `get_or_create_topic()` is called
+        When `_get_or_create_topic()` is called
             from an instance of the `Consumer`
         Then the call is delegated to the
             `TopicManager` with the correct args
@@ -84,7 +84,7 @@ class TestConsumerGetOrCreateMethods:
         )
 
         # When
-        created_model = consumer.get_or_create_topic(sub_theme=mocked_sub_theme)
+        created_model = consumer._get_or_create_topic(sub_theme=mocked_sub_theme)
 
         # Then
         assert created_model == expected_model

--- a/tests/unit/ingestion/consumer/test_get_or_create.py
+++ b/tests/unit/ingestion/consumer/test_get_or_create.py
@@ -160,7 +160,7 @@ class TestConsumerGetOrCreateMethods:
     ):
         """
         Given incoming headline data
-        When `get_or_create_metric_group()` is called
+        When `_get_or_create_metric_group()` is called
             from an instance of the `Consumer`
         Then the call is delegated to the
             `MetricGroupManager` with the correct args
@@ -177,7 +177,7 @@ class TestConsumerGetOrCreateMethods:
         )
 
         # When
-        created_model = consumer.get_or_create_metric_group(topic=mocked_topic)
+        created_model = consumer._get_or_create_metric_group(topic=mocked_topic)
 
         # Then
         assert created_model == expected_model

--- a/tests/unit/ingestion/consumer/test_get_or_create.py
+++ b/tests/unit/ingestion/consumer/test_get_or_create.py
@@ -191,7 +191,7 @@ class TestConsumerGetOrCreateMethods:
     ):
         """
         Given incoming headline data
-        When `get_or_create_metric()` is called
+        When `_get_or_create_metric()` is called
             from an instance of the `Consumer`
         Then the call is delegated to the
             `MetricManager` with the correct args
@@ -208,7 +208,7 @@ class TestConsumerGetOrCreateMethods:
         )
 
         # When
-        created_model = consumer.get_or_create_metric(
+        created_model = consumer._get_or_create_metric(
             metric_group=mocked_metric_group, topic=mocked_topic
         )
 

--- a/tests/unit/ingestion/consumer/test_get_or_create.py
+++ b/tests/unit/ingestion/consumer/test_get_or_create.py
@@ -225,7 +225,7 @@ class TestConsumerGetOrCreateMethods:
     ):
         """
         Given incoming headline data
-        When `get_or_create_stratum()` is called
+        When `_get_or_create_stratum()` is called
             from an instance of the `Consumer`
         Then the call is delegated to the
             `StratumManager` with the correct args
@@ -240,7 +240,7 @@ class TestConsumerGetOrCreateMethods:
         )
 
         # When
-        created_model = consumer.get_or_create_stratum()
+        created_model = consumer._get_or_create_stratum()
 
         # Then
         assert created_model == expected_model

--- a/tests/unit/ingestion/consumer/test_get_or_create.py
+++ b/tests/unit/ingestion/consumer/test_get_or_create.py
@@ -25,7 +25,7 @@ class TestConsumerGetOrCreateMethods:
         )
 
         # When
-        created_model = consumer.get_or_create_theme()
+        created_model = consumer._get_or_create_theme()
 
         # Then
         assert created_model == expected_model

--- a/tests/unit/ingestion/consumer/test_get_or_create.py
+++ b/tests/unit/ingestion/consumer/test_get_or_create.py
@@ -126,7 +126,7 @@ class TestConsumerGetOrCreateMethods:
     ):
         """
         Given incoming headline data
-        When `get_or_create_geography()` is called
+        When `_get_or_create_geography()` is called
             from an instance of the `Consumer`
         Then the call is delegated to the
             `GeographyManager` with the correct args
@@ -143,7 +143,7 @@ class TestConsumerGetOrCreateMethods:
         )
 
         # When
-        created_model = consumer.get_or_create_geography(
+        created_model = consumer._get_or_create_geography(
             geography_type=mocked_geography_type
         )
 

--- a/tests/unit/ingestion/consumer/test_get_or_create.py
+++ b/tests/unit/ingestion/consumer/test_get_or_create.py
@@ -253,7 +253,7 @@ class TestConsumerGetOrCreateMethods:
     ):
         """
         Given incoming headline data
-        When `get_or_create_age()` is called
+        When `_get_or_create_age()` is called
             from an instance of the `Consumer`
         Then the call is delegated to the
             `AgeManager` with the correct args
@@ -268,7 +268,7 @@ class TestConsumerGetOrCreateMethods:
         )
 
         # When
-        created_model = consumer.get_or_create_age()
+        created_model = consumer._get_or_create_age()
 
         # Then
         assert created_model == expected_model

--- a/tests/unit/ingestion/consumer/test_get_or_create.py
+++ b/tests/unit/ingestion/consumer/test_get_or_create.py
@@ -97,7 +97,7 @@ class TestConsumerGetOrCreateMethods:
     ):
         """
         Given incoming headline data
-        When `get_or_create_geography_type()` is called
+        When `_get_or_create_geography_type()` is called
             from an instance of the `Consumer`
         Then the call is delegated to the
             `GeographyTypeManager` with the correct args
@@ -113,7 +113,7 @@ class TestConsumerGetOrCreateMethods:
         )
 
         # When
-        created_model = consumer.get_or_create_geography_type()
+        created_model = consumer._get_or_create_geography_type()
 
         # Then
         assert created_model == expected_model

--- a/tests/unit/ingestion/consumer/test_get_or_create.py
+++ b/tests/unit/ingestion/consumer/test_get_or_create.py
@@ -10,7 +10,7 @@ class TestConsumerGetOrCreateMethods:
     ):
         """
         Given incoming headline data
-        When `get_or_create_theme()` is called
+        When `_get_or_create_theme()` is called
             from an instance of the `Consumer`
         Then the call is delegated to the
             `ThemeManager` with the correct args
@@ -38,7 +38,7 @@ class TestConsumerGetOrCreateMethods:
     ):
         """
         Given incoming headline data
-        When `get_or_create_sub_theme()` is called
+        When `_get_or_create_sub_theme()` is called
             from an instance of the `Consumer`
         Then the call is delegated to the
             `SubThemeManager` with the correct args
@@ -55,7 +55,7 @@ class TestConsumerGetOrCreateMethods:
         )
 
         # When
-        created_model = consumer.get_or_create_sub_theme(theme=mocked_theme)
+        created_model = consumer._get_or_create_sub_theme(theme=mocked_theme)
 
         # Then
         assert created_model == expected_model

--- a/tests/unit/ingestion/consumer/test_update_supporting_models.py
+++ b/tests/unit/ingestion/consumer/test_update_supporting_models.py
@@ -25,7 +25,7 @@ def consumer_with_mocked_model_managers() -> Consumer:
 
 
 class TestConsumerUpdateSupportingModels:
-    @mock.patch.object(Consumer, "get_or_create_theme")
+    @mock.patch.object(Consumer, "_get_or_create_theme")
     @mock.patch.object(Consumer, "get_or_create_sub_theme")
     @mock.patch.object(Consumer, "get_or_create_topic")
     def test_updates_theme_sub_theme_and_topic(

--- a/tests/unit/ingestion/consumer/test_update_supporting_models.py
+++ b/tests/unit/ingestion/consumer/test_update_supporting_models.py
@@ -67,8 +67,8 @@ class TestConsumerUpdateSupportingModels:
             sub_theme=spy_get_or_create_sub_theme.return_value
         )
 
-    @mock.patch.object(Consumer, "get_or_create_geography_type")
-    @mock.patch.object(Consumer, "get_or_create_geography")
+    @mock.patch.object(Consumer, "_get_or_create_geography_type")
+    @mock.patch.object(Consumer, "_get_or_create_geography")
     def test_updates_geography_and_geography_type(
         self,
         spy_get_or_create_geography: mock.MagicMock,
@@ -101,9 +101,9 @@ class TestConsumerUpdateSupportingModels:
             geography_type=spy_get_or_create_geography_type.return_value
         )
 
-    @mock.patch.object(Consumer, "get_or_create_topic")
-    @mock.patch.object(Consumer, "get_or_create_metric_group")
-    @mock.patch.object(Consumer, "get_or_create_metric")
+    @mock.patch.object(Consumer, "_get_or_create_topic")
+    @mock.patch.object(Consumer, "_get_or_create_metric_group")
+    @mock.patch.object(Consumer, "_get_or_create_metric")
     def test_updates_metric_and_metric_group(
         self,
         spy_get_or_create_metric: mock.MagicMock,
@@ -146,7 +146,7 @@ class TestConsumerUpdateSupportingModels:
             topic=spy_get_or_create_topic.return_value,
         )
 
-    @mock.patch.object(Consumer, "get_or_create_stratum")
+    @mock.patch.object(Consumer, "_get_or_create_stratum")
     def test_updates_stratum(
         self,
         spy_get_or_create_stratum: mock.MagicMock,
@@ -172,7 +172,7 @@ class TestConsumerUpdateSupportingModels:
         # Then
         spy_get_or_create_stratum.assert_called_once()
 
-    @mock.patch.object(Consumer, "get_or_create_age")
+    @mock.patch.object(Consumer, "_get_or_create_age")
     def test_updates_age(
         self,
         spy_get_or_create_age: mock.MagicMock,
@@ -198,10 +198,10 @@ class TestConsumerUpdateSupportingModels:
         # Then
         spy_get_or_create_age.assert_called_once()
 
-    @mock.patch.object(Consumer, "get_or_create_stratum")
-    @mock.patch.object(Consumer, "get_or_create_age")
-    @mock.patch.object(Consumer, "get_or_create_geography")
-    @mock.patch.object(Consumer, "get_or_create_metric")
+    @mock.patch.object(Consumer, "_get_or_create_stratum")
+    @mock.patch.object(Consumer, "_get_or_create_age")
+    @mock.patch.object(Consumer, "_get_or_create_geography")
+    @mock.patch.object(Consumer, "_get_or_create_metric")
     def test_returns_supporting_models_lookup(
         self,
         spy_get_or_create_metric: mock.MagicMock,

--- a/tests/unit/ingestion/consumer/test_update_supporting_models.py
+++ b/tests/unit/ingestion/consumer/test_update_supporting_models.py
@@ -27,7 +27,7 @@ def consumer_with_mocked_model_managers() -> Consumer:
 class TestConsumerUpdateSupportingModels:
     @mock.patch.object(Consumer, "_get_or_create_theme")
     @mock.patch.object(Consumer, "_get_or_create_sub_theme")
-    @mock.patch.object(Consumer, "get_or_create_topic")
+    @mock.patch.object(Consumer, "_get_or_create_topic")
     def test_updates_theme_sub_theme_and_topic(
         self,
         spy_get_or_create_topic: mock.MagicMock,

--- a/tests/unit/ingestion/consumer/test_update_supporting_models.py
+++ b/tests/unit/ingestion/consumer/test_update_supporting_models.py
@@ -26,7 +26,7 @@ def consumer_with_mocked_model_managers() -> Consumer:
 
 class TestConsumerUpdateSupportingModels:
     @mock.patch.object(Consumer, "_get_or_create_theme")
-    @mock.patch.object(Consumer, "get_or_create_sub_theme")
+    @mock.patch.object(Consumer, "_get_or_create_sub_theme")
     @mock.patch.object(Consumer, "get_or_create_topic")
     def test_updates_theme_sub_theme_and_topic(
         self,


### PR DESCRIPTION
# Description

This PR includes the following:

- Sets some of the methods on the `Consumer` class that were only being called internally to be private. This needs to be doen before any new methods are added because the linter will be unhappy about the number of public methods. Which is fair!

Fixes #CDD-1443

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
