### PR TITLE
CDD-2221: Remove trend number from simplified chart card

### DIFF
--- a/cms/dynamic_content/blocks.py
+++ b/cms/dynamic_content/blocks.py
@@ -13,13 +13,6 @@ MINIMUM_ROWS_NUMBER_BLOCK_COUNT: int = 1
 MAXIMUM_ROWS_NUMBER_BLOCK_COUNT: int = 2
 
 
-class TrendNumberBlockType(blocks.StreamBlock):
-    trend_number = TrendNumberComponent(help_text=help_texts.TREND_BLOCK_FIELD)
-
-    class Meta:
-        icon = "trend_down"
-
-
 class HeadlineNumberBlockTypes(blocks.StreamBlock):
     headline_number = HeadlineNumberComponent(help_text=help_texts.HEADLINE_BLOCK_FIELD)
     trend_number = TrendNumberComponent(help_text=help_texts.TREND_BLOCK_FIELD)

--- a/cms/dynamic_content/cards.py
+++ b/cms/dynamic_content/cards.py
@@ -5,7 +5,6 @@ from cms.dynamic_content import help_texts
 from cms.dynamic_content.blocks import (
     HeadlineNumberBlockTypes,
     MetricNumberBlock,
-    TrendNumberBlockType,
 )
 from cms.dynamic_content.components import (
     ChartComponent,
@@ -85,7 +84,7 @@ class ChartWithHeadlineAndTrendCard(blocks.StructBlock):
         icon = "chart_with_headline_and_trend_card"
 
 
-class TropicTrendChartAndLink(blocks.StructBlock):
+class SimplifiedChartWithLink(blocks.StructBlock):
     title = blocks.TextBlock(required=True, help_text=help_texts.TITLE_FIELD)
     body = blocks.TextBlock(required=False, help_text=help_texts.OPTIONAL_BODY_FIELD)
     tag_manager_event_id = blocks.CharBlock(
@@ -116,14 +115,9 @@ class TropicTrendChartAndLink(blocks.StructBlock):
         required=True,
         max_num=MAXIMUM_TOPIC_TREND_CARD_CHARTS,
     )
-    trend_number = TrendNumberBlockType(
-        required=True,
-        max_num=MAXIMUM_TREND_NUMBER,
-        help_text=help_texts.TREND_BLOCK_FIELD,
-    )
 
     class Meta:
-        icon = "chart_with_headline_and_trend_card"
+        icon = "standalone_chart"
 
 
 class ChartCard(blocks.StructBlock):
@@ -166,7 +160,7 @@ class ChartRowBlockTypes(blocks.StreamBlock):
     chart_card = ChartCard()
     headline_chart_card = HeadlineChartCard()
     chart_with_headline_and_trend_card = ChartWithHeadlineAndTrendCard()
-    topic_trend_chart_and_link = TropicTrendChartAndLink()
+    simplified_chart_with_link = SimplifiedChartWithLink()
 
 
 class ChartRowCard(blocks.StructBlock):


### PR DESCRIPTION
# Description

This PR includes includes an update to remove the `trend_number` component from the simplified chart card.


Fixes #CDD-2221

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
