### PR TITLE
CDD-2123: New simplified line chart

### DIFF
--- a/cms/metrics_interface/interface.py
+++ b/cms/metrics_interface/interface.py
@@ -135,7 +135,7 @@ class MetricsAPIInterface:
                 [("BLUE", "BLUE"), ...]
 
         """
-        return RGBAChartLineColours.choices()
+        return RGBAChartLineColours.selectable_choices()
 
     def get_all_topic_names(self) -> QuerySet:
         """Gets all available topic names as a flat list queryset.

--- a/metrics/domain/charts/chart_settings.py
+++ b/metrics/domain/charts/chart_settings.py
@@ -1,7 +1,9 @@
 import datetime
+from decimal import Decimal
 
 from metrics.domain.charts import colour_scheme
 from metrics.domain.charts.type_hints import DICT_OF_STR_ONLY
+from metrics.domain.charts.utils import return_formatted_max_y_axis_value
 from metrics.domain.common.utils import DEFAULT_CHART_WIDTH, get_last_day_of_month
 from metrics.domain.models import PlotData
 
@@ -102,13 +104,37 @@ class ChartSettings:
         chart_config["showlegend"] = False
         return chart_config
 
-    def get_line_single_simplified_chart_config(
+    def build_line_single_simplified_axis_params(
         self,
-        x_axis_tick_values: list[int],
-        x_axis_tick_text: list[str],
-        y_axis_tick_values: list[int],
-        y_axis_tick_text: list[str],
-    ):
+    ) -> dict[str, list[str | int | Decimal]]:
+        """Creates the parameters for `get_line_single_simplified_chart_config`
+
+        Returns:
+            dictionary of parameters for charts settings parameters
+        """
+        plot_data = self.plots_data[0]
+        return {
+            "x_axis_tick_values": [
+                plot_data.x_axis_values[0],
+                plot_data.x_axis_values[-1],
+            ],
+            "x_axis_tick_text": [
+                plot_data.x_axis_values[0].strftime("%b, %Y"),
+                plot_data.x_axis_values[-1].strftime("%b, %Y"),
+            ],
+            "y_axis_tick_values": [0, max(plot_data.y_axis_values)],
+            "y_axis_tick_text": [
+                "0",
+                return_formatted_max_y_axis_value(
+                    y_axis_values=plot_data.y_axis_values,
+                ),
+            ],
+        }
+
+    def get_line_single_simplified_chart_config(self):
+
+        axis_params = self.build_line_single_simplified_axis_params()
+
         # Chart Config
         chart_config = self.get_base_chart_config()
         chart_config["showlegend"] = False
@@ -117,9 +143,10 @@ class ChartSettings:
         chart_config["margin"]["pad"] = 25
 
         # x_axis config
+        chart_config["xaxis"]["showgrid"] = False
         chart_config["xaxis"]["ticks"] = "outside"
-        chart_config["xaxis"]["tickvals"] = x_axis_tick_values
-        chart_config["xaxis"]["ticktext"] = x_axis_tick_text
+        chart_config["xaxis"]["tickvals"] = axis_params["x_axis_tick_values"]
+        chart_config["xaxis"]["ticktext"] = axis_params["x_axis_tick_text"]
         chart_config["xaxis"]["ticklen"] = 0
         chart_config["xaxis"]["tickfont"][
             "color"
@@ -128,8 +155,8 @@ class ChartSettings:
         # y_axis config
         chart_config["yaxis"]["zeroline"] = False
         chart_config["yaxis"]["ticks"] = "outside"
-        chart_config["yaxis"]["tickvals"] = y_axis_tick_values
-        chart_config["yaxis"]["ticktext"] = y_axis_tick_text
+        chart_config["yaxis"]["tickvals"] = axis_params["y_axis_tick_values"]
+        chart_config["yaxis"]["ticktext"] = axis_params["y_axis_tick_text"]
         chart_config["yaxis"]["ticklen"] = 0
         chart_config["yaxis"]["tickfont"][
             "color"

--- a/metrics/domain/charts/chart_settings.py
+++ b/metrics/domain/charts/chart_settings.py
@@ -102,6 +102,41 @@ class ChartSettings:
         chart_config["showlegend"] = False
         return chart_config
 
+    def get_line_single_simplified_chart_config(
+        self,
+        x_axis_tick_values: list[int],
+        x_axis_tick_text: list[str],
+        y_axis_tick_values: list[int],
+        y_axis_tick_text: list[str],
+    ):
+        # Chart Config
+        chart_config = self.get_base_chart_config()
+        chart_config["showlegend"] = False
+        chart_config["margin"]["l"] = 25
+        chart_config["margin"]["r"] = 25
+        chart_config["margin"]["pad"] = 25
+
+        # x_axis config
+        chart_config["xaxis"]["ticks"] = "outside"
+        chart_config["xaxis"]["tickvals"] = x_axis_tick_values
+        chart_config["xaxis"]["ticktext"] = x_axis_tick_text
+        chart_config["xaxis"]["ticklen"] = 0
+        chart_config["xaxis"]["tickfont"][
+            "color"
+        ] = colour_scheme.RGBAColours.LS_DARK_GREY.stringified
+
+        # y_axis config
+        chart_config["yaxis"]["zeroline"] = False
+        chart_config["yaxis"]["ticks"] = "outside"
+        chart_config["yaxis"]["tickvals"] = y_axis_tick_values
+        chart_config["yaxis"]["ticktext"] = y_axis_tick_text
+        chart_config["yaxis"]["ticklen"] = 0
+        chart_config["yaxis"]["tickfont"][
+            "color"
+        ] = colour_scheme.RGBAColours.LS_DARK_GREY.stringified
+
+        return chart_config
+
     def get_bar_chart_config(self):
         chart_config = self.get_base_chart_config()
         chart_config["barmode"] = "group"

--- a/metrics/domain/charts/colour_scheme.py
+++ b/metrics/domain/charts/colour_scheme.py
@@ -17,6 +17,10 @@ class RGBAChartLineColours(Enum):
     COLOUR_11_KHAKI = 71, 71, 0
     COLOUR_12_BLUE = 0, 157, 214
 
+    # simplified single line chart colours
+    TREND_LINE_POSITIVE = 0, 112, 60
+    TREND_LINE_NEGATIVE = 171, 43, 23
+
     # Legacy colors
     RED: RGBA_VALUES = 212, 53, 28
     YELLOW: RGBA_VALUES = 255, 221, 0
@@ -54,8 +58,34 @@ class RGBAChartLineColours(Enum):
     @classmethod
     def choices(cls):
         return tuple(
-            (chart_type.name, cls._convert_to_readable_name(chart_type.name))
-            for chart_type in cls
+            (
+                chart_line_color.name,
+                cls._convert_to_readable_name(chart_line_color.name),
+            )
+            for chart_line_color in cls
+        )
+
+    @classmethod
+    def selectable_choices(cls):
+        """Returns chart line colours which are selectable from the CMS
+
+        Returns:
+            Nested tuples of 2 item tuples as expected by the CMS forms
+            with the value name and a formatted display version
+            Examples:
+                (("COLOUR_1_DARK_BLUE", "Colour 1 Dark Blue"), ...)
+        """
+        non_selectable = [
+            cls.TREND_LINE_NEGATIVE,
+            cls.TREND_LINE_POSITIVE,
+        ]
+        return tuple(
+            (
+                chart_line_color.name,
+                cls._convert_to_readable_name(chart_line_color.name),
+            )
+            for chart_line_color in cls
+            if chart_line_color not in non_selectable
         )
 
     @classmethod

--- a/metrics/domain/charts/line_single_simplified/__init__.py
+++ b/metrics/domain/charts/line_single_simplified/__init__.py
@@ -1,0 +1,2 @@
+from .generation import generate_chart_figure
+from .utils import return_formatted_max_y_axis_value

--- a/metrics/domain/charts/line_single_simplified/__init__.py
+++ b/metrics/domain/charts/line_single_simplified/__init__.py
@@ -1,2 +1,1 @@
 from .generation import generate_chart_figure
-from .utils import return_formatted_max_y_axis_value

--- a/metrics/domain/charts/line_single_simplified/generation.py
+++ b/metrics/domain/charts/line_single_simplified/generation.py
@@ -7,43 +7,12 @@ from metrics.domain.charts import chart_settings
 from metrics.domain.charts.colour_scheme import RGBAChartLineColours
 from metrics.domain.models import PlotData
 
-from .utils import return_formatted_max_y_axis_value
-
-
-def _build_chart_config_params(
-    x_axis_values: list[datetime.date],
-    y_axis_values: list[Decimal],
-) -> dict[str | int | Decimal]:
-    """Creates the parameters for `get_line_single_simplified_chart_config`
-
-    Args:
-        x_axis_values: list of dates for the x_axis of a chart
-        y_axis_values: list of Decimal values for the y_axis of a chart
-
-    Returns:
-        dictionary of parameters for charts settings parameters
-    """
-    return {
-        "x_axis_tick_values": [x_axis_values[0], x_axis_values[-1]],
-        "x_axis_tick_text": [
-            x_axis_values[0].strftime("%b, %Y"),
-            x_axis_values[-1].strftime("%b, %Y"),
-        ],
-        "y_axis_tick_values": [0, max(y_axis_values)],
-        "y_axis_tick_text": [
-            "0",
-            return_formatted_max_y_axis_value(y_axis_values=y_axis_values),
-        ],
-    }
-
 
 def create_simplified_line_chart(
     *,
     plot_data: PlotData,
     chart_height: int,
     chart_width: int,
-    x_axis_values: list[str],
-    y_axis_values: list[Decimal],
 ) -> plotly.graph_objects.Figure:
     """Creates a `Figure` object for the given `values` as a line graph with a shaded region.
 
@@ -51,8 +20,6 @@ def create_simplified_line_chart(
         plot_data: `PlotData` model
         chart_height: chart width as an integer
         chart_width: chart height as an integer
-        x_axis_values: list of `datetime.date` objects
-        y_axis_values: list of `Decimal` values
 
     Returns:
         `Figure`: A `Plotly` object which can be
@@ -67,8 +34,8 @@ def create_simplified_line_chart(
     line_shape = "spline" if plot_data[0].parameters.use_smooth_lines else "linear"
 
     line_plot: dict = _create_line_plot(
-        x_axis_values=x_axis_values,
-        y_axis_values=y_axis_values,
+        x_axis_values=plot_data[0].x_axis_values,
+        y_axis_values=plot_data[0].y_axis_values,
         line_shape=line_shape,
         colour=selected_colour.stringified,
     )
@@ -79,11 +46,7 @@ def create_simplified_line_chart(
         width=chart_width, height=chart_height, plots_data=plot_data
     )
 
-    layout_params = _build_chart_config_params(
-        x_axis_values=x_axis_values,
-        y_axis_values=y_axis_values,
-    )
-    layout_args = settings.get_line_single_simplified_chart_config(**layout_params)
+    layout_args = settings.get_line_single_simplified_chart_config()
     figure.update_layout(**layout_args)
 
     return figure
@@ -91,8 +54,8 @@ def create_simplified_line_chart(
 
 def _create_line_plot(
     *,
-    x_axis_values: list[str],
-    y_axis_values: list[str],
+    x_axis_values: list[datetime.date],
+    y_axis_values: list[Decimal],
     colour: str,
     line_shape: str,
 ) -> dict:
@@ -110,8 +73,6 @@ def generate_chart_figure(
     plot_data: PlotData,
     chart_height: int,
     chart_width: int,
-    x_axis_values: list[datetime.date],
-    y_axis_values: list[Decimal],
 ) -> plotly.graph_objects.Figure:
     """Creates a `Figure` object for the given `chart_plots_data` as a
         simplified line graph with a single plot and 4 axis ticks
@@ -120,10 +81,6 @@ def generate_chart_figure(
         plot_data: A `PlotData` model
         chart_height: The chart height in pixels
         chart_width: The chart width in pixels
-        x_axis_values: A list of datetime.date objects for
-            the x-axis of a chart
-        y_axis_values: A list of Decimal values for the
-            y-axis of a chart
 
     Returns:
         `Figure`: A `Plotly` object which can then be
@@ -133,6 +90,4 @@ def generate_chart_figure(
         plot_data=plot_data,
         chart_height=chart_height,
         chart_width=chart_width,
-        x_axis_values=x_axis_values,
-        y_axis_values=y_axis_values,
     )

--- a/metrics/domain/charts/line_single_simplified/generation.py
+++ b/metrics/domain/charts/line_single_simplified/generation.py
@@ -1,0 +1,138 @@
+from datetime import datetime
+from decimal import Decimal
+
+import plotly.graph_objects
+
+from metrics.domain.charts import chart_settings
+from metrics.domain.charts.colour_scheme import RGBAChartLineColours
+from metrics.domain.models import PlotData
+
+from .utils import return_formatted_max_y_axis_value
+
+
+def _build_chart_config_params(
+    x_axis_values: list[datetime.date],
+    y_axis_values: list[Decimal],
+) -> dict[str | int | Decimal]:
+    """Creates the parameters for `get_line_single_simplified_chart_config`
+
+    Args:
+        x_axis_values: list of dates for the x_axis of a chart
+        y_axis_values: list of Decimal values for the y_axis of a chart
+
+    Returns:
+        dictionary of parameters for charts settings parameters
+    """
+    return {
+        "x_axis_tick_values": [x_axis_values[0], x_axis_values[-1]],
+        "x_axis_tick_text": [
+            x_axis_values[0].strftime("%b, %Y"),
+            x_axis_values[-1].strftime("%b, %Y"),
+        ],
+        "y_axis_tick_values": [0, max(y_axis_values)],
+        "y_axis_tick_text": [
+            "0",
+            return_formatted_max_y_axis_value(y_axis_values=y_axis_values),
+        ],
+    }
+
+
+def create_simplified_line_chart(
+    *,
+    plot_data: PlotData,
+    chart_height: int,
+    chart_width: int,
+    x_axis_values: list[str],
+    y_axis_values: list[Decimal],
+) -> plotly.graph_objects.Figure:
+    """Creates a `Figure` object for the given `values` as a line graph with a shaded region.
+
+    Args:
+        plot_data: `PlotData` model
+        chart_height: chart width as an integer
+        chart_width: chart height as an integer
+        x_axis_values: list of `datetime.date` objects
+        y_axis_values: list of `Decimal` values
+
+    Returns:
+        `Figure`: A `Plotly` object which can be
+            written to a file, or shown.
+    """
+    figure = plotly.graph_objects.Figure()
+
+    selected_colour = RGBAChartLineColours.get_colour(
+        colour=plot_data[0].parameters.line_colour
+    )
+
+    line_shape = "spline" if plot_data[0].parameters.use_smooth_lines else "linear"
+
+    line_plot: dict = _create_line_plot(
+        x_axis_values=x_axis_values,
+        y_axis_values=y_axis_values,
+        line_shape=line_shape,
+        colour=selected_colour.stringified,
+    )
+
+    figure.add_trace(trace=line_plot)
+
+    settings = chart_settings.ChartSettings(
+        width=chart_width, height=chart_height, plots_data=plot_data
+    )
+
+    layout_params = _build_chart_config_params(
+        x_axis_values=x_axis_values,
+        y_axis_values=y_axis_values,
+    )
+    layout_args = settings.get_line_single_simplified_chart_config(**layout_params)
+    figure.update_layout(**layout_args)
+
+    return figure
+
+
+def _create_line_plot(
+    *,
+    x_axis_values: list[str],
+    y_axis_values: list[str],
+    colour: str,
+    line_shape: str,
+) -> dict:
+    return plotly.graph_objects.Scatter(
+        x=x_axis_values,
+        y=y_axis_values,
+        mode="lines",
+        line={"color": colour, "width": 3},
+        line_shape=line_shape,
+    )
+
+
+def generate_chart_figure(
+    *,
+    plot_data: PlotData,
+    chart_height: int,
+    chart_width: int,
+    x_axis_values: list[datetime.date],
+    y_axis_values: list[Decimal],
+) -> plotly.graph_objects.Figure:
+    """Creates a `Figure` object for the given `chart_plots_data` as a
+        simplified line graph with a single plot and 4 axis ticks
+
+    Args:
+        plot_data: A `PlotData` model
+        chart_height: The chart height in pixels
+        chart_width: The chart width in pixels
+        x_axis_values: A list of datetime.date objects for
+            the x-axis of a chart
+        y_axis_values: A list of Decimal values for the
+            y-axis of a chart
+
+    Returns:
+        `Figure`: A `Plotly` object which can then be
+            written to a file, or shown.
+    """
+    return create_simplified_line_chart(
+        plot_data=plot_data,
+        chart_height=chart_height,
+        chart_width=chart_width,
+        x_axis_values=x_axis_values,
+        y_axis_values=y_axis_values,
+    )

--- a/metrics/domain/charts/line_single_simplified/utils.py
+++ b/metrics/domain/charts/line_single_simplified/utils.py
@@ -1,0 +1,71 @@
+from decimal import Decimal
+
+SUFFIXES = ["", "k", "m"]
+E_NOTATION = [1e0, 1e3, 1e6, 1e9]
+CONVERT_LARGE_NUMBERS_VALUE_ERROR = (
+    "This number is to large to be formatted for the simplified chart."
+)
+
+
+def convert_large_numbers_to_short_text(number: int) -> str:
+    """Converts the provided `int` into a short number string.
+
+    Args:
+        number: Integer to be formatted as a string
+
+    Returns:
+        A short number string
+        Eg: 1000 = 1k, 2500 = 2k, 2690 = 3k, 100,000,000 = 1m
+    """
+    if number >= E_NOTATION[1]:
+
+        for index in range(len(E_NOTATION)):
+            try:
+                if E_NOTATION[index] <= number < E_NOTATION[index + 1]:
+                    return f"{str(int(number / E_NOTATION[index]))}{SUFFIXES[index]}"
+
+            except IndexError:
+                raise ValueError(CONVERT_LARGE_NUMBERS_VALUE_ERROR)
+
+    return str(number)
+
+
+def _extract_max_value(
+    y_axis_values: list[Decimal],
+) -> int:
+    """Extracts the highest `Decimal` value from the `y_axis_values`
+        list and returns an `Int` rounded to the nearest large number
+
+    Notes:
+        `place_value` is the place of the first digit in the number
+        represented by the number of digits to its right.
+        Eg: a number of `1000` has 3 places after the first digit
+        so `place_value` = 3
+
+    Args:
+        y_axis_values: list of Decimal values
+
+    Returns:
+        an integer of the highest value from the list rounded to the
+        nearest 10, 100, 1000, ... depending on the number provided.
+    """
+    max_y_axis_value = round(max(y_axis_values))
+    place_value = len(str(max_y_axis_value)) - 1
+    return round(max_y_axis_value, -place_value)
+
+
+def return_formatted_max_y_axis_value(
+    y_axis_values: list[Decimal],
+) -> str:
+    """Returns the highest value from `y_axis_values` as a formatted string
+
+    Args:
+        y_axis_values: A list of `Decimal` values representing
+        the y_axis values of a `Timeseries` chart.
+
+    Returns:
+        A string of the highest value from `y_axis_values` rounded up
+        and formatted as a short string Eg: 1400 becomes 1k
+    """
+    max_value = _extract_max_value(y_axis_values=y_axis_values)
+    return convert_large_numbers_to_short_text(number=max_value)

--- a/metrics/domain/charts/utils.py
+++ b/metrics/domain/charts/utils.py
@@ -13,6 +13,10 @@ def convert_large_numbers_to_short_text(number: int) -> str:
     Args:
         number: Integer to be formatted as a string
 
+    Raises:
+        `ValueError`: if the number provided is to large
+            for example over 1billion.
+
     Returns:
         A short number string
         Eg: 1000 = 1k, 2500 = 2k, 2690 = 3k, 100,000,000 = 1m

--- a/metrics/domain/common/utils.py
+++ b/metrics/domain/common/utils.py
@@ -26,6 +26,7 @@ class ChartTypes(Enum):
     line_with_shaded_section = "line_with_shaded_section"
     bar = "bar"
     line_multi_coloured = "line_multi_coloured"
+    line_single_simplified = "line_single_simplified"
 
     @classmethod
     def choices(cls) -> tuple[tuple[str, str], ...]:
@@ -45,6 +46,7 @@ class ChartTypes(Enum):
             cls.line_multi_coloured,
             cls.bar,
             cls.line_with_shaded_section,
+            cls.line_single_simplified,
         )
         return tuple((chart_type.value, chart_type.value) for chart_type in selectable)
 

--- a/metrics/interfaces/charts/access.py
+++ b/metrics/interfaces/charts/access.py
@@ -320,7 +320,7 @@ class ChartsInterface:
             ),
         }
 
-    def param_builder_for_line_single_simplified(self, *, plots_data):
+    def param_builder_for_line_single_simplified(self, *, plots_data: list[PlotData]):
         """Returns the params required to create a
             `line_single_simplified` chart.
 
@@ -336,15 +336,11 @@ class ChartsInterface:
         plot_data = plots_data[0]
         chart_height = self.chart_plots.chart_height
         chart_width = self.chart_plots.chart_width
-        x_axis_values = plot_data.x_axis_values
-        y_axis_value = plot_data.y_axis_values
 
         return {
             "plot_data": [plot_data],
             "chart_height": chart_height,
             "chart_width": chart_width,
-            "x_axis_values": x_axis_values,
-            "y_axis_values": y_axis_value,
         }
 
     def create_optimized_svg(self, *, figure: plotly.graph_objects.Figure) -> str:

--- a/tests/integration/metrics/domain/charts/line_single_simplified/test_generation.py
+++ b/tests/integration/metrics/domain/charts/line_single_simplified/test_generation.py
@@ -26,8 +26,8 @@ class TestLineSingleSimplified:
         Then the figure is drawn with the expected parameters
         """
         # Given
-        x_axis_values = DATES_FROM_SEP_TO_JAN
-        y_axis_values = [1.1, 0.9, 0.8, 0.3]
+        fake_plot_data.x_axis_values = DATES_FROM_SEP_TO_JAN
+        fake_plot_data.y_axis_values = [1.1, 0.9, 0.8, 0.3]
         chart_height = 200
         chart_width = 400
 
@@ -36,8 +36,6 @@ class TestLineSingleSimplified:
             plot_data=[fake_plot_data],
             chart_height=chart_height,
             chart_width=chart_width,
-            x_axis_values=x_axis_values,
-            y_axis_values=y_axis_values,
         )
 
         # Then
@@ -49,13 +47,16 @@ class TestLineSingleSimplified:
 
         assert figure.layout.margin.l == figure.layout.margin.r == 25
 
-        assert figure.layout.xaxis.tickvals == (x_axis_values[0], x_axis_values[-1])
+        assert figure.layout.xaxis.tickvals == (
+            fake_plot_data.x_axis_values[0],
+            fake_plot_data.x_axis_values[-1],
+        )
         assert figure.layout.xaxis.ticktext == (
-            x_axis_values[0].strftime("%b, %Y"),
-            x_axis_values[-1].strftime("%b, %Y"),
+            fake_plot_data.x_axis_values[0].strftime("%b, %Y"),
+            fake_plot_data.x_axis_values[-1].strftime("%b, %Y"),
         )
 
-        assert figure.layout.yaxis.tickvals == (0, max(y_axis_values))
+        assert figure.layout.yaxis.tickvals == (0, max(fake_plot_data.y_axis_values))
         assert figure.layout.yaxis.ticktext == (
             "0",
             "1",

--- a/tests/integration/metrics/domain/charts/line_single_simplified/test_generation.py
+++ b/tests/integration/metrics/domain/charts/line_single_simplified/test_generation.py
@@ -1,0 +1,62 @@
+import datetime
+from unittest import mock
+
+import plotly.graph_objects
+
+from metrics.domain.charts.colour_scheme import RGBAColours
+from metrics.domain.charts.line_single_simplified import generation
+from metrics.domain.models import PlotData
+
+DATES_FROM_SEP_TO_JAN: list[datetime.datetime] = [
+    datetime.date(2022, 9, 5),
+    datetime.date(2022, 10, 10),
+    datetime.date(2022, 11, 14),
+    datetime.date(2022, 12, 12),
+    datetime.date(2023, 1, 9),
+]
+
+
+class TestLineSingleSimplified:
+    def test_line_single_simplified_figure_is_drawn_with_expected_params(
+        self, fake_plot_data: PlotData
+    ):
+        """
+        Given a list of dates and values
+        When `generate_chart_figure()` is called from the `line_single_simplified` module
+        Then the figure is drawn with the expected parameters
+        """
+        # Given
+        x_axis_values = DATES_FROM_SEP_TO_JAN
+        y_axis_values = [1.1, 0.9, 0.8, 0.3]
+        chart_height = 200
+        chart_width = 400
+
+        # When
+        figure: plotly.graph_objects.Figure = generation.generate_chart_figure(
+            plot_data=[fake_plot_data],
+            chart_height=chart_height,
+            chart_width=chart_width,
+            x_axis_values=x_axis_values,
+            y_axis_values=y_axis_values,
+        )
+
+        # Then
+        main_layout = figure.layout
+        assert main_layout.paper_bgcolor == RGBAColours.WHITE.stringified
+        assert not main_layout.showlegend
+        assert main_layout.height == chart_height
+        assert main_layout.width == chart_width
+
+        assert figure.layout.margin.l == figure.layout.margin.r == 25
+
+        assert figure.layout.xaxis.tickvals == (x_axis_values[0], x_axis_values[-1])
+        assert figure.layout.xaxis.ticktext == (
+            x_axis_values[0].strftime("%b, %Y"),
+            x_axis_values[-1].strftime("%b, %Y"),
+        )
+
+        assert figure.layout.yaxis.tickvals == (0, max(y_axis_values))
+        assert figure.layout.yaxis.ticktext == (
+            "0",
+            "1",
+        )

--- a/tests/unit/cms/metrics_interface/test_interface.py
+++ b/tests/unit/cms/metrics_interface/test_interface.py
@@ -84,7 +84,7 @@ class TestMetricsAPIInterface:
         all_chart_types = metrics_api_interface.get_colours()
 
         # Then
-        assert all_chart_types == RGBAChartLineColours.choices()
+        assert all_chart_types == RGBAChartLineColours.selectable_choices()
 
     def test_get_all_topic_names_delegates_call_correctly(self):
         """

--- a/tests/unit/metrics/domain/charts/line_single_simplified/test_utils.py
+++ b/tests/unit/metrics/domain/charts/line_single_simplified/test_utils.py
@@ -1,0 +1,91 @@
+import pytest
+from unittest import mock
+from decimal import Decimal
+
+from metrics.domain.charts.line_single_simplified.utils import (
+    return_formatted_max_y_axis_value,
+)
+
+MODULE_PATH = "metrics.domain.charts"
+
+
+class TestReturnFormattedMaxYAxisValue:
+    @mock.patch(
+        f"{MODULE_PATH}.line_single_simplified.utils.convert_large_numbers_to_short_text"
+    )
+    def test_return_formatted_max_y_axis_value_delegates_calls_correctly(
+        self,
+        spy_convert_large_numbers_to_short_text: mock.MagicMock,
+    ):
+        """
+        Given a valid `y_axis_values` list
+        When `return_formatted_max_y_axis_value()` is called
+        Then `_convert_large_numbers_to_short_text()` is called with an integer
+        """
+        # Given
+        fake_y_axis_values = [Decimal(1.2), Decimal(2.9), Decimal(1.6)]
+        expected_number = 3
+
+        # When
+        return_formatted_max_y_axis_value(y_axis_values=fake_y_axis_values)
+
+        # Then
+        spy_convert_large_numbers_to_short_text.assert_called_once_with(
+            number=expected_number
+        )
+
+    @pytest.mark.parametrize(
+        "y_axis_values, expected_return_value",
+        (
+            [
+                ([Decimal(1.2), Decimal(1.3), Decimal(1.4)], "1"),
+                ([Decimal(1.2), Decimal(1.3), Decimal(1.6)], "2"),
+                ([Decimal(1.2), Decimal(2.2), Decimal(1.6)], "2"),
+                ([Decimal(1.2), Decimal(2.9), Decimal(1.6)], "3"),
+                ([Decimal(1.2), Decimal(9.9), Decimal(1.6)], "10"),
+                ([Decimal(39.2), Decimal(75.9), Decimal(10.6)], "80"),
+                ([Decimal(130.2), Decimal(103.3), Decimal(100.4)], "100"),
+                ([Decimal(100.2), Decimal(220.3), Decimal(240.6)], "200"),
+                ([Decimal(790.2), Decimal(840.2), Decimal(800.6)], "800"),
+                ([Decimal(1300.2), Decimal(1003.3), Decimal(1000.4)], "1k"),
+                ([Decimal(2000.2), Decimal(2500.0), Decimal(2400.6)], "2k"),
+                ([Decimal(8000.2), Decimal(8550.2), Decimal(8300.6)], "9k"),
+                ([Decimal(1300000.2), Decimal(1003000.3), Decimal(1000000.4)], "1m"),
+                ([Decimal(2000000.2), Decimal(2500000.0), Decimal(2400000.6)], "2m"),
+                ([Decimal(8000000.2), Decimal(8550000.2), Decimal(8300000.6)], "9m"),
+            ]
+        ),
+    )
+    def test_return_formatted_max_y_axis_value_returns_correct_value(
+        self,
+        y_axis_values: list[Decimal],
+        expected_return_value: str,
+    ):
+        """
+        Given a valid `y_axis_values` list of decimal values
+        When `return_formatted_max_y_axis_value()` is called with `y_axis_values`
+        Then a string of the maximum value formatted as a short value is returned.
+        """
+        # Given
+        fake_y_axis_values = y_axis_values
+        expected_max_value = expected_return_value
+
+        # When
+        max_value_return_value = return_formatted_max_y_axis_value(
+            y_axis_values=fake_y_axis_values
+        )
+
+        # Then
+        assert max_value_return_value == expected_max_value
+
+    def test_return_formatted_max_y_value_raises_error_when_number_is_to_high(self):
+        """
+        Given an invalid `y_axis_value` list that contains a number of a billion or higher
+        When the `return_formatted_max_y_axis_value()` method is called
+        Then a `ValueError` is raised.
+        """
+        # Given
+        fake_y_axis_values = [Decimal(3000.5), Decimal(1000000000.10)]
+
+        with pytest.raises(ValueError):
+            return_formatted_max_y_axis_value(y_axis_values=fake_y_axis_values)

--- a/tests/unit/metrics/domain/charts/test_chart_settings.py
+++ b/tests/unit/metrics/domain/charts/test_chart_settings.py
@@ -343,8 +343,10 @@ class TestChartSettings:
 
         assert line_with_shaded_section_chart_config == expected_chart_config
 
+    @mock.patch.object(ChartSettings, "build_line_single_simplified_axis_params")
     def test_get_line_single_simplified_chart_config(
         self,
+        mock_build_line_single_simplified_axis_params: mock.MagicMock,
         fake_chart_settings: ChartSettings,
     ):
         """
@@ -355,19 +357,22 @@ class TestChartSettings:
         """
         # Given
         chart_settings = fake_chart_settings
+
         fake_x_axis_tick_values = [0, 10]
         fake_x_axis_tick_text = ["tick01", "tick02"]
         fake_y_axis_tick_values = [0, 10]
         fake_y_axis_tick_text = ["tick01", "tick02"]
 
+        mock_build_line_single_simplified_axis_params.return_value = {
+            "x_axis_tick_values": fake_x_axis_tick_values,
+            "x_axis_tick_text": fake_x_axis_tick_text,
+            "y_axis_tick_values": fake_y_axis_tick_values,
+            "y_axis_tick_text": fake_y_axis_tick_text,
+        }
+
         # When
         line_single_simplified_chart_config = (
-            chart_settings.get_line_single_simplified_chart_config(
-                x_axis_tick_values=fake_x_axis_tick_values,
-                x_axis_tick_text=fake_x_axis_tick_text,
-                y_axis_tick_values=fake_y_axis_tick_values,
-                y_axis_tick_text=fake_y_axis_tick_text,
-            )
+            chart_settings.get_line_single_simplified_chart_config()
         )
 
         # Then
@@ -379,6 +384,7 @@ class TestChartSettings:
         expected_chart_config["margin"]["pad"] = 25
 
         # x_axis settings
+        expected_chart_config["xaxis"]["showgrid"] = False
         expected_chart_config["xaxis"]["tickvals"] = fake_x_axis_tick_values
         expected_chart_config["xaxis"]["ticktext"] = fake_x_axis_tick_text
         expected_chart_config["xaxis"]["ticklen"] = 0

--- a/tests/unit/metrics/domain/charts/test_chart_settings.py
+++ b/tests/unit/metrics/domain/charts/test_chart_settings.py
@@ -343,6 +343,61 @@ class TestChartSettings:
 
         assert line_with_shaded_section_chart_config == expected_chart_config
 
+    def test_get_line_single_simplified_chart_config(
+        self,
+        fake_chart_settings: ChartSettings,
+    ):
+        """
+        Given an instance of `ChartSettings`
+        When `get_line_single_simplified_chart_config()` is called
+        Then the correct configuration for
+            `line_single_simplified` charts is returned as a dict
+        """
+        # Given
+        chart_settings = fake_chart_settings
+        fake_x_axis_tick_values = [0, 10]
+        fake_x_axis_tick_text = ["tick01", "tick02"]
+        fake_y_axis_tick_values = [0, 10]
+        fake_y_axis_tick_text = ["tick01", "tick02"]
+
+        # When
+        line_single_simplified_chart_config = (
+            chart_settings.get_line_single_simplified_chart_config(
+                x_axis_tick_values=fake_x_axis_tick_values,
+                x_axis_tick_text=fake_x_axis_tick_text,
+                y_axis_tick_values=fake_y_axis_tick_values,
+                y_axis_tick_text=fake_y_axis_tick_text,
+            )
+        )
+
+        # Then
+        expected_chart_config = chart_settings.get_base_chart_config()
+        # Chart settings
+        expected_chart_config["showlegend"] = False
+        expected_chart_config["margin"]["l"] = 25
+        expected_chart_config["margin"]["r"] = 25
+        expected_chart_config["margin"]["pad"] = 25
+
+        # x_axis settings
+        expected_chart_config["xaxis"]["tickvals"] = fake_x_axis_tick_values
+        expected_chart_config["xaxis"]["ticktext"] = fake_x_axis_tick_text
+        expected_chart_config["xaxis"]["ticklen"] = 0
+        expected_chart_config["xaxis"]["tickfont"][
+            "color"
+        ] = colour_scheme.RGBAColours.LS_DARK_GREY.stringified
+
+        # y_axis settings
+        expected_chart_config["yaxis"]["ticks"] = "outside"
+        expected_chart_config["yaxis"]["zeroline"] = False
+        expected_chart_config["yaxis"]["tickvals"] = fake_y_axis_tick_values
+        expected_chart_config["yaxis"]["ticktext"] = fake_y_axis_tick_text
+        expected_chart_config["yaxis"]["ticklen"] = 0
+        expected_chart_config["yaxis"]["tickfont"][
+            "color"
+        ] = colour_scheme.RGBAColours.LS_DARK_GREY.stringified
+
+        assert line_single_simplified_chart_config == expected_chart_config
+
     def test_get_bar_chart_config(self, fake_chart_settings: ChartSettings):
         """
         Given an instance of `ChartSettings`

--- a/tests/unit/metrics/domain/charts/test_utils.py
+++ b/tests/unit/metrics/domain/charts/test_utils.py
@@ -2,7 +2,7 @@ import pytest
 from unittest import mock
 from decimal import Decimal
 
-from metrics.domain.charts.line_single_simplified.utils import (
+from metrics.domain.charts.utils import (
     return_formatted_max_y_axis_value,
 )
 
@@ -10,9 +10,7 @@ MODULE_PATH = "metrics.domain.charts"
 
 
 class TestReturnFormattedMaxYAxisValue:
-    @mock.patch(
-        f"{MODULE_PATH}.line_single_simplified.utils.convert_large_numbers_to_short_text"
-    )
+    @mock.patch(f"{MODULE_PATH}.utils.convert_large_numbers_to_short_text")
     def test_return_formatted_max_y_axis_value_delegates_calls_correctly(
         self,
         spy_convert_large_numbers_to_short_text: mock.MagicMock,

--- a/tests/unit/metrics/domain/common/test_utils.py
+++ b/tests/unit/metrics/domain/common/test_utils.py
@@ -189,6 +189,7 @@ class TestChartTypes:
             "line_with_shaded_section",
             "bar",
             "line_multi_coloured",
+            "line_single_simplified",
         )
         assert choices == tuple((choice, choice) for choice in _choices)
 
@@ -262,6 +263,7 @@ class TestChartTypes:
             "line_with_shaded_section",
             "bar",
             "line_multi_coloured",
+            "line_single_simplified",
         ]
         assert values == expected_values
 

--- a/tests/unit/metrics/interfaces/charts/test_access.py
+++ b/tests/unit/metrics/interfaces/charts/test_access.py
@@ -154,6 +154,40 @@ class TestChartsInterface:
             == spy_generate_line_multi_coloured_chart_method.return_value
         )
 
+    @mock.patch.object(ChartsInterface, "build_chart_plots_data")
+    @mock.patch.object(ChartsInterface, "generate_line_single_simplified")
+    def test_generate_chart_figure_delegates_call_for_line_single_simplified_chart(
+        self,
+        spy_generate_line_single_simplified: mock.MagicMock,
+        mocked_build_chart_plots_data: mock.MagicMock,
+        fake_plots_collection: PlotsCollection,
+    ):
+        """
+        Given a requirement for a `line_single_simplified` chart
+        When `generate_chart_figure()` is called from an instance of the `ChartsInterface`
+        Then the call is delegated to the `generate_line_single_simplified_chart()` method
+        """
+        # Given
+        fake_plots_collection.plots[0].chart_type = (
+            ChartTypes.line_single_simplified.value
+        )
+        charts_interface = ChartsInterface(
+            chart_plots=fake_plots_collection,
+        )
+
+        # When
+        generated_chart_output = charts_interface.generate_chart_output()
+
+        # Then
+        spy_generate_line_single_simplified.assert_called_once_with(
+            plots_data=mocked_build_chart_plots_data.return_value
+        )
+        charts_output = ChartOutput(
+            figure=spy_generate_line_single_simplified.return_value,
+            description=charts_interface.build_chart_description(plots_data=[]),
+        )
+        assert generated_chart_output == charts_output
+
     @mock.patch.object(ChartsInterface, "_set_latest_date_from_plots_data")
     @mock.patch(f"{MODULE_PATH}.line_multi_coloured.generate_chart_figure")
     def test_generate_line_multi_coloured_chart(
@@ -273,6 +307,64 @@ class TestChartsInterface:
         assert (
             line_with_shaded_section_chart
             == spy_line_with_shaded_section_generate_chart_figure.return_value
+        )
+
+    @mock.patch.object(ChartsInterface, "_set_latest_date_from_plots_data")
+    @mock.patch(f"{MODULE_PATH}.line_single_simplified.generate_chart_figure")
+    def test_generate_line_single_simplified_chart(
+        self,
+        spy_line_single_simplified_generate_chart_figure: mock.MagicMock,
+        mocked_set_latest_date_from_plots_data: mock.MagicMock,
+        valid_plot_parameters: PlotParameters,
+    ):
+        """
+        Given a valid `PlotParameters` for a `line_single_simplified` chart
+        When `generate_line_single_simplified_chart()` is called
+        Then the call is delegated to the `generate_chart_figure()` from
+            the `line_single_simplified` module with the correct args
+
+        Patches:
+            `spy_line_with_shaded_section_generate_chart_figure`: For the
+                main assertion.
+        """
+        # Given
+        valid_plot_parameters.chart_type = ChartTypes.line_single_simplified.value
+        fake_core_time_series_collection = self._setup_fake_time_series_for_plot(
+            chart_plot_parameters=valid_plot_parameters
+        )
+        fake_core_time_series_manager = FakeCoreTimeSeriesManager(
+            fake_core_time_series_collection
+        )
+        plots_collection = PlotsCollection(
+            plots=[valid_plot_parameters],
+            file_format="svg",
+            chart_width=123,
+            chart_height=456,
+            x_axis="date",
+            y_axis="metric",
+        )
+
+        charts_interface = ChartsInterface(
+            chart_plots=plots_collection,
+            core_model_manager=fake_core_time_series_manager,
+        )
+        plots_data = charts_interface.build_chart_plots_data()
+
+        # When
+        line_single_simplified_chart = charts_interface.generate_line_single_simplified(
+            plots_data=plots_data
+        )
+
+        # Then
+        expected_params = charts_interface.param_builder_for_line_single_simplified(
+            plots_data=plots_data
+        )
+        spy_line_single_simplified_generate_chart_figure.assert_called_once_with(
+            **expected_params
+        )
+        assert (
+            line_single_simplified_chart
+            == spy_line_single_simplified_generate_chart_figure.return_value
         )
 
     @mock.patch.object(ChartsInterface, "_set_latest_date_from_plots_data")
@@ -419,6 +511,57 @@ class TestChartsInterface:
         spy_get_rolling_period_slice_for_metric.assert_called_once_with(
             metric_name=metric
         )
+
+    def test_param_builder_for_line_single_simplified(
+        self, fake_chart_plot_parameters: PlotParameters
+    ):
+        """
+        Given a `PlotsCollection` model representing the requested plot and its corresponding data
+        When `param_builder_for_line_single_simplified()` is called from an instance of the `ChartsInterface`
+        Then the returned dict contains the expected key-value pairs
+        """
+        # Given
+        chart_height = 200
+        chart_width = 400
+        mocked_x_axis_values = mock.Mock()
+        mocked_y_axis_values = mock.Mock()
+        fake_plot_data = PlotData(
+            parameters=fake_chart_plot_parameters,
+            x_axis_values=mocked_x_axis_values,
+            y_axis_values=mocked_y_axis_values,
+        )
+        fake_plot_data.parameters.chart_type = "line_single_simplified"
+
+        # When
+        fake_chart_plots = PlotsCollection(
+            plots=[fake_chart_plot_parameters],
+            file_format="svg",
+            chart_height=chart_height,
+            chart_width=chart_width,
+            x_axis="date",
+            y_axis="metric",
+        )
+
+        charts_interface = ChartsInterface(
+            chart_plots=fake_chart_plots,
+        )
+
+        params_for_line_single_simplified = (
+            charts_interface.param_builder_for_line_single_simplified(
+                plots_data=[fake_plot_data]
+            )
+        )
+
+        expected_params_reponse = {
+            "plot_data": [fake_plot_data],
+            "chart_height": chart_height,
+            "chart_width": chart_width,
+            "x_axis_values": mocked_x_axis_values,
+            "y_axis_values": mocked_y_axis_values,
+        }
+
+        # Then
+        assert params_for_line_single_simplified == expected_params_reponse
 
     def test_plots_interface_is_created_with_correct_args_by_default(
         self,

--- a/tests/unit/metrics/interfaces/charts/test_access.py
+++ b/tests/unit/metrics/interfaces/charts/test_access.py
@@ -556,8 +556,6 @@ class TestChartsInterface:
             "plot_data": [fake_plot_data],
             "chart_height": chart_height,
             "chart_width": chart_width,
-            "x_axis_values": mocked_x_axis_values,
-            "y_axis_values": mocked_y_axis_values,
         }
 
         # Then


### PR DESCRIPTION
# Description

This PR includes a new simplified `ChartType` for displaying `Timeseries` data. The chart provides a single line chart with 4 axis labels. The metric value (y-axis) for the top of the chart is rounded and displayed as a short string. Eg: 1400 = 1k


Fixes #CDD-2123

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [x] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
