### PR TITLE
Task/clear stale data at point of data ingestion/cdd 1443

### DIFF
--- a/ingestion/consumer.py
+++ b/ingestion/consumer.py
@@ -456,6 +456,24 @@ class Consumer:
             model_manager=self.core_timeseries_manager, model_instances=core_time_series
         )
 
+    def clear_stale_headlines(self):
+        """Deletes all stale records for the `CoreHeadline` records relevant to the ingested dataset
+
+        Returns:
+            None
+
+        """
+        self.core_headline_manager.delete_superseded_data(
+            topic_name=self.dto.topic,
+            metric_name=self.dto.metric,
+            geography_name=self.dto.geography,
+            geography_type_name=self.dto.geography_type,
+            geography_code=self.dto.geography_code,
+            stratum_name=self.dto.stratum,
+            sex=self.dto.sex,
+            age=self.dto.age,
+        )
+
     def build_api_time_series(self) -> list[API_TIME_SERIES_MODEL]:
         """Builds `APITimeSeries` model instances from the ingested data
 
@@ -516,3 +534,29 @@ class Consumer:
         """
         self.create_core_time_series()
         self.create_api_time_series()
+
+    def clear_stale_timeseries(self):
+        """Deletes all stale records for both `CoreTimeSeries` and `APITimeSeries` relevant to the ingested dataset
+
+        Returns:
+            None
+
+        """
+        self.core_timeseries_manager.delete_superseded_data(
+            metric_name=self.dto.metric,
+            geography_name=self.dto.geography,
+            geography_type_name=self.dto.geography_type,
+            geography_code=self.dto.geography_code,
+            stratum_name=self.dto.stratum,
+            sex=self.dto.sex,
+            age=self.dto.age,
+        )
+        self.api_timeseries_manager.delete_superseded_data(
+            metric_name=self.dto.metric,
+            geography_name=self.dto.geography,
+            geography_type_name=self.dto.geography_type,
+            geography_code=self.dto.geography_code,
+            stratum_name=self.dto.stratum,
+            sex=self.dto.sex,
+            age=self.dto.age,
+        )

--- a/ingestion/consumer.py
+++ b/ingestion/consumer.py
@@ -552,6 +552,9 @@ class Consumer:
             age=self.dto.age,
         )
         self.api_timeseries_manager.delete_superseded_data(
+            theme_name=self.dto.parent_theme,
+            sub_theme=self.dto.child_theme,
+            topic_name=self.dto.topic,
             metric_name=self.dto.metric,
             geography_name=self.dto.geography,
             geography_type_name=self.dto.geography_type,

--- a/ingestion/consumer.py
+++ b/ingestion/consumer.py
@@ -336,6 +336,41 @@ class Consumer:
             age_id=age.id,
         )
 
+    def process_core_headlines(self) -> None:
+        """Creates `CoreHeadline` database records from the ingested data after stale records are deleted ahead of time.
+
+        Notes:
+            Any necessary supporting models will be created
+            as required for the `CoreHeadline` records.
+            For example, if the ingested data contains a new value
+            for the `topic` field which is not already available as a `Topic` model,
+            then a new `Topic` model will be created
+            and that record will be inserted into the database.
+
+        Returns:
+            None
+
+        """
+        self.clear_stale_headlines()
+        self.create_core_headlines()
+
+    def process_core_and_api_timeseries(self) -> None:
+        """Creates `APITimeSeries` and `CoreTimeSeries` records from the ingested data after stale records are deleted.
+
+        Any necessary supporting models will be created
+            as required for the records.
+            For example, if the ingested data contains a new value
+            for the `topic` field which is not already available as a `Topic` model,
+            then a new `Topic` model will be created
+            and that record will be inserted into the database.
+
+        Returns:
+            None
+
+        """
+        self.clear_stale_timeseries()
+        self.create_core_and_api_timeseries()
+
     # build and create model methods
 
     def build_core_headlines(self) -> list[CORE_HEADLINE_MODEL]:

--- a/ingestion/consumer.py
+++ b/ingestion/consumer.py
@@ -588,7 +588,7 @@ class Consumer:
         )
         self.api_timeseries_manager.delete_superseded_data(
             theme_name=self.dto.parent_theme,
-            sub_theme=self.dto.child_theme,
+            sub_theme_name=self.dto.child_theme,
             topic_name=self.dto.topic,
             metric_name=self.dto.metric,
             geography_name=self.dto.geography,

--- a/metrics/data/managers/api_models/time_series.py
+++ b/metrics/data/managers/api_models/time_series.py
@@ -430,4 +430,10 @@ class APITimeSeriesManager(models.Manager):
             sex=sex,
             age=age,
         )
-        superseded_records.delete()
+        # Note that we cannot call `delete()` on the above queryset.
+        # This is because it uses the `WINDOW` function.
+        # Which is not allowed with a `DELETE` statement.
+        superseded_record_ids = superseded_records.values_list("id", flat=True)
+
+        stale_records = self.get_queryset().filter(pk__in=superseded_record_ids)
+        stale_records.delete()

--- a/metrics/data/managers/core_models/headline.py
+++ b/metrics/data/managers/core_models/headline.py
@@ -284,8 +284,14 @@ class CoreHeadlineManager(models.Manager):
         # Which cannot be done since `OFFSET` and `DELETE` clauses are not allowed.
         # Since we always expect the number of resulting records to be fairly small.
         # We can pay the penalty of making the extra db call.
-        live_headline = queryset.first()
-        return queryset.exclude(id=live_headline.id)
+        try:
+            live_headline_id: int = queryset.first().id
+        except AttributeError:
+            # Thrown when the queryset was empty
+            # And `first()` returned `None`
+            return queryset
+
+        return queryset.exclude(id=live_headline_id)
 
     def get_latest_headlines_for_geography_codes(
         self,

--- a/metrics/data/managers/core_models/headline.py
+++ b/metrics/data/managers/core_models/headline.py
@@ -269,7 +269,7 @@ class CoreHeadlineManager(models.Manager):
            The stale records in their entirety as a queryset
 
         """
-        return self.get_queryset().get_headlines_released_from_embargo(
+        queryset = self.get_queryset().get_headlines_released_from_embargo(
             topic_name=topic_name,
             metric_name=metric_name,
             geography_name=geography_name,
@@ -278,7 +278,14 @@ class CoreHeadlineManager(models.Manager):
             stratum_name=stratum_name,
             age=age,
             sex=sex,
-        )[1:]
+        )
+        # Note that we cannot slice / limit the above queryset.
+        # This is because we will later call `delete()` on this queryset.
+        # Which cannot be done since `OFFSET` and `DELETE` clauses are not allowed.
+        # Since we always expect the number of resulting records to be fairly small.
+        # We can pay the penalty of making the extra db call.
+        live_headline = queryset.first()
+        return queryset.exclude(id=live_headline.id)
 
     def get_latest_headlines_for_geography_codes(
         self,

--- a/tests/unit/ingestion/consumer/test_clear_stale_models.py
+++ b/tests/unit/ingestion/consumer/test_clear_stale_models.py
@@ -69,6 +69,9 @@ class TestConsumerClearStaleModels:
             age=example_headline_data["age"],
         )
         spy_api_timeseries_manager.delete_superseded_data.assert_called_once_with(
+            theme_name=example_headline_data["parent_theme"],
+            sub_theme=example_headline_data["child_theme"],
+            topic_name=example_headline_data["topic"],
             metric_name=example_headline_data["metric"],
             geography_name=example_headline_data["geography"],
             geography_type_name=example_headline_data["geography_type"],

--- a/tests/unit/ingestion/consumer/test_clear_stale_models.py
+++ b/tests/unit/ingestion/consumer/test_clear_stale_models.py
@@ -70,7 +70,7 @@ class TestConsumerClearStaleModels:
         )
         spy_api_timeseries_manager.delete_superseded_data.assert_called_once_with(
             theme_name=example_headline_data["parent_theme"],
-            sub_theme=example_headline_data["child_theme"],
+            sub_theme_name=example_headline_data["child_theme"],
             topic_name=example_headline_data["topic"],
             metric_name=example_headline_data["metric"],
             geography_name=example_headline_data["geography"],

--- a/tests/unit/ingestion/consumer/test_clear_stale_models.py
+++ b/tests/unit/ingestion/consumer/test_clear_stale_models.py
@@ -1,0 +1,79 @@
+from unittest import mock
+
+from ingestion.consumer import Consumer
+from metrics.data.managers.api_models.time_series import APITimeSeriesManager
+from metrics.data.managers.core_models.headline import CoreHeadlineManager
+from metrics.data.managers.core_models.time_series import CoreTimeSeriesManager
+
+
+class TestConsumerClearStaleModels:
+    def test_clear_stale_headlines(self, example_headline_data: dict):
+        """
+        Given incoming headline data
+        When `clear_stale_headlines()` is called
+            from an instance of the `Consumer`
+        Then the call is delegated to the
+            `CoreHeadlineManager` with the correct args
+        """
+        # Given
+        spy_core_headline_manager = mock.Mock(spec_set=CoreHeadlineManager)
+        consumer = Consumer(
+            source_data=example_headline_data,
+            core_headline_manager=spy_core_headline_manager,
+        )
+
+        # When
+        consumer.clear_stale_headlines()
+
+        # Then
+        spy_core_headline_manager.delete_superseded_data.assert_called_once_with(
+            topic_name=example_headline_data["topic"],
+            metric_name=example_headline_data["metric"],
+            geography_name=example_headline_data["geography"],
+            geography_type_name=example_headline_data["geography_type"],
+            geography_code=example_headline_data["geography_code"],
+            stratum_name=example_headline_data["stratum"],
+            sex=example_headline_data["sex"],
+            age=example_headline_data["age"],
+        )
+
+    def test_clear_stale_timeseries(self, example_headline_data: dict):
+        """
+        Given incoming timeseries data
+        When `clear_stale_timeseries()` is called
+            from an instance of the `Consumer`
+        Then the call is delegated to the
+            `CoreTimeSeriesManager` with the correct args
+        And a similar call is made to the `APITimeSeriesManager`
+        """
+        # Given
+        spy_core_timeseries_manager = mock.Mock(spec_set=CoreTimeSeriesManager)
+        spy_api_timeseries_manager = mock.Mock(spec_set=APITimeSeriesManager)
+        consumer = Consumer(
+            source_data=example_headline_data,
+            core_timeseries_manager=spy_core_timeseries_manager,
+            api_timeseries_manager=spy_api_timeseries_manager,
+        )
+
+        # When
+        consumer.clear_stale_timeseries()
+
+        # Then
+        spy_core_timeseries_manager.delete_superseded_data.assert_called_once_with(
+            metric_name=example_headline_data["metric"],
+            geography_name=example_headline_data["geography"],
+            geography_type_name=example_headline_data["geography_type"],
+            geography_code=example_headline_data["geography_code"],
+            stratum_name=example_headline_data["stratum"],
+            sex=example_headline_data["sex"],
+            age=example_headline_data["age"],
+        )
+        spy_api_timeseries_manager.delete_superseded_data.assert_called_once_with(
+            metric_name=example_headline_data["metric"],
+            geography_name=example_headline_data["geography"],
+            geography_type_name=example_headline_data["geography_type"],
+            geography_code=example_headline_data["geography_code"],
+            stratum_name=example_headline_data["stratum"],
+            sex=example_headline_data["sex"],
+            age=example_headline_data["age"],
+        )

--- a/tests/unit/ingestion/consumer/test_process_models.py
+++ b/tests/unit/ingestion/consumer/test_process_models.py
@@ -1,0 +1,71 @@
+from unittest import mock
+
+from ingestion.consumer import Consumer
+
+
+class TestConsumerProcessModels:
+    @mock.patch.object(Consumer, "create_core_headlines")
+    @mock.patch.object(Consumer, "clear_stale_headlines")
+    def test_process_core_headlines(
+        self,
+        spy_clear_stale_headlines: mock.MagicMock,
+        spy_create_core_headlines: mock.MagicMock,
+        example_headline_data,
+    ):
+        """
+        Given incoming headline data
+        When `process_core_headlines()` is called
+            from an instance of the `Consumer`
+        Then the `clear_stale_headlines()` method is called first
+        And then the `create_core_headlines()` method is called after
+        """
+        # Given
+        spy_manager = mock.Mock()
+        spy_manager.attach_mock(spy_clear_stale_headlines, "spy_clear_stale_headlines")
+        spy_manager.attach_mock(spy_create_core_headlines, "spy_create_core_headlines")
+        consumer = Consumer(source_data=example_headline_data)
+
+        # When
+        consumer.process_core_headlines()
+
+        # Then
+        expected_calls = [
+            mock.call.spy_clear_stale_headlines,
+            mock.call.spy_create_core_headlines,
+        ]
+        spy_manager.assert_has_calls(calls=expected_calls, any_order=False)
+
+    @mock.patch.object(Consumer, "create_core_and_api_timeseries")
+    @mock.patch.object(Consumer, "clear_stale_timeseries")
+    def test_process_timeseries(
+        self,
+        spy_clear_stale_timeseries: mock.MagicMock,
+        spy_create_core_and_api_timeseries: mock.MagicMock,
+        example_headline_data,
+    ):
+        """
+        Given incoming timeseries data
+        When `process_core_and_api_timeseries()` is called
+            from an instance of the `Consumer`
+        Then the `clear_stale_timeseries()` method is called first
+        And then the `create_core_and_api_timeseries()` method is called after
+        """
+        # Given
+        spy_manager = mock.Mock()
+        spy_manager.attach_mock(
+            spy_clear_stale_timeseries, "spy_clear_stale_timeseries"
+        )
+        spy_manager.attach_mock(
+            spy_create_core_and_api_timeseries, "spy_create_core_and_api_timeseries"
+        )
+        consumer = Consumer(source_data=example_headline_data)
+
+        # When
+        consumer.process_core_and_api_timeseries()
+
+        # Then
+        expected_calls = [
+            mock.call.spy_clear_stale_timeseries,
+            mock.call.spy_create_core_and_api_timeseries,
+        ]
+        spy_manager.assert_has_calls(calls=expected_calls, any_order=False)

--- a/tests/unit/metrics/data/managers/core_models/test_headline.py
+++ b/tests/unit/metrics/data/managers/core_models/test_headline.py
@@ -1,6 +1,10 @@
 from unittest import mock
 
-from metrics.data.managers.core_models.headline import CoreHeadlineManager
+from metrics.data.managers.core_models.headline import (
+    CoreHeadlineManager,
+    CoreHeadlineQuerySet,
+)
+from metrics.data.models.core_models import CoreHeadline
 
 
 class TestCoreHeadlineManager:
@@ -53,3 +57,42 @@ class TestCoreHeadlineManager:
 
         returned_records = spy_query_for_superseded_data.return_value
         returned_records.delete.assert_called_once()
+
+    @mock.patch.object(CoreHeadlineQuerySet, "get_headlines_released_from_embargo")
+    def test_query_for_superseded_data_returns_empty_queryset_for_no_data(
+        self, mocked_get_headlines_released_from_embargo: mock.MagicMock
+    ):
+        """
+        Given a payload containing the required fields
+            for a dataset slice which does not exist
+        When `query_for_superseded_data()` is called
+            from an instance of the `CoreHeadlineManager`
+        Then an empty queryset is returned
+        """
+        # Given
+        fake_topic = "COVID-19"
+        fake_metric = "COVID-19_deaths_ONSByWeek"
+        fake_geography = "England"
+        fake_geography_type = "Nation"
+        fake_geography_code = "E92000001"
+        fake_stratum = "default"
+        fake_sex = "all"
+        fake_age = "all"
+        mocked_get_headlines_released_from_embargo.return_value = (
+            CoreHeadline.objects.none()
+        )
+
+        # When
+        queryset = CoreHeadline.objects.query_for_superseded_data(
+            topic_name=fake_topic,
+            metric_name=fake_metric,
+            geography_name=fake_geography,
+            geography_type_name=fake_geography_type,
+            geography_code=fake_geography_code,
+            stratum_name=fake_stratum,
+            sex=fake_sex,
+            age=fake_age,
+        )
+
+        # Then
+        assert not queryset.exists()


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds `process_core_headlines()` and `process_core_and_api_timeseries()` methods on the `Consumer` class. This means we clear stale data **before** ingesting the new data. This means at the point of ingestion we will only have the 1 live record per window + a stale record.

Fixes #CDD-1443

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
