### PR TITLE
Add tick padding to Y axis

### DIFF
--- a/metrics/domain/charts/chart_settings.py
+++ b/metrics/domain/charts/chart_settings.py
@@ -65,6 +65,9 @@ class ChartSettings:
 
     def get_y_axis_config(self) -> dict[str, bool | DICT_OF_STR_ONLY]:
         return {
+            "ticks": "outside",
+            "tickson": "boundaries",
+            "tickcolor": "rgba(0,0,0,0)",
             "showgrid": False,
             "showticklabels": True,
             "fixedrange": True,

--- a/tests/unit/metrics/domain/charts/test_chart_settings.py
+++ b/tests/unit/metrics/domain/charts/test_chart_settings.py
@@ -144,6 +144,9 @@ class TestChartSettings:
             "showticklabels": True,
             "fixedrange": True,
             "gridcolor": "#000",
+            "ticks": "outside",
+            "tickson": "boundaries",
+            "tickcolor": "rgba(0,0,0,0)",
             "tickfont": chart_settings.get_tick_font_config(),
         }
         assert y_axis_config == expected_y_axis_config


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds padding to the y-axis between the tick labels and the axis

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [x] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
