### PR TITLE
CDD-2171: update bulk downloads to support headline charts

### DIFF
--- a/caching/private_api/crawler/request_payload_builder.py
+++ b/caching/private_api/crawler/request_payload_builder.py
@@ -1,4 +1,8 @@
 from caching.private_api.crawler.type_hints import CMS_COMPONENT_BLOCK_TYPE
+from metrics.domain.common.utils import (
+    DataSourceFileType,
+    extract_metric_group_from_metric,
+)
 
 
 class RequestPayloadBuilder:
@@ -88,7 +92,7 @@ class RequestPayloadBuilder:
             to the `charts` or `tables` endpoint
 
         """
-        return {
+        plot_data = {
             "topic": plot_value["topic"],
             "metric": plot_value["metric"],
             "chart_type": plot_value["chart_type"],
@@ -97,12 +101,18 @@ class RequestPayloadBuilder:
             "geography_type": plot_value["geography_type"],
             "sex": plot_value["sex"],
             "age": plot_value["age"],
-            "date_from": plot_value["date_from"],
-            "date_to": plot_value["date_to"],
             "label": plot_value["label"],
             "line_colour": plot_value["line_colour"],
-            "line_type": plot_value["line_type"],
         }
+
+        if DataSourceFileType[
+            extract_metric_group_from_metric(plot_value["metric"])
+        ].is_timeseries:
+            plot_data["date_to"] = plot_value["date_to"]
+            plot_data["date_from"] = plot_value["date_from"]
+            plot_data["line_type"] = plot_value["line_type"]
+
+        return plot_data
 
     @classmethod
     def _build_plot_data_for_chart(
@@ -169,6 +179,7 @@ class RequestPayloadBuilder:
                 self.build_downloads_plot_data(plot_value=plot["value"])
                 for plot in chart_block["chart"]
             ],
+            "x_axis": chart_block["x_axis"],
             "file_format": file_format,
         }
 
@@ -185,14 +196,20 @@ class RequestPayloadBuilder:
             to the `downloads` endpoint only
 
         """
-        return {
+        plot_data = {
             "topic": plot_value["topic"],
             "metric": plot_value["metric"],
-            "date_from": plot_value["date_from"],
-            "date_to": plot_value["date_to"],
             "stratum": plot_value["stratum"],
             "geography": plot_value["geography"],
             "geography_type": plot_value["geography_type"],
             "sex": plot_value["sex"],
             "age": plot_value["age"],
         }
+
+        if DataSourceFileType[
+            extract_metric_group_from_metric(plot_value["metric"])
+        ].is_timeseries:
+            plot_data["date_to"] = plot_value["date_to"]
+            plot_data["date_from"] = plot_value["date_from"]
+
+        return plot_data

--- a/metrics/api/views/downloads.py
+++ b/metrics/api/views/downloads.py
@@ -78,9 +78,8 @@ class DownloadsView(APIView):
         response["Content-Disposition"] = "attachment; filename=chart_download.json"
         return response
 
-    @classmethod
     def _handle_csv(
-        cls,
+        self,
         *,
         queryset: CoreTimeSeriesQuerySet | CoreHeadlineQuerySet,
         metric_group: str,
@@ -89,9 +88,13 @@ class DownloadsView(APIView):
         response = HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = 'attachment; filename="mymodel.csv"'
 
+        serializer = self._get_serializer_class(
+            queryset=queryset, metric_group=metric_group
+        )
+
         if DataSourceFileType[metric_group].is_headline:
             return write_headline_data_to_csv(
-                file=response, core_headline_queryset=queryset
+                file=response, core_headline_data=serializer.data
             )
 
         return write_data_to_csv(file=response, core_time_series_queryset=queryset)

--- a/metrics/domain/exports/csv_output.py
+++ b/metrics/domain/exports/csv_output.py
@@ -44,16 +44,6 @@ def write_data_to_csv(
     return _write_to_csv_file(file=file, headers=headers, rows=rows)
 
 
-def write_headline_data_to_csv(
-    *,
-    file: io.StringIO,
-    core_headline_queryset,
-) -> io.StringIO:
-    headers = HEADLINE_FIELDS.keys()
-    rows = core_headline_queryset
-    return _write_to_csv_file(file=file, headers=headers, rows=rows)
-
-
 def _write_to_csv_file(
     *, file: io.StringIO, headers: list[str], rows: Iterable
 ) -> io.StringIO:
@@ -62,5 +52,25 @@ def _write_to_csv_file(
 
     for row in rows:
         writer.writerow(row)
+
+    return file
+
+
+def write_headline_data_to_csv(
+    *,
+    file: io.StringIO,
+    core_headline_data: Iterable,
+) -> io.StringIO:
+    headers = list(HEADLINE_FIELDS.keys())
+    rows = core_headline_data
+    return _write_headline_to_csv_file(file=file, headers=headers, rows=rows)
+
+
+def _write_headline_to_csv_file(
+    *, file: io.StringIO, headers: list[str], rows: Iterable
+) -> io.StringIO:
+    writer = csv.DictWriter(file, fieldnames=headers)
+    writer.writeheader()
+    writer.writerows(rows)
 
     return file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,6 +263,37 @@ def example_chart_block() -> dict[str, str | list[dict]]:
 
 
 @pytest.fixture
+def example_headline_chart_block() -> dict[str, str | list[dict]]:
+    return {
+        "title": "COVID-19 headline cases 7 Days Total",
+        "body": "COVID-19 cases 7 day total by age",
+        "x_axis": "age",
+        "y_axis": "metric",
+        "chart": [
+            {
+                "type": "plot",
+                "value": {
+                    "topic": "COVID-19",
+                    "metric": "COVID-19_headline_cases_7DayTotals",
+                    "chart_type": "bar",
+                    "stratum": "",
+                    "geography": "England",
+                    "geography_type": "Nation",
+                    "sex": "",
+                    "age": "01-04",
+                    "label": "Admission rate",
+                    "line_colour": "",
+                    "line_type": "",
+                    "use_markers": False,
+                    "use_smooth_lines": True,
+                },
+                "id": "791efbf1-8880-4dfa-9f5d-526982ed1539",
+            }
+        ],
+    }
+
+
+@pytest.fixture
 def example_headline_number_block() -> dict[str, str]:
     return {
         "topic": "COVID-19",

--- a/tests/integration/metrics/api/views/test_downloads.py
+++ b/tests/integration/metrics/api/views/test_downloads.py
@@ -43,8 +43,8 @@ class TestDownloadsView:
         "sex": "",
         "age": "01-04",
         "metric_value": 123.45,
-        "period_start": "2024-01-01 00:00:00+00:00",
-        "period_end": "2024-02-02 00:00:00+00:00",
+        "period_start": "2024-01-01 00:00:00",
+        "period_end": "2024-02-02 00:00:00",
     }
 
     def _build_valid_payload(self) -> dict[str, str | list[dict[str, str]]]:

--- a/tests/unit/caching/private_api/crawler/test_request_payload_builder.py
+++ b/tests/unit/caching/private_api/crawler/test_request_payload_builder.py
@@ -198,6 +198,46 @@ class TestRequestPayloadBuilder:
         }
         assert tables_request_data == expected_tables_request_data
 
+    def test_build_tables_request_headline_data(
+        self,
+        example_headline_chart_block: dict[str, str | list[dict]],
+    ):
+        """
+        Given a valid headline chart block
+        When `build_tables_request_data()` is called
+        Then the correct div is returned.
+        """
+        # Given
+        chart_block_data = example_headline_chart_block
+        request_payload_builder = RequestPayloadBuilder()
+
+        # When
+        tables_request_data = request_payload_builder.build_tables_request_data(
+            chart_block=example_headline_chart_block,
+        )
+
+        # Then
+        plot_value = chart_block_data["chart"][0]["value"]
+        expected_tables_request_data = {
+            "plots": [
+                {
+                    "topic": plot_value["topic"],
+                    "metric": plot_value["metric"],
+                    "chart_type": plot_value["chart_type"],
+                    "stratum": plot_value["stratum"],
+                    "geography": plot_value["geography"],
+                    "geography_type": plot_value["geography_type"],
+                    "sex": plot_value["sex"],
+                    "age": plot_value["age"],
+                    "label": plot_value["label"],
+                    "line_colour": plot_value["line_colour"],
+                }
+            ],
+            "x_axis": chart_block_data["x_axis"],
+            "y_axis": chart_block_data["y_axis"],
+        }
+        assert tables_request_data == expected_tables_request_data
+
     def test_build_downloads_request_data(
         self,
         example_chart_block: dict[str, str | list[dict]],
@@ -222,12 +262,53 @@ class TestRequestPayloadBuilder:
         plot_value = chart_block_data["chart"][0]["value"]
         expected_downloads_request_data = {
             "file_format": "csv",
+            "x_axis": chart_block_data["x_axis"],
             "plots": [
                 {
                     "topic": plot_value["topic"],
                     "metric": plot_value["metric"],
                     "date_from": plot_value["date_from"],
                     "date_to": plot_value["date_to"],
+                    "stratum": plot_value["stratum"],
+                    "geography": plot_value["geography"],
+                    "geography_type": plot_value["geography_type"],
+                    "sex": plot_value["sex"],
+                    "age": plot_value["age"],
+                }
+            ],
+        }
+        assert downloads_request_data == expected_downloads_request_data
+
+    def test_build_downloads_request_data_for_headline_charts(
+        self,
+        example_headline_chart_block: dict[str, str],
+    ):
+        """
+        Given a chart block with optional fields removed
+            Eg. `date_to` and `date_from`
+        When `build_downloads_request_data()` is called
+            from an instance of `RequestPayloadBuilder`
+        Then the correct dict is returned
+        """
+        # Given
+        chart_block_data = example_headline_chart_block
+        file_format = "csv"
+        request_payload_builder = RequestPayloadBuilder()
+
+        # When
+        downloads_request_data = request_payload_builder.build_downloads_request_data(
+            chart_block=chart_block_data, file_format=file_format
+        )
+
+        # Then
+        plot_value = chart_block_data["chart"][0]["value"]
+        expected_downloads_request_data = {
+            "file_format": "csv",
+            "x_axis": chart_block_data["x_axis"],
+            "plots": [
+                {
+                    "topic": plot_value["topic"],
+                    "metric": plot_value["metric"],
                     "stratum": plot_value["stratum"],
                     "geography": plot_value["geography"],
                     "geography_type": plot_value["geography_type"],


### PR DESCRIPTION
# Description

This PR adds support to the `private_api` crawler to support `Headline` charts


Fixes #CDD-2171

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [x] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
