### PR TITLE
Crawl for global-banners and menus when the main headless CMS pages/ API is crawled

### DIFF
--- a/caching/internal_api_client.py
+++ b/caching/internal_api_client.py
@@ -11,6 +11,8 @@ CHARTS_ENDPOINT_PATH = f"{API_PREFIX}charts/v3/"
 TABLES_ENDPOINT_PATH = f"{API_PREFIX}tables/v4/"
 DOWNLOADS_ENDPOINT_PATH = f"{API_PREFIX}downloads/v2/"
 GEOGRAPHIES_ENDPOINT_PATH = f"{API_PREFIX}geographies/v2/"
+GLOBAL_BANNERS_ENDPOINT_PATH = f"{API_PREFIX}global-banners/v1"
+MENUS_ENDPOINT_PATH = f"{API_PREFIX}menus/v1"
 
 
 CACHE_FORCE_REFRESH_HEADER_KEY = "Cache-Force-Refresh"
@@ -51,6 +53,8 @@ class InternalAPIClient:
         self.tables_endpoint_path = TABLES_ENDPOINT_PATH
         self.downloads_endpoint_path = DOWNLOADS_ENDPOINT_PATH
         self.geographies_endpoint_path = GEOGRAPHIES_ENDPOINT_PATH
+        self.global_banners_endpoint_path = GLOBAL_BANNERS_ENDPOINT_PATH
+        self.menus_endpoint_path = MENUS_ENDPOINT_PATH
 
         # Header configurations
         self.force_refresh = force_refresh
@@ -244,3 +248,27 @@ class InternalAPIClient:
         headers = self.build_headers()
         self._client.get(path=f"{path}/", headers=headers, format="json")
         return self._client.get(path=path, headers=headers, format="json")
+
+    def hit_global_banners_endpoint(self) -> Response:
+        """Sends a `GET` request to the `global-banners/` endpoint
+
+        Returns:
+            `Response` from the `global-banners/` endpoint
+
+        """
+        headers = self.build_headers()
+        return self._client.get(
+            path=self.global_banners_endpoint_path, headers=headers, format="json"
+        )
+
+    def hit_menus_endpoint(self) -> Response:
+        """Sends a `GET` request to the `menus/` endpoint
+
+        Returns:
+            `Response` from the `menus/` endpoint
+
+        """
+        headers = self.build_headers()
+        return self._client.get(
+            path=self.menus_endpoint_path, headers=headers, format="json"
+        )

--- a/caching/private_api/crawler/headless_cms_api.py
+++ b/caching/private_api/crawler/headless_cms_api.py
@@ -49,3 +49,33 @@ class HeadlessCMSAPICrawler:
         """
         logger.info("Hitting GET pages/ endpoint for `%s` page", page.title)
         self._internal_api_client.hit_pages_detail_endpoint(page_id=page.id)
+
+    def process_all_snippets(self) -> None:
+        """Makes a request to all the requisite snippet endpoints
+
+        Returns:
+            None
+
+        """
+        self.process_global_banners_for_headless_cms_api()
+        self.process_menus_for_headless_cms_api()
+
+    def process_global_banners_for_headless_cms_api(self) -> None:
+        """Makes a request to the headless CMS API `global-banners/` endpoint
+
+        Returns:
+            None
+
+        """
+        logger.info("Hitting GET global-banners/ endpoint")
+        self._internal_api_client.hit_global_banners_endpoint()
+
+    def process_menus_for_headless_cms_api(self) -> None:
+        """Makes a request to the headless CMS API `menus/` endpoint
+
+        Returns:
+            None
+
+        """
+        logger.info("Hitting GET menus/ endpoint")
+        self._internal_api_client.hit_menus_endpoint()

--- a/caching/private_api/crawler/private_api_crawler.py
+++ b/caching/private_api/crawler/private_api_crawler.py
@@ -110,6 +110,7 @@ class PrivateAPICrawler:
         self._headless_cms_api_crawler.process_detail_pages_for_headless_cms_api(
             pages=pages
         )
+        self._headless_cms_api_crawler.process_all_snippets()
         logger.info("Completed processing of headless CMS API")
 
         pages_count = len(pages)

--- a/tests/unit/caching/private_api/crawler/private_api_crawler/test_process_pages.py
+++ b/tests/unit/caching/private_api/crawler/private_api_crawler/test_process_pages.py
@@ -104,6 +104,36 @@ class TestPrivateAPICrawlerProcessPages:
             pages=fake_pages
         )
 
+    @mock.patch.object(HeadlessCMSAPICrawler, "process_all_snippets")
+    def test_delegates_call_for_processing_all_snippets(
+        self,
+        spy_process_all_snippets: mock.MagicMock,
+        private_api_crawler_with_mocked_internal_api_client: PrivateAPICrawler,
+    ):
+        """
+        Given a list of pages
+        When `process_pages()` is called
+            from an instance of `PrivateAPICrawler`
+        Then the `process_all_snippets()` method is called
+
+        Patches:
+            `spy_process_all_snippets`: For the main assertion
+
+        """
+        # Given
+        fake_pages = [
+            FakeTopicPageFactory._build_page(page_name="covid_19"),
+            FakeTopicPageFactory._build_page(page_name="influenza"),
+        ]
+
+        # When
+        private_api_crawler_with_mocked_internal_api_client.process_pages(
+            pages=fake_pages
+        )
+
+        # Then
+        spy_process_all_snippets.assert_called_once()
+
     def test_logs_when_page_sections_cannot_be_processed_eg_common_pages(
         self,
         private_api_crawler_with_mocked_internal_api_client: PrivateAPICrawler,

--- a/tests/unit/caching/private_api/crawler/test_headless_cms_api.py
+++ b/tests/unit/caching/private_api/crawler/test_headless_cms_api.py
@@ -140,3 +140,71 @@ class TestHeadlessCMSAPICrawler:
                 f"Hitting GET pages/ endpoint for `{mocked_page.title}` page"
                 in caplog.text
             )
+
+    # Snippets
+
+    @mock.patch.object(
+        HeadlessCMSAPICrawler, "process_global_banners_for_headless_cms_api"
+    )
+    @mock.patch.object(HeadlessCMSAPICrawler, "process_menus_for_headless_cms_api")
+    def test_process_all_snippets(
+        self,
+        spy_process_global_banners_for_headless_cms_api: mock.MagicMock,
+        spy_process_menus_for_headless_cms_api: mock.MagicMock,
+        headless_cms_api_crawler_with_mocked_internal_api_client: HeadlessCMSAPICrawler,
+    ):
+        """
+        Given no input
+        When `process_all_snippets()` is called
+            from an instance of the `HeadlessCMSAPICrawler`
+        Then the call is delegated to each of the methods
+            for the correct snippets
+        """
+        # Given / When
+        headless_cms_api_crawler_with_mocked_internal_api_client.process_all_snippets()
+
+        # Then
+        spy_process_global_banners_for_headless_cms_api.assert_called_once()
+        spy_process_menus_for_headless_cms_api.assert_called_once()
+
+    def test_process_global_banners_for_headless_cms_api_delegates_call_to_api_client(
+        self,
+        headless_cms_api_crawler_with_mocked_internal_api_client: HeadlessCMSAPICrawler,
+    ):
+        """
+        Given no input
+        When `process_global_banners_for_headless_cms_api()`
+            is called from an instance of `HeadlessCMSAPICrawler`
+        Then the call is delegated to the `InternalAPIClient`
+        """
+        # Given
+        spy_internal_api_client: mock.Mock = (
+            headless_cms_api_crawler_with_mocked_internal_api_client._internal_api_client
+        )
+
+        # When
+        headless_cms_api_crawler_with_mocked_internal_api_client.process_global_banners_for_headless_cms_api()
+
+        # Then
+        spy_internal_api_client.hit_global_banners_endpoint.assert_called_once()
+
+    def test_process_menus_for_headless_cms_api_delegates_call_to_api_client(
+        self,
+        headless_cms_api_crawler_with_mocked_internal_api_client: HeadlessCMSAPICrawler,
+    ):
+        """
+        Given no input
+        When `process_menus_for_headless_cms_api()`
+            is called from an instance of `HeadlessCMSAPICrawler`
+        Then the call is delegated to the `InternalAPIClient`
+        """
+        # Given
+        spy_internal_api_client: mock.Mock = (
+            headless_cms_api_crawler_with_mocked_internal_api_client._internal_api_client
+        )
+
+        # When
+        headless_cms_api_crawler_with_mocked_internal_api_client.process_menus_for_headless_cms_api()
+
+        # Then
+        spy_internal_api_client.hit_menus_endpoint.assert_called_once()

--- a/tests/unit/caching/test_internal_api_client.py
+++ b/tests/unit/caching/test_internal_api_client.py
@@ -24,6 +24,8 @@ class TestInternalAPIClient:
                 ("tables_endpoint_path", "/api/tables/v4/"),
                 ("downloads_endpoint_path", "/api/downloads/v2/"),
                 ("geographies_endpoint_path", "/api/geographies/v2/"),
+                ("global_banners_endpoint_path", "/api/global-banners/v1"),
+                ("menus_endpoint_path", "/api/menus/v1"),
             ]
         ),
     )
@@ -512,3 +514,47 @@ class TestInternalAPIClient:
         ]
 
         mocked_client.get.assert_has_calls(calls=expected_calls, any_order=True)
+
+    def test_hit_global_banners_endpoint_delegates_call_correctly(self):
+        """
+        Given a client and mocked request data
+        When `hit_global_banners_endpoint()` is called
+            from an instance of the `InternalAPIClient`
+        Then the call is delegated to the `client` object
+        """
+        # Given
+        mocked_client = mock.Mock()
+        internal_api_client = InternalAPIClient(client=mocked_client)
+
+        # When
+        response = internal_api_client.hit_global_banners_endpoint()
+
+        # Then
+        assert response == mocked_client.get.return_value
+        mocked_client.get.assert_called_once_with(
+            path=internal_api_client.global_banners_endpoint_path,
+            headers=internal_api_client.build_headers(),
+            format="json",
+        )
+
+    def test_hit_menus_endpoint_delegates_call_correctly(self):
+        """
+        Given a client and mocked request data
+        When `hit_menus_endpoint()` is called
+            from an instance of the `InternalAPIClient`
+        Then the call is delegated to the `client` object
+        """
+        # Given
+        mocked_client = mock.Mock()
+        internal_api_client = InternalAPIClient(client=mocked_client)
+
+        # When
+        response = internal_api_client.hit_menus_endpoint()
+
+        # Then
+        assert response == mocked_client.get.return_value
+        mocked_client.get.assert_called_once_with(
+            path=internal_api_client.menus_endpoint_path,
+            headers=internal_api_client.build_headers(),
+            format="json",
+        )


### PR DESCRIPTION
# Description

This PR includes the following:

- Includes the `global-banners` and `menus` endpoint when the private API crawler crawls the headless CMS API

Fixes #CDD-2142

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
