### PR TITLE
Task/cdd 2220 update alt text for tend line none

### DIFF
--- a/metrics/domain/models/plots_text.py
+++ b/metrics/domain/models/plots_text.py
@@ -347,6 +347,8 @@ class PlotsText:
                 return "positive"
             case RGBAChartLineColours.TREND_LINE_NEUTRAL.name:
                 return "neutral"
+            case _:
+                return "none"
 
     def _describe_plot_type(self, *, plot_parameters: PlotParameters) -> str:
         line_type: str = self._get_line_type_or_default(plot_parameters=plot_parameters)
@@ -357,7 +359,12 @@ class PlotsText:
 
         if self._plot_is_simplified_chart(plot_parameters=plot_parameters):
             trend_type: str = self._get_trend_direction(plot_parameters=plot_parameters)
-            return f"This is a {line_type} {plot_type} chart, showing a {trend_type} trend in the data. "
+            plot_description = f"This is a {line_type} {plot_type} chart, "
+
+            if trend_type != "none":
+                plot_description += f"showing a {trend_type} trend in the data. "
+
+            return plot_description
 
         return f"This is a {line_colour} {line_type} {plot_type} plot. "
 

--- a/tests/unit/metrics/domain/models/test_plots_text.py
+++ b/tests/unit/metrics/domain/models/test_plots_text.py
@@ -150,6 +150,27 @@ class TestPlotsText:
         )
         assert expected_text_about_parameters in text
 
+    def test_returns_no_trend_type_when_line_colour_is_trend_line_none(
+        self,
+        fake_plot_data: PlotData,
+    ):
+        """
+        Given a valid plot where the `line_colour` that is not a `TREND_LINE` colour
+        When the `construct_text()` method is called
+        Then no trend type is returned in the response.
+        """
+        fake_plot_data.parameters.line_colour = "COLOUR_1_DARK_BLUE"
+        fake_plot_data.parameters.line_type = "SOLID"
+        fake_plot_data.parameters.chart_type = ChartTypes.line_single_simplified.value
+        plots_text = PlotsText(plots_data=[fake_plot_data])
+
+        # When
+        text: str = plots_text.construct_text()
+
+        # Then
+        expected_text_about_parameters = f"This is a solid line chart,"
+        assert expected_text_about_parameters in text
+
     def test_returns_correct_text_about_parameters_for_multiple_plots(
         self, fake_plot_data: PlotData
     ):


### PR DESCRIPTION
# Description

This PR includes an update to `plots_text` for when the simplified chart colour is `TREND_LINE_NONE`

Fixes #CDD-2220

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
