### PR TITLE
Register new wagtail hook to provide full URL as href to `<a>` tag for internal links

### DIFF
--- a/cms/dashboard/wagtail_hooks.py
+++ b/cms/dashboard/wagtail_hooks.py
@@ -5,10 +5,6 @@ from django.utils.safestring import SafeString
 from draftjs_exporter.dom import DOM
 from wagtail import hooks
 from wagtail.admin.menu import MenuItem
-from wagtail.admin.rich_text.converters.html_to_contentstate import (
-    ExternalLinkElementHandler,
-    PageLinkElementHandler,
-)
 from wagtail.admin.site_summary import PagesSummaryItem, SummaryItem
 from wagtail.models import Page
 from wagtail.whitelist import check_url
@@ -116,16 +112,10 @@ def _build_link_props(props: dict) -> dict[str, str | int]:
 
 @hooks.register("register_rich_text_features", order=1)
 def register_link_props(features):
+    rule = features.converter_rules_by_converter["contentstate"]["link"]
+    rule["to_database_format"]["entity_decorators"]["LINK"] = link_entity_with_href
     features.register_converter_rule(
         "contentstate",
         "link",
-        {
-            "from_database_format": {
-                "a[href]": ExternalLinkElementHandler("LINK"),
-                'a[linktype="page"]': PageLinkElementHandler("LINK"),
-            },
-            "to_database_format": {
-                "entity_decorators": {"LINK": link_entity_with_href}
-            },
-        },
+        rule
     )

--- a/cms/dashboard/wagtail_hooks.py
+++ b/cms/dashboard/wagtail_hooks.py
@@ -102,20 +102,24 @@ def _build_link_props(props: dict) -> dict[str, str | int]:
 
         # This is the added functionality
         # on top of the original Wagtail implementation
-        page = Page.objects.get(id=page_id).specific
-        link_props["href"] = page.full_url
+        page_url = _get_page_url(page_id=page_id)
+        link_props["href"] = page_url
     else:
         link_props["href"] = check_url(url_string=props.get("url"))
 
     return link_props
 
 
+def _get_page_url(page_id: int) -> str:
+    try:
+        page = Page.objects.get(id=page_id).specific
+    except Page.DoesNotExist:
+        return ""
+    return page.full_url
+
+
 @hooks.register("register_rich_text_features", order=1)
 def register_link_props(features):
     rule = features.converter_rules_by_converter["contentstate"]["link"]
     rule["to_database_format"]["entity_decorators"]["LINK"] = link_entity_with_href
-    features.register_converter_rule(
-        "contentstate",
-        "link",
-        rule
-    )
+    features.register_converter_rule("contentstate", "link", rule)

--- a/tests/unit/cms/dashboard/test_wagtail_hooks.py
+++ b/tests/unit/cms/dashboard/test_wagtail_hooks.py
@@ -1,11 +1,6 @@
 from unittest import mock
 
-import pytest
 from draftjs_exporter.dom import DOM
-from wagtail.admin.rich_text.converters.html_to_contentstate import (
-    ExternalLinkElementHandler,
-    PageLinkElementHandler,
-)
 from wagtail.admin.site_summary import SummaryItem
 from wagtail.models import Page
 
@@ -208,3 +203,23 @@ class TestBuildLinkProps:
         expected_props = {"href": url}
         assert link_props == expected_props
         spy_check_url.assert_called_once_with(url_string=url)
+
+    @mock.patch.object(Page, "objects")
+    def test_build_link_props_for_non_existent_page(
+        self, mocked_page_manager: mock.MagicMock
+    ):
+        """
+        Given a `Page` object which does not exist
+        When `_build_link_props()` is called
+        Then the returned props
+            contains an empty string for the URL
+        """
+        # Given
+        mocked_page_manager.get.side_effect = Page.DoesNotExist
+
+        # When
+        link_props = _build_link_props(props={"id": 123})
+
+        # Then the correct link properties are returned
+        expected_props = {"href": "", "id": 123, "linktype": "page"}
+        assert link_props == expected_props

--- a/tests/unit/cms/dashboard/test_wagtail_hooks.py
+++ b/tests/unit/cms/dashboard/test_wagtail_hooks.py
@@ -116,9 +116,7 @@ def test_register_link_props(spy_link_entity_with_href: mock.MagicMock):
     """
     # Given
     fake_rule = {"to_database_format": {"entity_decorators": {"LINK": {}}}}
-    fake_converter_rules = {
-        "contentstate": {"link": fake_rule}
-    }
+    fake_converter_rules = {"contentstate": {"link": fake_rule}}
     spy_features = mock.MagicMock()
     spy_features.converter_rules_by_converter = fake_converter_rules
 
@@ -126,7 +124,10 @@ def test_register_link_props(spy_link_entity_with_href: mock.MagicMock):
     wagtail_hooks.register_link_props(features=spy_features)
 
     # Then
-    assert fake_rule["to_database_format"]["entity_decorators"]["LINK"] == spy_link_entity_with_href
+    assert (
+        fake_rule["to_database_format"]["entity_decorators"]["LINK"]
+        == spy_link_entity_with_href
+    )
 
 
 class TestLinkEntityWithHref:

--- a/tests/unit/cms/dashboard/test_wagtail_hooks.py
+++ b/tests/unit/cms/dashboard/test_wagtail_hooks.py
@@ -115,18 +115,18 @@ def test_register_link_props(spy_link_entity_with_href: mock.MagicMock):
         via the `register_converter_rule()` call
     """
     # Given
-    spy_features = mock.Mock()
+    fake_rule = {"to_database_format": {"entity_decorators": {"LINK": {}}}}
+    fake_converter_rules = {
+        "contentstate": {"link": fake_rule}
+    }
+    spy_features = mock.MagicMock()
+    spy_features.converter_rules_by_converter = fake_converter_rules
 
     # When
     wagtail_hooks.register_link_props(features=spy_features)
 
     # Then
-    assert (
-        spy_features.mock_calls[0][1][2]["to_database_format"]["entity_decorators"][
-            "LINK"
-        ]
-        == spy_link_entity_with_href
-    )
+    assert fake_rule["to_database_format"]["entity_decorators"]["LINK"] == spy_link_entity_with_href
 
 
 class TestLinkEntityWithHref:


### PR DESCRIPTION
# Description

This PR includes the following:

- Sends a `href` for a tags associated with internal links

Fixes #CDD-2187

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
