### PR TITLE
CDD-2111: Filter out headline metrics from charts component

### DIFF
--- a/cms/dynamic_content/elements.py
+++ b/cms/dynamic_content/elements.py
@@ -7,6 +7,7 @@ from cms.metrics_interface.field_choices_callables import (
     get_all_geography_type_names,
     get_all_sex_names,
     get_all_stratum_names,
+    get_all_timeseries_metric_names,
     get_all_topic_names,
     get_all_unique_metric_names,
     get_chart_line_types,
@@ -65,6 +66,11 @@ class BaseMetricsElement(blocks.StructBlock):
 
 
 class ChartPlotElement(BaseMetricsElement):
+    metric = blocks.ChoiceBlock(
+        required=True,
+        choices=get_all_timeseries_metric_names,
+        help_text=help_texts.METRIC_FIELD,
+    )
     chart_type = blocks.ChoiceBlock(
         required=True,
         choices=get_chart_types,

--- a/cms/metrics_interface/field_choices_callables.py
+++ b/cms/metrics_interface/field_choices_callables.py
@@ -65,6 +65,29 @@ def get_all_unique_metric_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
     )
 
 
+def get_all_timeseries_metric_names() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
+    """Callable for the `choices` on the `metric` fields of the CMS blocks.
+
+    Notes:
+        This callable wraps the `MetricsAPIInterface`
+        and is passed to a migration for the CMS blocks.
+        This means that we don't need to create a new migration
+        whenever a new `Metric` is added to that table.
+        Instead, the 1-off migration is pointed at this callable.
+        So Wagtail will pull the choices by invoking this function.
+
+    Returns:
+        A list of 2-item tuples of unique metric names.
+        Examples:
+            [("COVID-19_deaths_ONSByDay", "COVID-19_deaths_ONSByDay"), ...]
+
+    """
+    metrics_interface = MetricsAPIInterface()
+    return _build_two_item_tuple_choices(
+        choices=metrics_interface.get_all_timeseries_metric_names()
+    )
+
+
 def get_chart_types() -> LIST_OF_TWO_STRING_ITEM_TUPLES:
     """Callable for the `choices` on the `chart_type` fields of the CMS blocks.
 

--- a/cms/metrics_interface/interface.py
+++ b/cms/metrics_interface/interface.py
@@ -142,6 +142,18 @@ class MetricsAPIInterface:
         """
         return self.metric_manager.get_all_unique_names()
 
+    def get_all_timeseries_metric_names(self) -> QuerySet:
+        """Gets all unique metric names that belong to a timeseries metric_group as a flat list.
+        Note this is achieved by delegating the call to the `MetricManager` from the Metrics API
+
+        Returns:
+            QuerySet: A queryset of the individual metric names without repetition:
+                Examples:
+                    `<MetricQuerySet ['COVID-19_deaths_ONSByDay', 'COVID-19_deaths_ONSByDay']>`
+
+        """
+        return self.metric_manager.get_all_timeseries_names()
+
     def get_all_unique_change_type_metric_names(self) -> QuerySet:
         """Gets all unique metric names as a flat list queryset, which contain the word `change`
         Note this is achieved by delegating the call to the `MetricManager` from the Metrics API

--- a/metrics/data/managers/core_models/metric.py
+++ b/metrics/data/managers/core_models/metric.py
@@ -58,6 +58,19 @@ class MetricQuerySet(models.QuerySet):
         """
         return self.get_all_unique_names().filter(name__icontains="percent")
 
+    def get_all_timeseries_names(self) -> models.QuerySet:
+        """Gets all unique metric names that have a `timeseries` metric_group
+            and returns them as a flat list.
+
+        Returns:
+            QuerySet: A queryset of the individual metric names without repetition
+                ordered in descending ordering starting from A -> Z:
+                    Examples:
+                        `<MetricQuerySet ['COVID-19_deaths_ONSByDay', 'COVID-19_testing_PCRcountByDay']>`
+
+        """
+        return self.get_all_unique_names().exclude(metric_group__name="headline")
+
     def get_all_headline_names(self) -> models.QuerySet:
         """Gets all unique headline metric names as a flat list queryset
 
@@ -121,6 +134,16 @@ class MetricManager(models.Manager):
 
         """
         return self.get_queryset().get_all_unique_percent_change_type_names()
+
+    def get_all_timeseries_names(self) -> MetricQuerySet:
+        """Gets all unique timeseries metric names as a flat list queryset
+
+        Returns:
+            QuerySet: A queryset of the individual metric names without repetition
+                Examples:
+                    `<MetricQuerySet ['COVID-19_deaths_ONSByDay', 'COVID-19_testing_PCRcountByDay']>`
+        """
+        return self.get_queryset().get_all_timeseries_names()
 
     def get_all_headline_names(self) -> MetricQuerySet:
         """Gets all unique headline metric names as a flat list queryset

--- a/tests/integration/metrics/data/managers/core_models/test_metric.py
+++ b/tests/integration/metrics/data/managers/core_models/test_metric.py
@@ -1,6 +1,6 @@
 import pytest
 
-from metrics.data.models.core_models import Metric
+from metrics.data.models.core_models import Metric, MetricGroup
 from tests.factories.metrics.metric import MetricFactory
 
 
@@ -27,5 +27,35 @@ class TestMetricManager:
         # Then
         assert all_unique_change_type_metrics.count() == 1
         assert change_type_metric_name in all_unique_change_type_metrics.values_list(
+            "name", flat=True
+        )
+
+    @pytest.mark.django_db
+    def test_get_all_timeseries_metric_names(self):
+        """
+        Given a number of existing `Metric` records
+        When `get_all_timeseries_metric_names()` is called
+            from the `MetricManager`
+        Then the metrics returned have been filtered correctly
+        """
+        # Given
+        timeseries_metric_name = "COVID-19_deaths_ONSByWeek"
+        timeseries_metric_group = MetricGroup.objects.create(name="deaths")
+        Metric.objects.create(
+            name=timeseries_metric_name,
+            metric_group=timeseries_metric_group,
+        )
+        headline_metric_group = MetricGroup.objects.create(name="headline")
+        Metric.objects.create(
+            name="COVID-19_headline_ONSdeaths_7DayChange",
+            metric_group=headline_metric_group,
+        )
+
+        # When
+        all_timeseries_metric_names = Metric.objects.get_all_timeseries_names()
+
+        # Then
+        assert all_timeseries_metric_names.count() == 1
+        assert timeseries_metric_name in all_timeseries_metric_names.values_list(
             "name", flat=True
         )

--- a/tests/unit/cms/metrics_interface/test_field_choices_callables.py
+++ b/tests/unit/cms/metrics_interface/test_field_choices_callables.py
@@ -29,6 +29,29 @@ class TestGetAllUniqueMetricNames:
         assert unique_metric_names == [(x, x) for x in retrieved_unique_metric_names]
 
 
+class TestGetAlLTimeSeriesMetricNames:
+    @mock.patch.object(interface.MetricsAPIInterface, "get_all_timeseries_metric_names")
+    def test_delegates_calls_correctly(
+        self, mocked_get_all_timeseries_metric_names: mock.MagicMock
+    ):
+        """
+        Given an instance of the `MetricsAPIInterface` which returns unique timeseries metric names
+        When `get_all_timeseries_metric_names()` is called
+        Then the unique metric names are returned as a list of 2-item tuples
+        """
+        # Given
+        retrieved_unique_metric_names = ["COVID-19_deaths_ONSRollingMean"]
+        mocked_get_all_timeseries_metric_names.return_value = (
+            retrieved_unique_metric_names
+        )
+
+        # When
+        unique_metric_names = field_choices_callables.get_all_timeseries_metric_names()
+
+        # Then
+        assert unique_metric_names == [(x, x) for x in retrieved_unique_metric_names]
+
+
 class TestGetAllUniqueChangeTypeMetricNames:
     @mock.patch.object(
         interface.MetricsAPIInterface, "get_all_unique_change_type_metric_names"

--- a/tests/unit/cms/metrics_interface/test_interface.py
+++ b/tests/unit/cms/metrics_interface/test_interface.py
@@ -108,6 +108,30 @@ class TestMetricsAPIInterface:
             == spy_metric_manager.get_all_unique_names.return_value
         )
 
+    def test_get_all_timeseries_metric_names(self):
+        """
+        Given a `MetricManager` from the Metrics API app
+        When `get_all_timeseries_metric_names()` is called from an instance of the `MetricsAPIInterface`
+        Then the call is delegated to the correct method  on the `MetricManager`
+        """
+        # Given
+        spy_metric_manager = mock.Mock()
+        metrics_api_interface = interface.MetricsAPIInterface(
+            metric_manager=spy_metric_manager,
+            topic_manager=mock.Mock(),
+        )
+
+        # When
+        all_timeseries_metric_names = (
+            metrics_api_interface.get_all_timeseries_metric_names()
+        )
+
+        # Then
+        assert (
+            all_timeseries_metric_names
+            == spy_metric_manager.get_all_timeseries_names.return_value
+        )
+
     def test_get_all_unique_change_type_metric_names_delegates_call_correctly(self):
         """
         Given a `MetricManager` from the Metrics API app


### PR DESCRIPTION
# Description

This PR includes an update to the chart component in the cms to filter out `Headline` metrics from the metric choice field. The headline charts will be managed through a Headline chart component.

-

Fixes #CDD-2111

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
