### PR TITLE
CDD-2195: Use `plot_label` when provided for headline reference field

### DIFF
--- a/metrics/domain/tables/generation.py
+++ b/metrics/domain/tables/generation.py
@@ -14,6 +14,8 @@ IN_REPORTING_DELAY_PERIOD = "in_reporting_delay_period"
 PLOT_DATA_LOOKUP_TYPE = dict[datetime.date, Decimal]
 IN_REPORTING_DELAY_PERIOD_LOOKUP_TYPE = dict[datetime.date, bool]
 
+DEFAULT_PLOT_LABEL = "Plot"
+
 
 class TabularData:
     def __init__(self, *, plots: list[PlotData]):
@@ -110,7 +112,7 @@ class TabularData:
 
         """
         for index, plot in enumerate(self.plots, 1):
-            plot_label: str = plot.parameters.label or f"Plot{index}"
+            plot_label: str = plot.parameters.label or f"{DEFAULT_PLOT_LABEL}{index}"
             self.plot_labels.append(plot_label)
 
             plot_data: PLOT_DATA_LOOKUP_TYPE = self._build_plot_data_for_axes_values(
@@ -178,6 +180,11 @@ class TabularData:
     ) -> dict[str, str | list[dict]]:
         """Creates a row for tabular data output
 
+        Notes:
+            When creating a chart based on `CoreHeadline` data
+            if a `plot_label` is provided it should replace `left_column`
+            so that the label is returned in the `reference` field.
+
         Returns:
             A dictionary representing the tabular row returned
             Eg. {"reference": "Age", "values": [{"label": "Amount", "value": 53.00, IN_REPORTING_DELAY_PERIOD: False}]}
@@ -190,6 +197,11 @@ class TabularData:
             )
 
         if DataSourceFileType[self.metric_group].is_headline:
+            current_plot_label = next(iter(plot_values))
+
+            if DEFAULT_PLOT_LABEL not in current_plot_label:
+                row[self.column_heading] = current_plot_label
+
             row["values"].extend(
                 self.create_headline_plot_values(plot_values=plot_values)
             )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,6 +34,7 @@ def core_headline_example() -> CoreHeadline:
         metric_value=123.0000,
         metric=metric,
         geography=geography,
+        sex="f",
         refresh_date=refresh_date,
         period_start="2023-01-01",
         period_end="2023-01-07",


### PR DESCRIPTION
# Description

This PR includes an update to the tables endpoint for `Headline` data, when a label is provided for a plot this label is used to the populate the `reference` field in place of the `x_axis` value. This allows for more control over the presentation of tabular data for charts that use none date values.

Fixes #CDD-2195

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [x] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
