### PR TITLE
Check `percentage_metric` instead of main metric when assessing trend state

### DIFF
--- a/metrics/domain/trends/state.py
+++ b/metrics/domain/trends/state.py
@@ -49,7 +49,7 @@ class Trend(BaseModel):
         Returns:
             str: The name of the direction.
                 Can be either "up", "neutral" or "down"
-                depending on the `metric_value`
+                depending on the `percentage_metric_value`
 
         """
         if self.percentage_metric_value > 0:
@@ -67,13 +67,13 @@ class Trend(BaseModel):
         Returns:
             str: The name of the colour.
                 Can be either "green", "neutral" or "red"
-                depending on the `metric_value`
+                depending on the `percentage_metric_value`
 
         """
         if self.percentage_metric_value == 0:
             return Colour.neutral.name
 
-        metric_is_improving = is_metric_improving(
+        metric_is_improving: bool = is_metric_improving(
             change_in_metric_value=self.percentage_metric_value,
             metric_name=self.metric_name,
         )

--- a/metrics/domain/trends/state.py
+++ b/metrics/domain/trends/state.py
@@ -52,10 +52,10 @@ class Trend(BaseModel):
                 depending on the `metric_value`
 
         """
-        if self.metric_value > 0:
+        if self.percentage_metric_value > 0:
             return ArrowDirection.up.name
 
-        if self.metric_value == 0:
+        if self.percentage_metric_value == 0:
             return ArrowDirection.neutral.name
 
         return ArrowDirection.down.name
@@ -70,11 +70,11 @@ class Trend(BaseModel):
                 depending on the `metric_value`
 
         """
-        if self.metric_value == 0:
+        if self.percentage_metric_value == 0:
             return Colour.neutral.name
 
         metric_is_improving = is_metric_improving(
-            change_in_metric_value=self.metric_value,
+            change_in_metric_value=self.percentage_metric_value,
             metric_name=self.metric_name,
         )
 

--- a/tests/unit/metrics/domain/trends/test_state.py
+++ b/tests/unit/metrics/domain/trends/test_state.py
@@ -36,8 +36,8 @@ class TestTrend:
 
         # Then
         expected_trend_data = valid_payload
-        expected_trend_data["direction"] = ArrowDirection.up.name
-        expected_trend_data["colour"] = Colour.red.name
+        expected_trend_data["direction"] = ArrowDirection.down.name
+        expected_trend_data["colour"] = Colour.green.name
         assert trend_data == expected_trend_data
 
     @pytest.mark.parametrize(
@@ -58,7 +58,7 @@ class TestTrend:
         """
         # Given
         valid_payload = self._create_valid_payload()
-        valid_payload["metric_value"] = metric_value
+        valid_payload["percentage_metric_value"] = metric_value
         trend = Trend(**valid_payload)
 
         # When
@@ -75,7 +75,7 @@ class TestTrend:
         """
         # Given
         valid_payload = self._create_valid_payload()
-        valid_payload["metric_value"] = 0
+        valid_payload["percentage_metric_value"] = 0
         trend = Trend(**valid_payload)
 
         # When
@@ -103,7 +103,7 @@ class TestTrend:
 
         # Then
         spy_is_metric_improving.assert_called_once_with(
-            change_in_metric_value=trend.metric_value,
+            change_in_metric_value=trend.percentage_metric_value,
             metric_name=trend.metric_name,
         )
         assert colour == Colour.green.name
@@ -127,7 +127,7 @@ class TestTrend:
 
         # Then
         spy_is_metric_improving.assert_called_once_with(
-            change_in_metric_value=trend.metric_value,
+            change_in_metric_value=trend.percentage_metric_value,
             metric_name=trend.metric_name,
         )
         assert colour == Colour.red.name


### PR DESCRIPTION
# Description

This PR includes the following:

- Checks against the given `percentage_metric` when assessing the trend. This will always be a percentage change metric representing the change as opposed to an absolute number which the main metric has a chance of being

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
