### PR TITLE
Remove geography_type from ChartAxisFields

### DIFF
--- a/metrics/domain/common/utils.py
+++ b/metrics/domain/common/utils.py
@@ -72,7 +72,6 @@ class ChartAxisFields(Enum):
     date = "date"
     metric = "metric_value"
     geography = "geography__name"
-    geography_type = "geography__geography_type__name"
     sex = "sex"
 
     @classmethod

--- a/tests/unit/metrics/domain/common/test_utils.py
+++ b/tests/unit/metrics/domain/common/test_utils.py
@@ -166,7 +166,6 @@ class TestChartAxisFields:
             "date",
             "metric_value",
             "geography__name",
-            "geography__geography_type__name",
             "sex",
         )
         assert values == expected_values


### PR DESCRIPTION
# Description

This PR removes `geography_type` from the `ChartAxisFields` to remove that option from the CMS chart cards.


---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
