### PR TITLE
Enforce `seo_title` field to be mandatory

### DIFF
--- a/cms/dashboard/models.py
+++ b/cms/dashboard/models.py
@@ -1,6 +1,7 @@
 import datetime
 from decimal import Decimal
 
+from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from rest_framework.templatetags.rest_framework import render_markdown
@@ -63,6 +64,11 @@ class UKHSAPage(Page):
 
     class Meta:
         abstract = True
+
+    def clean(self):
+        super().clean()
+        if not self.seo_title:
+            raise ValidationError(message="Search engine title tag is required")
 
     def get_url_parts(self, request=None) -> tuple[int, str, str]:
         """Builds the full URL for this page

--- a/cms/dashboard/templates/cms_starting_pages/access_our_data_data_structure.json
+++ b/cms/dashboard/templates/cms_starting_pages/access_our_data_data_structure.json
@@ -1,7 +1,7 @@
 {
     "id": 323,
     "meta": {
-        "seo_title": "",
+        "seo_title": "Data structure | UKHSA data dashboard",
         "search_description": "",
         "type": "composite.CompositePage",
         "detail_url": "https://d06bcac6.dev.ukhsa-dashboard.data.gov.uk/api/pages/323/",

--- a/cms/dashboard/templates/cms_starting_pages/cold_health_alerts.json
+++ b/cms/dashboard/templates/cms_starting_pages/cold_health_alerts.json
@@ -1,7 +1,7 @@
 {
   "id": 22,
   "meta": {
-    "seo_title": "",
+    "seo_title": "Cold health alerts | UKHSA data dashboard",
     "search_description": "",
     "type": "composite.CompositePage",
     "detail_url": "http://localhost/api/pages/22/",

--- a/cms/dashboard/templates/cms_starting_pages/heat_health_alerts.json
+++ b/cms/dashboard/templates/cms_starting_pages/heat_health_alerts.json
@@ -1,7 +1,7 @@
 {
   "id": 21,
   "meta": {
-    "seo_title": "",
+    "seo_title": "Heat health alerts | UKHSA data dashboard",
     "search_description": "",
     "type": "composite.CompositePage",
     "detail_url": "http://localhost/api/pages/21/",

--- a/cms/dashboard/templates/cms_starting_pages/metrics_documentation_covid-19_deaths_onsbyweek.json
+++ b/cms/dashboard/templates/cms_starting_pages/metrics_documentation_covid-19_deaths_onsbyweek.json
@@ -1,13 +1,13 @@
 {
   "id": 17,
   "meta": {
-    "search_description": "",
+    "seo_title": "Metrics documentation - COVID-19 deaths ONS by week | UKHSA data dashboard",
     "type": "metrics_documentation.MetricsDocumentationChildEntry",
     "detail_url": "http://localhost/api/pages/17/",
     "html_url": null,
     "slug": "covid-19-deaths-ons-by-week",
     "show_in_menus": false,
-    "seo_title": "",
+    "search_description": "",
     "first_published_at": "2023-12-11T18:53:25.857988Z",
     "alias_of": null,
     "parent": {

--- a/cms/dashboard/templates/cms_starting_pages/weather_health_alerts.json
+++ b/cms/dashboard/templates/cms_starting_pages/weather_health_alerts.json
@@ -1,7 +1,7 @@
 {
   "id": 20,
   "meta": {
-    "seo_title": "",
+    "seo_title": "Weather health alerts | UKHSA data dashboard",
     "search_description": "",
     "type": "composite.CompositePage",
     "detail_url": "http://localhost/api/pages/20/",

--- a/cms/metrics_documentation/data_migration/operations.py
+++ b/cms/metrics_documentation/data_migration/operations.py
@@ -91,6 +91,7 @@ def _create_metrics_documentation_parent_page():
         date_posted=datetime.datetime.today(),
         body=parent_page_data["body"],
         show_in_menus=False,
+        seo_title=parent_page_data["meta"]["seo_title"],
     )
     add_page_as_subpage_to_parent(subpage=metrics_parent, parent_page=root_page)
     return metrics_parent

--- a/tests/fakes/factories/cms/composite_page_factory.py
+++ b/tests/fakes/factories/cms/composite_page_factory.py
@@ -31,4 +31,8 @@ class FakeCompositePageFactory(factory.Factory):
             data["meta"]["slug"] = slug
             kwargs.pop("slug")
 
-        return cls.build(body=data["body"], title=data["title"], slug=slug, **kwargs)
+        seo_title = (data["meta"]["seo_title"],)
+
+        return cls.build(
+            body=data["body"], title=data["title"], slug=slug, seo_title=slug, **kwargs
+        )

--- a/tests/fakes/factories/cms/home_page_factory.py
+++ b/tests/fakes/factories/cms/home_page_factory.py
@@ -26,4 +26,5 @@ class FakeHomePageFactory(factory.Factory):
             title=data["title"],
             page_description=data["page_description"],
             slug=data["meta"]["slug"],
+            seo_title=data["meta"]["seo_title"],
         )

--- a/tests/fakes/factories/cms/metrics_documentation_factory.py
+++ b/tests/fakes/factories/cms/metrics_documentation_factory.py
@@ -29,4 +29,12 @@ class FakeMetricsDocumentationParentPageFactory(factory.Factory):
             data["meta"]["slug"] = slug
             kwargs.pop("slug")
 
-        return cls.build(body=data["body"], title=data["title"], slug=slug, **kwargs)
+        seo_title = data["meta"]["seo_title"]
+
+        return cls.build(
+            body=data["body"],
+            title=data["title"],
+            slug=slug,
+            seo_title=seo_title,
+            **kwargs
+        )

--- a/tests/fakes/factories/cms/topic_page_factory.py
+++ b/tests/fakes/factories/cms/topic_page_factory.py
@@ -22,6 +22,7 @@ class FakeTopicPageFactory(factory.Factory):
             title=data["title"],
             page_description=data["page_description"],
             slug=data["meta"]["slug"],
+            seo_title=data["meta"]["seo_title"],
             **kwargs
         )
 

--- a/tests/fakes/factories/cms/whats_new_child_entry_factory.py
+++ b/tests/fakes/factories/cms/whats_new_child_entry_factory.py
@@ -21,11 +21,13 @@ class FakeWhatsNewChildEntryFactory(factory.Factory):
             page_name="whats_new_soft_launch_of_the_ukhsa_data_dashboard"
         )
         badge = Badge(text=data["badge"]["text"], colour=data["badge"]["colour"])
+        seo_title = data["meta"]["seo_title"]
         return cls.build(
             title=data["title"],
             body=data["body"],
             additional_details=data["additional_details"],
             slug=data["meta"]["slug"],
             badge=badge,
+            seo_title=seo_title,
             **kwargs
         )

--- a/tests/fakes/factories/cms/whats_new_parent_page_factory.py
+++ b/tests/fakes/factories/cms/whats_new_parent_page_factory.py
@@ -27,4 +27,12 @@ class FakeWhatsNewParentPageFactory(factory.Factory):
             data["meta"]["slug"] = slug
             kwargs.pop("slug")
 
-        return cls.build(body=data["body"], title=data["title"], slug=slug, **kwargs)
+        seo_title = data["meta"]["seo_title"]
+
+        return cls.build(
+            body=data["body"],
+            title=data["title"],
+            slug=slug,
+            seo_title=seo_title,
+            **kwargs
+        )

--- a/tests/integration/cms/common/test_managers.py
+++ b/tests/integration/cms/common/test_managers.py
@@ -19,6 +19,7 @@ class TestCommonPageManager:
             date_posted="2023-01-01",
             body="ghi",
             live=True,
+            seo_title="ABC",
         )
         unpublished_page = CommonPage.objects.create(
             path="def",
@@ -27,6 +28,7 @@ class TestCommonPageManager:
             date_posted="2023-01-01",
             body="ghi",
             live=False,
+            seo_title="DEF",
         )
 
         # When

--- a/tests/integration/cms/home/test_managers.py
+++ b/tests/integration/cms/home/test_managers.py
@@ -14,10 +14,18 @@ class TestHomePageManager:
         """
         # Given
         landing_page = HomePage.objects.create(
-            path="abc", depth=1, title="abc", slug=EXPECTED_HOME_PAGE_SLUG
+            path="abc",
+            depth=1,
+            title="abc",
+            slug=EXPECTED_HOME_PAGE_SLUG,
+            seo_title="ABC",
         )
         invalid_page = HomePage.objects.create(
-            path="def", depth=1, title="def", slug="invalid_slug"
+            path="def",
+            depth=1,
+            title="def",
+            slug="invalid_slug",
+            seo_title="DEF",
         )
 
         # When

--- a/tests/integration/cms/metrics_documentation/data_migration/test_operations.py
+++ b/tests/integration/cms/metrics_documentation/data_migration/test_operations.py
@@ -42,6 +42,7 @@ class TestRemoveMetricsDocumentationChildEntries:
             date_posted=datetime.date.today(),
             page_description="xyz",
             metric=metric.name,
+            seo_title="Test",
         )
         assert MetricsDocumentationChildEntry.objects.exists()
 
@@ -69,6 +70,7 @@ class TestRemoveMetricsDocumentationParentPage:
             slug="metrics-documentation",
             date_posted=datetime.date.today(),
             body="xyz",
+            seo_title="Metrics documentation",
         )
         assert MetricsDocumentationParentPage.objects.exists()
 

--- a/tests/integration/cms/metrics_documentation/models/test_child.py
+++ b/tests/integration/cms/metrics_documentation/models/test_child.py
@@ -41,4 +41,5 @@ def _create_metrics_documentation_child_entry(
         slug=metric_name,
         date_posted=datetime.date.today(),
         page_description="xyz",
+        seo_title=metric_name.replace("_", "").title(),
     )

--- a/tests/integration/cms/metrics_documentation/models/test_parent.py
+++ b/tests/integration/cms/metrics_documentation/models/test_parent.py
@@ -21,6 +21,7 @@ class TestMetricsDocumentationParentPage:
             date_posted="2023-11-01",
             body="lorem ipsum...",
             live=True,
+            seo_title="Metrics documentation",
         )
 
         # When / Then
@@ -33,4 +34,5 @@ class TestMetricsDocumentationParentPage:
                 date_posted="2023-11-02",
                 body="lorem ipsum...",
                 live=True,
+                seo_title="Metrics documentation",
             )

--- a/tests/integration/cms/topic/test_managers.py
+++ b/tests/integration/cms/topic/test_managers.py
@@ -24,6 +24,7 @@ class TestTopicPageManager:
             title="abc",
             date_posted=date_posted,
             live=True,
+            seo_title="ABC",
         )
         unpublished_page = TopicPage.objects.create(
             path="def",
@@ -31,6 +32,7 @@ class TestTopicPageManager:
             title="def",
             date_posted=date_posted,
             live=False,
+            seo_title="DEF",
         )
 
         # When

--- a/tests/integration/cms/whats_new/managers/test_child.py
+++ b/tests/integration/cms/whats_new/managers/test_child.py
@@ -19,6 +19,7 @@ class TestWhatsNewChildEntryManager:
             date_posted="2023-01-01",
             body="ghi",
             live=True,
+            seo_title="ABC",
         )
         unpublished_page = WhatsNewChildEntry.objects.create(
             path="def",
@@ -27,6 +28,7 @@ class TestWhatsNewChildEntryManager:
             date_posted="2023-01-01",
             body="ghi",
             live=False,
+            seo_title="DEF",
         )
 
         # When

--- a/tests/unit/cms/dashboard/test_models.py
+++ b/tests/unit/cms/dashboard/test_models.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import pytest
+from django.core.exceptions import ValidationError
 
 from cms.dashboard.models import UKHSAPage
 from tests.fakes.factories.cms.common_page_factory import FakeCommonPageFactory
@@ -80,3 +81,33 @@ class TestUKHSAPage:
 
         # Then
         assert timestamp == mocked_last_published_at
+
+    @pytest.mark.parametrize(
+        "fake_page",
+        [
+            FakeHomePageFactory.build_blank_page(),
+            FakeTopicPageFactory.build_influenza_page_from_template(),
+            FakeCommonPageFactory.build_blank_page(),
+            FakeCompositePageFactory.build_page_from_template(
+                page_name="access_our_data_getting_started"
+            ),
+            FakeMetricsDocumentationParentPageFactory.build_page_from_template(),
+            FakeWhatsNewChildEntryFactory.build_page_from_template(),
+            FakeWhatsNewParentPageFactory.build_page_from_template(),
+        ],
+    )
+    def test_seo_title_field_is_required_by_clean_method_call(
+        self, fake_page: UKHSAPage
+    ):
+        """
+        Given a page model which inherits from `UKHSAPage`
+        And no `seo_title` field was set
+        When the `clean()` method is called
+        Then a `ValidationError` is raised
+        """
+        # Given
+        fake_page.seo_title = None
+
+        # When / Then
+        with pytest.raises(ValidationError):
+            fake_page.clean()


### PR DESCRIPTION
# Description

This PR includes the following:

- Extends the `clean()` method on all pages to ensure that the `seo_title` field is required.
Note that because the `seo_title` column is implemented by the `Page` model itself, the easiest way was to enforce the field at the `clean()` method call which will be enforced on save/publish of the page.

Fixes #CDD-1633

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
