### PR TITLE
Task/cdd 2168 update period dates in downloads

### DIFF
--- a/metrics/api/serializers/headlines.py
+++ b/metrics/api/serializers/headlines.py
@@ -1,4 +1,5 @@
 import contextlib
+from datetime import datetime
 
 from django.db.models import Manager
 from django.db.utils import OperationalError, ProgrammingError
@@ -126,6 +127,8 @@ class CoreHeadlineSerializer(serializers.ModelSerializer):
     metric = serializers.SerializerMethodField()
     age = serializers.SerializerMethodField()
     stratum = serializers.SerializerMethodField()
+    period_start = serializers.SerializerMethodField()
+    period_end = serializers.SerializerMethodField()
 
     class Meta:
         """
@@ -181,3 +184,11 @@ class CoreHeadlineSerializer(serializers.ModelSerializer):
     @classmethod
     def get_stratum(cls, obj) -> str:
         return obj.stratum__name
+
+    @classmethod
+    def get_period_start(cls, obj) -> str:
+        return datetime.strftime(obj.period_start, "%Y-%m-%d %H:%M:%S")
+
+    @classmethod
+    def get_period_end(cls, obj) -> str:
+        return datetime.strftime(obj.period_end, "%Y-%m-%d %H:%M:%S")

--- a/tests/unit/metrics/api/serializers/test_headlines.py
+++ b/tests/unit/metrics/api/serializers/test_headlines.py
@@ -395,3 +395,31 @@ class TestCoreHeadlineSerializer:
 
         # Then
         assert expected_field in serializer.fields
+
+    def test_dates_are_formatted_correct(
+        self,
+        mock_core_headline_data: mock.MagicMock,
+    ):
+        """
+        Given a valid payload with a `period_start` and `period_end` date
+        When the `CoreHeadlineSerializer` is initialised
+        Then the dates returned are in the correct format.
+        """
+        # Given
+        mocked_core_headline_data = mock_core_headline_data
+        mocked_core_headline_data.period_start = datetime.datetime(
+            day=1, month=2, year=2024
+        )
+        mocked_core_headline_data.period_end = datetime.datetime(
+            day=2, month=3, year=2024
+        )
+
+        # When
+        serializer = CoreHeadlineSerializer(instance=mocked_core_headline_data)
+
+        serialized_field_value_period_start = serializer.data["period_start"]
+        serialized_field_value_period_end = serializer.data["period_end"]
+
+        # Then
+        assert serialized_field_value_period_start == "2024-02-01 00:00:00"
+        assert serialized_field_value_period_end == "2024-03-02 00:00:00"


### PR DESCRIPTION
# Description

This PR includes an update to the headline serializer to format the datetime of `period_start` and `period_end` dates in the downloads response.


Fixes #CDD-2168

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
