### PR TITLE
Thread processing of v2 public API within cache crawler

### DIFF
--- a/tests/unit/caching/public_api/test_crawlers.py
+++ b/tests/unit/caching/public_api/test_crawlers.py
@@ -54,7 +54,7 @@ class TestPublicAPICrawler:
         # Given
         mocked_cdn_auth_key = mock.Mock()
         crawler = PublicAPICrawler(
-            public_api_base_url=mock.Mock(), cdn_auth_key=mocked_cdn_auth_key
+            public_api_base_url=FAKE_URL, cdn_auth_key=mocked_cdn_auth_key
         )
 
         # When
@@ -74,7 +74,7 @@ class TestPublicAPICrawler:
         # Given
         mocked_cdn_auth_key = mock.Mock()
         crawler = PublicAPICrawler(
-            public_api_base_url=mock.Mock(), cdn_auth_key=mocked_cdn_auth_key
+            public_api_base_url=FAKE_URL, cdn_auth_key=mocked_cdn_auth_key
         )
 
         # When
@@ -97,7 +97,7 @@ class TestPublicAPICrawler:
         # Given
         mocked_cdn_auth_key = mock.Mock()
         crawler = PublicAPICrawler(
-            public_api_base_url=mock.Mock(), cdn_auth_key=mocked_cdn_auth_key
+            public_api_base_url=FAKE_URL, cdn_auth_key=mocked_cdn_auth_key
         )
 
         # When


### PR DESCRIPTION
# Description

This PR includes the following:

- Processes the v2 public API endpoints within a seperate thread when crawling the public API endpoints. This is so that we don't wait for the v1 API to be processed completely first before moving onto the v2 API.
Due to the nature of the index, the first few paths will be the slowest (before being cached) so its important to cache them first as quick as possible

Fixes #CDD-2165

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [x] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
