### PR TITLE
Stop publishing to deprecated mutable-tag based ECRs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -176,32 +176,6 @@ jobs:
   # Build image
   ###############################################################################
 
-  publish-main-image-with-mutable-tag:
-    name: Publish main image with mutable tag to central ECR
-    needs: [
-      quality-checks,
-      unit-tests,
-      integration-tests,
-      system-tests,
-      migration-tests,
-      test-coverage,
-      dependency-checks,
-      vulnerability-checks,
-      architecture-checks
-    ]
-    runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Build and publish docker image
-        uses: ./.github/actions/publish-image
-        with:
-          ecr-repository: data-dashboard/api
-          role-to-assume: ${{ secrets.AWS_TOOLS_ACCOUNT_ROLE }}
-          architecture: arm64
-          image-tag: latest-graviton
-
   publish-main-image:
     name: Publish main image to central ECR
     needs: [
@@ -227,34 +201,6 @@ jobs:
           role-to-assume: ${{ secrets.AWS_TOOLS_ACCOUNT_ROLE }}
           architecture: arm64
           image-tag: ${{ github.sha }}
-
-  publish-ingestion-image-with-mutable-tag:
-    name: Publish ingestion image with mutable tag to central ECR
-    needs: [
-      quality-checks,
-      unit-tests,
-      integration-tests,
-      system-tests,
-      migration-tests,
-      test-coverage,
-      dependency-checks,
-      vulnerability-checks,
-      architecture-checks
-    ]
-    runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Build and publish docker image with mutable tag
-        uses: ./.github/actions/publish-image
-        with:
-          ecr-repository: data-dashboard/ingestion
-          role-to-assume: ${{ secrets.AWS_TOOLS_ACCOUNT_ROLE }}
-          dockerfile: Dockerfile-ingestion
-          architecture: arm64
-          image-tag: latest
 
   publish-ingestion-image:
     name: Publish ingestion image to central ECR


### PR DESCRIPTION
# Description

This PR includes the following:

- Stops publishing to deprecated mutable-tag based ECRs so that we can safely remove those ECRs

Fixes #CDD-1248

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
