### PR TITLE
CDD-2219: Add `TREND_LINE_NONE` to simplified chart colours

### DIFF
--- a/metrics/domain/charts/colour_scheme.py
+++ b/metrics/domain/charts/colour_scheme.py
@@ -21,6 +21,7 @@ class RGBAChartLineColours(Enum):
     TREND_LINE_POSITIVE = 0, 112, 60
     TREND_LINE_NEGATIVE = 171, 43, 23
     TREND_LINE_NEUTRAL = 56, 63, 67
+    TREND_LINE_NONE = 17, 67, 110
 
     # Legacy colors
     RED: RGBA_VALUES = 212, 53, 28
@@ -80,6 +81,7 @@ class RGBAChartLineColours(Enum):
             cls.TREND_LINE_NEGATIVE,
             cls.TREND_LINE_POSITIVE,
             cls.TREND_LINE_NEUTRAL,
+            cls.TREND_LINE_NONE,
         ]
         return tuple(
             (


### PR DESCRIPTION
# Description

This PR includes an update to the charts colour scheme to include a `none` trend line colour for charts that don't have trend data.

Fixes #CDD-2219

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [x] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
