### PR TITLE
Task/add last updated at timestamp to pages

### DIFF
--- a/cms/dynamic_content/blocks_deconstruction.py
+++ b/cms/dynamic_content/blocks_deconstruction.py
@@ -405,3 +405,119 @@ class CMSBlockParser:
 
         """
         return {block["value"]["topic"] for block in headline_blocks}
+
+    # Extraction of selected topics
+
+    @classmethod
+    def get_all_selected_metrics_from_sections(cls, *, sections) -> set[str]:
+        """Extracts a set of metrics from all headline & chart blocks in the given `sections`
+
+        Args:
+            sections: List of all CMS section components
+                from the target page
+
+        Returns:
+            Set of strings where each string represents
+            a metric which has been selected at least
+            once in the list of given `sections`
+
+        """
+        selected_metrics_from_headline_blocks: set[str] = (
+            cls._get_all_selected_metrics_in_headline_blocks_from_sections(
+                sections=sections
+            )
+        )
+        selected_metrics_from_chart_blocks: set[str] = (
+            cls._get_all_selected_metrics_in_chart_blocks_from_sections(
+                sections=sections
+            )
+        )
+        return selected_metrics_from_chart_blocks.union(
+            selected_metrics_from_headline_blocks
+        )
+
+    @classmethod
+    def _get_all_selected_metrics_in_chart_blocks_from_sections(
+        cls, *, sections: list[dict[list[CMS_COMPONENT_BLOCK_TYPE]]]
+    ) -> set[str]:
+        """Extracts a set of metrics from all chart blocks in the given `sections`
+
+        Args:
+            sections: List of all CMS section components
+                from the target page
+
+        Returns:
+            Set of strings where each string represents
+            a metric which has been selected at least
+            once in the list of given `sections`
+
+        """
+        chart_blocks = []
+        for section in sections:
+            chart_blocks += cls.get_all_chart_blocks_from_section(section=section)
+
+        return cls.get_all_selected_metrics_from_chart_blocks(chart_blocks=chart_blocks)
+
+    @classmethod
+    def _get_all_selected_metrics_in_headline_blocks_from_sections(
+        cls, *, sections: list[dict[list[CMS_COMPONENT_BLOCK_TYPE]]]
+    ) -> set[str]:
+        """Extracts a set of metrics from all headline blocks in the given `sections`
+
+        Args:
+            sections: List of all CMS section components
+                from the target page
+
+        Returns:
+            Set of strings where each string represents
+            a metric which has been selected at least
+            once in the list of given `sections`
+
+        """
+        headline_blocks = []
+        for section in sections:
+            headline_blocks += cls.get_all_headline_blocks_from_section(section=section)
+
+        return cls.get_all_selected_metrics_from_headline_blocks(
+            headline_blocks=headline_blocks
+        )
+
+    @classmethod
+    def get_all_selected_metrics_from_chart_blocks(
+        cls, *, chart_blocks: list[CMS_COMPONENT_BLOCK_TYPE]
+    ) -> set[str]:
+        """Extracts a set of metrics from the given `chart_blocks`
+
+        Args:
+            chart_blocks: List of chart blocks
+                from which to extract the unique
+                selected metrics
+
+        Returns:
+            Set of strings where each string represents
+            a metric which has been selected at least
+            once in the list of given `chart_blocks`
+
+        """
+        return {
+            plot["value"]["metric"] for block in chart_blocks for plot in block["chart"]
+        }
+
+    @classmethod
+    def get_all_selected_metrics_from_headline_blocks(
+        cls, *, headline_blocks: list[CMS_COMPONENT_BLOCK_TYPE]
+    ) -> set[str]:
+        """Extracts a set of metrics from the given `headline_blocks`
+
+        Args:
+            headline_blocks: List of headline number blocks
+                from which to extract the unique
+                selected metrics
+
+        Returns:
+            Set of strings where each string represents
+            a metric which has been selected at least
+            once in the list of given `headline_blocks`
+
+        """
+        return {block["value"]["metric"] for block in headline_blocks}

--- a/cms/metrics_interface/interface.py
+++ b/cms/metrics_interface/interface.py
@@ -12,6 +12,7 @@ DEFAULT_GEOGRAPHY_MANAGER = core_models.Geography.objects
 DEFAULT_GEOGRAPHY_TYPE_MANAGER = core_models.GeographyType.objects
 DEFAULT_AGE_MANAGER = core_models.Age.objects
 DEFAULT_CORE_TIME_SERIES_MANAGER = core_models.CoreTimeSeries.objects
+DEFAULT_CORE_HEADLINE_MANAGER = core_models.CoreHeadline.objects
 
 
 class MetricsAPIInterface:
@@ -44,6 +45,9 @@ class MetricsAPIInterface:
     core_time_series_manager : `CoreTimeSeriesManager`
         The model manager for the `CoreTimeSeries` model belonging to the Metrics API
         Defaults to the concrete `CoreTimeSeriesManager` via `CoreTimeSeries.objects`
+    core_headline_manager : `CoreHeadlineManager`
+        The model manager for the `CoreHeadline` model belonging to the Metrics API
+        Defaults to the concrete `CoreHeadlineManager` via `CoreHeadline.objects`
 
     """
 
@@ -57,6 +61,7 @@ class MetricsAPIInterface:
         geography_type_manager: Manager = DEFAULT_GEOGRAPHY_TYPE_MANAGER,
         age_manager: Manager = DEFAULT_AGE_MANAGER,
         core_time_series_manager: Manager = DEFAULT_CORE_TIME_SERIES_MANAGER,
+        core_headline_manager: Manager = DEFAULT_CORE_HEADLINE_MANAGER,
     ):
         self.topic_manager = topic_manager
         self.metric_manager = metric_manager
@@ -65,6 +70,7 @@ class MetricsAPIInterface:
         self.geography_type_manager = geography_type_manager
         self.age_manager = age_manager
         self.core_time_series_manager = core_time_series_manager
+        self.core_headline_manager = core_headline_manager
 
     @staticmethod
     def get_chart_types() -> tuple[tuple[str, str], ...]:

--- a/cms/topic/models.py
+++ b/cms/topic/models.py
@@ -65,6 +65,13 @@ class TopicPage(UKHSAPage):
 
     objects = TopicPageManager()
 
+    def __init__(self, *args, **kwargs):
+        core_timeseries_manager = kwargs.pop(
+            "core_timeseries_manager", CoreTimeSeries.objects
+        )
+        super().__init__(*args, **kwargs)
+        self._core_timeseries_manager = core_timeseries_manager
+
     @classmethod
     def is_previewable(cls) -> bool:
         """Returns False. Since this is a headless CMS the preview panel is not supported"""

--- a/cms/topic/models.py
+++ b/cms/topic/models.py
@@ -13,8 +13,11 @@ from cms.dashboard.models import UKHSAPage
 from cms.dynamic_content import help_texts
 from cms.dynamic_content.access import ALLOWABLE_BODY_CONTENT
 from cms.dynamic_content.blocks_deconstruction import CMSBlockParser
+from cms.metrics_interface import MetricsAPIInterface
 from cms.topic.managers import TopicPageManager
-from metrics.data.models.core_models import CoreHeadline, CoreTimeSeries
+
+DEFAULT_CORE_TIME_SERIES_MANGER = MetricsAPIInterface().core_time_series_manager
+DEFAULT_CORE_HEADLINE_MANGER = MetricsAPIInterface().core_headline_manager
 
 
 class TopicPage(UKHSAPage):
@@ -70,10 +73,10 @@ class TopicPage(UKHSAPage):
 
     def __init__(self, *args, **kwargs):
         core_timeseries_manager = kwargs.pop(
-            "core_timeseries_manager", CoreTimeSeries.objects
+            "core_timeseries_manager", DEFAULT_CORE_TIME_SERIES_MANGER
         )
         core_headline_manager = kwargs.pop(
-            "core_headline_manager", CoreHeadline.objects
+            "core_headline_manager", DEFAULT_CORE_HEADLINE_MANGER
         )
         super().__init__(*args, **kwargs)
         self._core_timeseries_manager = core_timeseries_manager

--- a/cms/topic/models.py
+++ b/cms/topic/models.py
@@ -135,7 +135,7 @@ class TopicPage(UKHSAPage):
             by the area selector. False otherwise.
 
         """
-        return len(self.selected_topics) == 1 and self.enable_area_selector
+        return self.enable_area_selector and len(self.selected_topics) == 1
 
 
 class TopicPageRelatedLink(Orderable):

--- a/cms/topic/models.py
+++ b/cms/topic/models.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django.db import models
 from modelcluster.fields import ParentalKey
 from wagtail.admin.panels import FieldPanel, InlinePanel, ObjectList, TabbedInterface
@@ -12,6 +14,7 @@ from cms.dynamic_content import help_texts
 from cms.dynamic_content.access import ALLOWABLE_BODY_CONTENT
 from cms.dynamic_content.blocks_deconstruction import CMSBlockParser
 from cms.topic.managers import TopicPageManager
+from metrics.data.models.core_models import CoreTimeSeries
 
 
 class TopicPage(UKHSAPage):
@@ -89,6 +92,32 @@ class TopicPage(UKHSAPage):
         """
         return CMSBlockParser.get_all_selected_topics_from_sections(
             sections=self.body.raw_data
+        )
+
+    @property
+    def selected_metrics(self) -> set[str]:
+        """Extracts a set of the selected metrics from all the headline & chart blocks in the `body`
+
+        Returns:
+            Set of strings where each string represents
+            a metric which has been selected at least
+            once in the body of the page
+
+        """
+        return CMSBlockParser.get_all_selected_metrics_from_sections(
+            sections=self.body.raw_data
+        )
+
+    def find_latest_released_embargo_for_metrics(self) -> datetime.datetime:
+        """Finds the latest `embargo` timestamp which has been released for the selected `metrics` on this page.
+
+        Returns:
+            A datetime object representing the latest
+            released embargo timestamp.
+
+        """
+        return self._core_timeseries_manager.find_latest_released_embargo_for_metrics(
+            metrics=self.selected_metrics
         )
 
     @property

--- a/cms/topic/models.py
+++ b/cms/topic/models.py
@@ -72,8 +72,12 @@ class TopicPage(UKHSAPage):
         core_timeseries_manager = kwargs.pop(
             "core_timeseries_manager", CoreTimeSeries.objects
         )
+        core_headline_manager = kwargs.pop(
+            "core_headline_manager", CoreHeadline.objects
+        )
         super().__init__(*args, **kwargs)
         self._core_timeseries_manager = core_timeseries_manager
+        self._core_headline_manager = core_headline_manager
 
     @classmethod
     def is_previewable(cls) -> bool:

--- a/cms/topic/models.py
+++ b/cms/topic/models.py
@@ -14,7 +14,7 @@ from cms.dynamic_content import help_texts
 from cms.dynamic_content.access import ALLOWABLE_BODY_CONTENT
 from cms.dynamic_content.blocks_deconstruction import CMSBlockParser
 from cms.topic.managers import TopicPageManager
-from metrics.data.models.core_models import CoreTimeSeries
+from metrics.data.models.core_models import CoreHeadline, CoreTimeSeries
 
 
 class TopicPage(UKHSAPage):
@@ -112,17 +112,29 @@ class TopicPage(UKHSAPage):
             sections=self.body.raw_data
         )
 
-    def find_latest_released_embargo_for_metrics(self) -> datetime.datetime:
+    def find_latest_released_embargo_for_metrics(
+        self,
+    ) -> list[datetime.datetime | None]:
         """Finds the latest `embargo` timestamp which has been released for the selected `metrics` on this page.
 
         Returns:
-            A datetime object representing the latest
-            released embargo timestamp.
+            A list of datetime object representing the latest
+            released embargo timestamp
+            for all time series and headline data on the page
 
         """
-        return self._core_timeseries_manager.find_latest_released_embargo_for_metrics(
-            metrics=self.selected_metrics
+        selected_metrics = self.selected_metrics
+        released_embargo_for_timeseries = (
+            self._core_timeseries_manager.find_latest_released_embargo_for_metrics(
+                metrics=selected_metrics
+            )
         )
+        released_embargo_for_headline = (
+            self._core_headline_manager.find_latest_released_embargo_for_metrics(
+                metrics=selected_metrics
+            )
+        )
+        return [released_embargo_for_timeseries, released_embargo_for_headline]
 
     @property
     def is_valid_for_area_selector(self) -> bool:

--- a/metrics/data/managers/core_models/headline.py
+++ b/metrics/data/managers/core_models/headline.py
@@ -5,6 +5,7 @@ Note that the application layer should only call into the `Manager` class.
 The application should not interact directly with the `QuerySet` class.
 """
 
+import datetime
 from typing import Optional, Self
 
 from django.db import models
@@ -167,6 +168,29 @@ class CoreHeadlineQuerySet(models.QuerySet):
         current_time = timezone.now()
         return queryset.filter(
             models.Q(embargo__lte=current_time) | models.Q(embargo=None)
+        )
+
+    def find_latest_released_embargo_for_metrics(
+        self, *, metrics: set[str]
+    ) -> datetime.datetime:
+        """Finds the latest `embargo` timestamp which has been released for the associated `metrics`
+
+        Args:
+            metrics: Iterable of metric names
+                to search the latest `embargo`
+                timestamp against.
+
+        Returns:
+            A datetime object representing the latest
+            embargo timestamp.
+
+        """
+        current_time = timezone.now()
+        return (
+            self.filter(metric__name__in=metrics, embargo__lte=current_time)
+            .values_list("embargo", flat=True)
+            .distinct()
+            .latest("embargo")
         )
 
 
@@ -468,3 +492,22 @@ class CoreHeadlineManager(models.Manager):
             sex=sex,
         )
         superseded_records.delete()
+
+    def find_latest_released_embargo_for_metrics(
+        self, metrics: set[str]
+    ) -> datetime.datetime:
+        """Finds the latest `embargo` timestamp which has been released for the associated `metrics`
+
+        Args:
+            metrics: Iterable of metric names
+                to search the latest `embargo`
+                timestamp against.
+
+        Returns:
+            A datetime object representing the latest
+            embargo timestamp.
+
+        """
+        return self.get_queryset().find_latest_released_embargo_for_metrics(
+            metrics=metrics
+        )

--- a/metrics/data/managers/core_models/time_series.py
+++ b/metrics/data/managers/core_models/time_series.py
@@ -378,6 +378,28 @@ class CoreTimeSeriesQuerySet(models.QuerySet):
             .distinct()
         )
 
+    def find_latest_released_embargo_for_metrics(
+        self, *, metrics: set[str]
+    ) -> datetime.datetime:
+        """Finds the latest `embargo` timestamp which has been released for the associated `metrics`
+
+        Args:
+            metrics: Iterable of metric names
+                to search the latest `embargo`
+                timestamp against.
+
+        Returns:
+            A datetime object representing the latest
+            embargo timestamp.
+
+        """
+        return (
+            self.filter(metric__name__in=metrics, embargo__lte=timezone.now())
+            .values_list("embargo", flat=True)
+            .distinct()
+            .latest("embargo")
+        )
+
 
 class CoreTimeSeriesManager(models.Manager):
     """Custom model manager class for the `TimeSeries` model."""
@@ -604,3 +626,22 @@ class CoreTimeSeriesManager(models.Manager):
             age=age,
         )
         superseded_records.delete()
+
+    def find_latest_released_embargo_for_metrics(
+        self, metrics: set[str]
+    ) -> datetime.datetime:
+        """Finds the latest `embargo` timestamp which has been released for the associated `metrics`
+
+        Args:
+            metrics: Iterable of metric names
+                to search the latest `embargo`
+                timestamp against.
+
+        Returns:
+            A datetime object representing the latest
+            embargo timestamp.
+
+        """
+        return self.get_queryset().find_latest_released_embargo_for_metrics(
+            metrics=metrics
+        )

--- a/metrics/data/managers/core_models/time_series.py
+++ b/metrics/data/managers/core_models/time_series.py
@@ -380,7 +380,7 @@ class CoreTimeSeriesQuerySet(models.QuerySet):
 
     def find_latest_released_embargo_for_metrics(
         self, *, metrics: set[str]
-    ) -> datetime.datetime:
+    ) -> datetime.datetime | None:
         """Finds the latest `embargo` timestamp which has been released for the associated `metrics`
 
         Args:
@@ -390,16 +390,20 @@ class CoreTimeSeriesQuerySet(models.QuerySet):
 
         Returns:
             A datetime object representing the latest
-            embargo timestamp.
+            embargo timestamp
+            or None if no data could be found.
 
         """
         current_time = timezone.now()
-        return (
-            self.filter(metric__name__in=metrics, embargo__lte=current_time)
-            .values_list("embargo", flat=True)
-            .distinct()
-            .latest("embargo")
-        )
+        try:
+            return (
+                self.filter(metric__name__in=metrics, embargo__lte=current_time)
+                .values_list("embargo", flat=True)
+                .distinct()
+                .latest("embargo")
+            )
+        except self.model.DoesNotExist:
+            return None
 
 
 class CoreTimeSeriesManager(models.Manager):

--- a/metrics/data/managers/core_models/time_series.py
+++ b/metrics/data/managers/core_models/time_series.py
@@ -393,8 +393,9 @@ class CoreTimeSeriesQuerySet(models.QuerySet):
             embargo timestamp.
 
         """
+        current_time = timezone.now()
         return (
-            self.filter(metric__name__in=metrics, embargo__lte=timezone.now())
+            self.filter(metric__name__in=metrics, embargo__lte=current_time)
             .values_list("embargo", flat=True)
             .distinct()
             .latest("embargo")

--- a/tests/integration/metrics/data/managers/core_models/test_headline.py
+++ b/tests/integration/metrics/data/managers/core_models/test_headline.py
@@ -450,3 +450,58 @@ class TestCoreHeadlineManager:
         assert second_stale_round_headline not in retrieved_records
         assert current_round_headline in retrieved_records
         assert embargoed_round_headline in retrieved_records
+
+    @pytest.mark.django_db
+    def test_find_latest_released_embargo_for_metrics(self):
+        """
+        Given a number of `CoreHeadline` records
+            for different metrics
+        When `find_latest_released_embargo_for_metrics()` is called
+            from an instance of the `CoreHeadlineManager`
+        Then the latest released embargo timestamp is returned
+        """
+        # Given
+        covid_metric = "COVID-19_headline_7DayAdmissions"
+        covid_metric_for_outdated_embargo = "COVID-19_headline_7DayOccupiedBeds"
+
+        superseded_embargo = datetime.datetime(
+            year=2024, month=1, day=1, hour=1, minute=1, second=1, tzinfo=datetime.UTC
+        )
+        latest_released_embargo = datetime.datetime(
+            year=2024, month=2, day=2, hour=1, minute=2, second=2, tzinfo=datetime.UTC
+        )
+        last_unreleased_embargo = datetime.datetime(
+            year=2024,
+            month=8,
+            day=28,
+            hour=11,
+            minute=49,
+            second=0,
+            tzinfo=datetime.UTC,
+        )
+
+        CoreHeadlineFactory.create_record(
+            metric_name=covid_metric, embargo=latest_released_embargo
+        )
+        CoreHeadlineFactory.create_record(
+            metric_name=covid_metric_for_outdated_embargo, embargo=superseded_embargo
+        )
+        CoreHeadlineFactory.create_record(
+            metric_name="adenovirus_headline_positivityLatest",
+            embargo=last_unreleased_embargo,
+        )
+
+        # When
+        extracted_embargo = (
+            CoreHeadline.objects.find_latest_released_embargo_for_metrics(
+                metrics=[covid_metric, covid_metric_for_outdated_embargo]
+            )
+        )
+
+        # Then
+        assert (
+            extracted_embargo
+            == latest_released_embargo
+            != superseded_embargo
+            != last_unreleased_embargo
+        )

--- a/tests/integration/metrics/data/managers/core_models/test_headline.py
+++ b/tests/integration/metrics/data/managers/core_models/test_headline.py
@@ -470,14 +470,8 @@ class TestCoreHeadlineManager:
         latest_released_embargo = datetime.datetime(
             year=2024, month=2, day=2, hour=1, minute=2, second=2, tzinfo=datetime.UTC
         )
-        last_unreleased_embargo = datetime.datetime(
-            year=2024,
-            month=8,
-            day=28,
-            hour=11,
-            minute=49,
-            second=0,
-            tzinfo=datetime.UTC,
+        last_unreleased_embargo = get_date_n_months_ago_from_timestamp(
+            datetime_stamp=timezone.now(), number_of_months=-1
         )
 
         CoreHeadlineFactory.create_record(

--- a/tests/integration/metrics/data/managers/core_models/test_headline.py
+++ b/tests/integration/metrics/data/managers/core_models/test_headline.py
@@ -499,3 +499,26 @@ class TestCoreHeadlineManager:
             != superseded_embargo
             != last_unreleased_embargo
         )
+
+    @pytest.mark.django_db
+    def test_find_latest_released_embargo_for_metrics_returns_none_when_no_data_found(
+        self,
+    ):
+        """
+        Given no existing `CoreHeadline` records
+        When `find_latest_released_embargo_for_metrics()` is called
+            from an instance of the `CoreHeadlineManager`
+        Then None is returned
+        """
+        # Given
+        covid_metric = "COVID-19_headline_7DayAdmissions"
+
+        # When
+        extracted_embargo = (
+            CoreHeadline.objects.find_latest_released_embargo_for_metrics(
+                metrics=[covid_metric]
+            )
+        )
+
+        # Then
+        assert extracted_embargo is None

--- a/tests/integration/metrics/data/managers/core_models/test_time_series.py
+++ b/tests/integration/metrics/data/managers/core_models/test_time_series.py
@@ -520,7 +520,7 @@ class TestCoreTimeSeriesManager:
     @pytest.mark.django_db
     def test_find_latest_released_embargo_for_metrics(self):
         """
-        Given a number of `CoreHeadline` records
+        Given a number of `CoreTimeSeries` records
             for different metrics
         When `find_latest_released_embargo_for_metrics()` is called
             from an instance of the `CoreTimeSeriesManager`
@@ -564,4 +564,9 @@ class TestCoreTimeSeriesManager:
         )
 
         # Then
-        assert extracted_embargo == latest_released_embargo
+        assert (
+            extracted_embargo
+            == latest_released_embargo
+            != superseded_embargo
+            != last_unreleased_embargo
+        )

--- a/tests/integration/metrics/data/managers/core_models/test_time_series.py
+++ b/tests/integration/metrics/data/managers/core_models/test_time_series.py
@@ -564,3 +564,26 @@ class TestCoreTimeSeriesManager:
             != superseded_embargo
             != last_unreleased_embargo
         )
+
+    @pytest.mark.django_db
+    def test_find_latest_released_embargo_for_metrics_returns_none_when_no_data_found(
+        self,
+    ):
+        """
+        Given no existing `CoreTimeSeries` records
+        When `find_latest_released_embargo_for_metrics()` is called
+            from an instance of the `CoreTimeSeriesManager`
+        Then None is returned
+        """
+        # Given
+        covid_metric = "COVID-19_deaths_ONSByWeek"
+
+        # When
+        extracted_embargo = (
+            CoreTimeSeries.objects.find_latest_released_embargo_for_metrics(
+                metrics=[covid_metric]
+            )
+        )
+
+        # Then
+        assert extracted_embargo is None

--- a/tests/integration/metrics/data/managers/core_models/test_time_series.py
+++ b/tests/integration/metrics/data/managers/core_models/test_time_series.py
@@ -536,14 +536,8 @@ class TestCoreTimeSeriesManager:
         latest_released_embargo = datetime.datetime(
             year=2024, month=2, day=2, hour=1, minute=2, second=2, tzinfo=datetime.UTC
         )
-        last_unreleased_embargo = datetime.datetime(
-            year=2024,
-            month=8,
-            day=28,
-            hour=11,
-            minute=49,
-            second=0,
-            tzinfo=datetime.UTC,
+        last_unreleased_embargo = get_date_n_months_ago_from_timestamp(
+            datetime_stamp=timezone.now(), number_of_months=-1
         )
 
         CoreTimeSeriesFactory.create_record(

--- a/tests/integration/metrics/data/managers/core_models/test_time_series.py
+++ b/tests/integration/metrics/data/managers/core_models/test_time_series.py
@@ -516,3 +516,52 @@ class TestCoreTimeSeriesManager:
         assert expected_live_third_version_for_third_date in retrieved_records
         assert expected_live_fourth_round_for_first_date in retrieved_records
         assert embargoed_fifth_round_for_first_date in retrieved_records
+
+    @pytest.mark.django_db
+    def test_find_latest_released_embargo_for_metrics(self):
+        """
+        Given a number of `CoreHeadline` records
+            for different metrics
+        When `find_latest_released_embargo_for_metrics()` is called
+            from an instance of the `CoreTimeSeriesManager`
+        Then the latest released embargo timestamp is returned
+        """
+        # Given
+        covid_metric = "COVID-19_deaths_ONSByWeek"
+        covid_metric_for_outdated_embargo = "COVID-19_cases_rateRollingMean"
+
+        superseded_embargo = datetime.datetime(
+            year=2024, month=1, day=1, hour=1, minute=1, second=1, tzinfo=datetime.UTC
+        )
+        latest_released_embargo = datetime.datetime(
+            year=2024, month=2, day=2, hour=1, minute=2, second=2, tzinfo=datetime.UTC
+        )
+        last_unreleased_embargo = datetime.datetime(
+            year=2024,
+            month=8,
+            day=28,
+            hour=11,
+            minute=49,
+            second=0,
+            tzinfo=datetime.UTC,
+        )
+
+        CoreTimeSeriesFactory.create_record(
+            metric_name=covid_metric, embargo=latest_released_embargo
+        )
+        CoreTimeSeriesFactory.create_record(
+            metric_name=covid_metric_for_outdated_embargo, embargo=superseded_embargo
+        )
+        CoreTimeSeriesFactory.create_record(
+            metric_name="hMPV_testing_positivityByWeek", embargo=last_unreleased_embargo
+        )
+
+        # When
+        extracted_embargo = (
+            CoreTimeSeries.objects.find_latest_released_embargo_for_metrics(
+                metrics=[covid_metric, covid_metric_for_outdated_embargo]
+            )
+        )
+
+        # Then
+        assert extracted_embargo == latest_released_embargo

--- a/tests/unit/cms/dynamic_content/blocks_deconstruction/test_extraction_of_selected_topics.py
+++ b/tests/unit/cms/dynamic_content/blocks_deconstruction/test_extraction_of_selected_topics.py
@@ -62,3 +62,31 @@ class TestCMSBlockParserExtractionOfSelectedTopics:
 
         # Then
         assert topics == {"COVID-19"}
+
+    def test_get_all_selected_metrics_from_sections(
+        self,
+        example_section_with_headline_chart_and_text_cards: CMS_COMPONENT_BLOCK_TYPE,
+    ):
+        """
+        Given a list of section CMS components
+        When `get_all_selected_metrics_from_sections()` is called
+            from the `CMSBlockParser` class
+        Then a set containing only the selected metrics
+        """
+        # Given
+        sections = [example_section_with_headline_chart_and_text_cards]
+
+        # When
+        metrics = CMSBlockParser.get_all_selected_metrics_from_sections(
+            sections=sections
+        )
+
+        # Then
+        expected_metrics = {
+            "COVID-19_cases_countRollingMean",
+            "COVID-19_deaths_ONSRollingMean",
+            "COVID-19_headline_cases_7DayChange",
+            "COVID-19_headline_cases_7DayTotals",
+            "COVID-19_headline_positivity_latest",
+        }
+        assert metrics == expected_metrics

--- a/tests/unit/cms/topic/test_models.py
+++ b/tests/unit/cms/topic/test_models.py
@@ -231,25 +231,36 @@ class TestTemplateCOVID19Page:
         Given an instance of a `TopicPage`
         When `find_latest_released_embargo_for_metrics()` is called
         Then the call is delegated to the `CoreTimeSeriesManager`
-            to fetch the latest released embargo timestamp
+            and the `CoreHeadlineManager` to fetch
+            the latest released embargo timestamp
         """
         # Given
         spy_core_timeseries_manager = mock.Mock()
+        spy_core_headline_manager = mock.Mock()
+
         page = TopicPage(
             core_timeseries_manager=spy_core_timeseries_manager,
+            core_headline_manager=spy_core_headline_manager,
             content_type_id=1,
         )
 
         # When
-        latest_released_embargo = page.find_latest_released_embargo_for_metrics()
+        latest_released_embargoes = page.find_latest_released_embargo_for_metrics()
 
         # Then
         spy_core_timeseries_manager.find_latest_released_embargo_for_metrics.assert_called_once_with(
             metrics=page.selected_metrics
         )
+        spy_core_headline_manager.find_latest_released_embargo_for_metrics.assert_called_once_with(
+            metrics=page.selected_metrics
+        )
         assert (
-            latest_released_embargo
-            == spy_core_timeseries_manager.find_latest_released_embargo_for_metrics.return_value
+            spy_core_timeseries_manager.find_latest_released_embargo_for_metrics.return_value
+            in latest_released_embargoes
+        )
+        assert (
+            spy_core_headline_manager.find_latest_released_embargo_for_metrics.return_value
+            in latest_released_embargoes
         )
 
     def test_selected_metrics(self):

--- a/tests/unit/cms/topic/test_models.py
+++ b/tests/unit/cms/topic/test_models.py
@@ -1,5 +1,8 @@
+from unittest import mock
+
 import pytest
 
+from cms.topic.models import TopicPage
 from metrics.domain.charts.colour_scheme import RGBAChartLineColours
 from metrics.domain.charts.line_multi_coloured.properties import ChartLineTypes
 from metrics.domain.common.utils import ChartTypes
@@ -223,6 +226,65 @@ class TestTemplateCOVID19Page:
 
         assert expected_content_panel_name in content_panel_names
 
+    def test_find_latest_released_embargo_for_metrics(self):
+        """
+        Given an instance of a `TopicPage`
+        When `find_latest_released_embargo_for_metrics()` is called
+        Then the call is delegated to the `CoreTimeSeriesManager`
+            to fetch the latest released embargo timestamp
+        """
+        # Given
+        spy_core_timeseries_manager = mock.Mock()
+        page = TopicPage(
+            core_timeseries_manager=spy_core_timeseries_manager,
+            content_type_id=1,
+        )
+
+        # When
+        latest_released_embargo = page.find_latest_released_embargo_for_metrics()
+
+        # Then
+        spy_core_timeseries_manager.find_latest_released_embargo_for_metrics.assert_called_once_with(
+            metrics=page.selected_metrics
+        )
+        assert (
+            latest_released_embargo
+            == spy_core_timeseries_manager.find_latest_released_embargo_for_metrics.return_value
+        )
+
+    def test_selected_metrics(self):
+        """
+        Given a `TopicPage` created
+            with a template for the `COVID-19` page
+        When the `selected_metrics` property is called
+        Then the correct metrics are extracted
+        """
+        # Given
+        template_covid_19_page = (
+            FakeTopicPageFactory.build_covid_19_page_from_template()
+        )
+
+        # When
+        selected_metrics: set[str] = template_covid_19_page.selected_metrics
+
+        # Then
+        expected_metrics = {
+            "COVID-19_cases_casesByDay",
+            "COVID-19_cases_countRollingMean",
+            "COVID-19_cases_rateRollingMean",
+            "COVID-19_deaths_ONSByDay",
+            "COVID-19_deaths_ONSRollingMean",
+            "COVID-19_healthcare_admissionByDay",
+            "COVID-19_healthcare_occupiedBedsByDay",
+            "COVID-19_testing_PCRcountByDay",
+            "COVID-19_testing_positivity7DayRolling",
+            "COVID-19_vaccinations_autumn22_dosesByDay",
+            "COVID-19_vaccinations_autumn22_uptakeByDay",
+            "COVID-19_vaccinations_spring23_dosesByDay",
+            "COVID-19_vaccinations_spring23_uptakeByDay",
+        }
+        assert selected_metrics == expected_metrics
+
 
 class TestTemplateInfluenzaPage:
     @property
@@ -430,6 +492,28 @@ class TestTemplateInfluenzaPage:
         # Then
         assert selected_topics == {"Influenza"}
 
+    def test_selected_metrics(self):
+        """
+        Given a `TopicPage` created
+            with a template for the `Influenza` page
+        When the `selected_metrics` property is called
+        Then the correct metrics are extracted
+        """
+        # Given
+        template_influenza_page = (
+            FakeTopicPageFactory.build_influenza_page_from_template()
+        )
+
+        # When
+        selected_metrics: set[str] = template_influenza_page.selected_metrics
+
+        # Then
+        expected_metrics = {
+            "influenza_healthcare_ICUHDUadmissionRateByWeek",
+            "influenza_testing_positivityByWeek",
+        }
+        assert selected_metrics == expected_metrics
+
 
 class TestTemplateOtherRespiratoryVirusesPage:
     @pytest.mark.parametrize("enable_area_selector", [True, False])
@@ -459,3 +543,31 @@ class TestTemplateOtherRespiratoryVirusesPage:
 
         # Then
         assert not is_valid_for_area_selector
+
+    def test_selected_metrics(self):
+        """
+        Given a `TopicPage` created with a template
+            for the `Other Respiratory Viruses` page
+        When the `selected_metrics` property is called
+        Then the correct metrics are extracted
+        """
+        # Given
+        template_other_respiratory_viruses_page = (
+            FakeTopicPageFactory.build_other_respiratory_viruses_page_from_template()
+        )
+
+        # When
+        selected_metrics: set[str] = (
+            template_other_respiratory_viruses_page.selected_metrics
+        )
+
+        # Then
+        expected_metrics = {
+            "RSV_healthcare_admissionRateByWeek",
+            "RSV_testing_positivityByWeek",
+            "adenovirus_testing_positivityByWeek",
+            "hMPV_testing_positivityByWeek",
+            "parainfluenza_testing_positivityByWeek",
+            "rhinovirus_testing_positivityByWeek",
+        }
+        assert selected_metrics == expected_metrics


### PR DESCRIPTION
# Description

This PR includes the following:

- Sets up the functionality to extract the last released embargo timestamp for a given set of metrics
- Allows a topic page to determine these embargoes from its own selected metrics

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
