### PR TITLE
DO NOT MERGE: Validate `epiweek` is relevant for given `date` before data ingestion

### DIFF
--- a/ingestion/data_transfer_models/time_series.py
+++ b/ingestion/data_transfer_models/time_series.py
@@ -1,6 +1,6 @@
 import datetime
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, model_validator
 from pydantic.fields import Field
 
 from ingestion.data_transfer_models import validation
@@ -36,6 +36,22 @@ class InboundTimeSeriesSpecificFields(BaseModel):
 
         """
         return validation.cast_date_to_uk_timezone(date_value=embargo)
+
+    @model_validator(mode="after")
+    def validate_epiweek_is_correct_for_date(self) -> int:
+        """Validates the epiweek against the date
+
+        Returns:
+            The model instance having verified the epiweek
+
+        Raises:
+            `ValidationError`: If the epiweek is not
+                appropriate for the given date.
+
+        """
+        validation.validate_epiweek(input_epiweek=self.epiweek, input_date=self.date)
+
+        return self
 
 
 class TimeSeriesDTO(IncomingBaseDataModel):

--- a/ingestion/data_transfer_models/validation/__init__.py
+++ b/ingestion/data_transfer_models/validation/__init__.py
@@ -8,3 +8,4 @@ from .child_theme import validate_child_theme
 from .topic import validate_topic
 from .in_reporting_delay_period import validate_in_reporting_delay_period
 from .deprecated_geographies import validate_deprecated_geographies
+from .epiweek import validate_epiweek

--- a/ingestion/data_transfer_models/validation/epiweek.py
+++ b/ingestion/data_transfer_models/validation/epiweek.py
@@ -1,0 +1,26 @@
+import datetime
+
+import epiweeks
+
+
+def validate_epiweek(*, input_epiweek: int, input_date: datetime.date) -> int:
+    """Checks to see if the given `input_epiweek` is valid for the `input_date`
+
+    Args:
+        `input_epiweek`: The epiweek number
+        `input_date`: The associated date of the record
+
+    Returns:
+        The validated epiweek number
+
+    Raises:
+        `ValueError`: If the given date was not calculated
+            as being within the given epiweek
+
+    """
+    week = epiweeks.Week.fromdate(date_object=input_date, system="iso")
+    if week.week == input_epiweek:
+        return input_epiweek
+
+    error_message = f"Input epiweek of `{input_epiweek}` is not valid to calculated no. of `{week.week}`"
+    raise ValueError(error_message)

--- a/requirements-prod-ingestion.txt
+++ b/requirements-prod-ingestion.txt
@@ -2,6 +2,7 @@ asgiref==3.8.1
 boto3==1.34.68
 botocore==1.34.109
 Django==5.1.1
+epiweeks==2.3.0
 psycopg2-binary==2.9.9
 pydantic==2.9.2
 python-dotenv==1.0.1

--- a/tests/unit/ingestion/data_transfer_models/time_series/test_epiweek.py
+++ b/tests/unit/ingestion/data_transfer_models/time_series/test_epiweek.py
@@ -6,23 +6,39 @@ from ingestion.data_transfer_models.time_series import InboundTimeSeriesSpecific
 
 class TestInboundTimeSeriesSpecificFieldsForEpiWeek:
     @property
-    def payload_without_epiweek(self) -> dict[str, str | int | None]:
+    def payload_without_epiweek_or_date(self) -> dict[str, int | None]:
         return {
-            "date": "2023-11-01",
             "embargo": None,
             "metric_value": 123,
         }
 
-    @pytest.mark.parametrize("epiweek", list(range(1, 53 + 1)))
-    def test_epiweek_between_1_and_53_is_valid(self, epiweek: int):
+    @pytest.mark.parametrize(
+        "input_epiweek, input_date",
+        (
+            [44, "2022-11-01"],
+            [45, "2022-11-09"],
+            [46, "2022-11-18"],
+            [46, "2022-11-20"],
+            [49, "2022-12-09"],
+            [50, "2022-12-14"],
+            [52, "2022-12-31"],
+            [52, "2023-01-01"],
+            [1, "2023-01-02"],
+            [2, "2023-01-09"],
+        ),
+    )
+    def test_epiweek_between_1_and_53_is_valid(
+        self, input_epiweek: int, input_date: str
+    ):
         """
         Given an epiweek between 1 and 53
         When the `InboundTimeSeriesSpecificFields` is initialized
         Then the model is deemed valid
         """
         # Given
-        payload = self.payload_without_epiweek
-        payload["epiweek"] = epiweek
+        payload = self.payload_without_epiweek_or_date
+        payload["epiweek"] = input_epiweek
+        payload["date"] = input_date
 
         # When
         time_series_model = InboundTimeSeriesSpecificFields(**payload)
@@ -38,8 +54,9 @@ class TestInboundTimeSeriesSpecificFieldsForEpiWeek:
         Then a `ValidationError` is raised
         """
         # Given
-        payload = self.payload_without_epiweek
+        payload = self.payload_without_epiweek_or_date
         payload["epiweek"] = epiweek
+        payload["date"] = "2023-12-31"
 
         # When / Then
         with pytest.raises(ValidationError):
@@ -52,8 +69,9 @@ class TestInboundTimeSeriesSpecificFieldsForEpiWeek:
         Then a `ValidationError` is raised
         """
         # Given
-        payload = self.payload_without_epiweek
+        payload = self.payload_without_epiweek_or_date
         payload["epiweek"] = 0
+        payload["date"] = "2024-01-01"
 
         # When / Then
         with pytest.raises(ValidationError):

--- a/tests/unit/ingestion/data_transfer_models/time_series/test_time_series.py
+++ b/tests/unit/ingestion/data_transfer_models/time_series/test_time_series.py
@@ -19,7 +19,7 @@ class TestInboundTimeSeriesSpecificFields:
         Then model is deemed valid
         """
         # Given
-        fake_epiweek = 46
+        fake_epiweek = 44
         fake_date = "2023-11-01"
         fake_embargo = VALID_DATETIME
         fake_metric_value = 123
@@ -50,7 +50,7 @@ class TestInboundTimeSeriesSpecificFields:
         Then model is deemed valid
         """
         # Given
-        fake_epiweek = 46
+        fake_epiweek = 44
         fake_date = "2023-11-01"
         fake_embargo = None
         fake_metric_value = 123
@@ -121,7 +121,7 @@ class TestInboundTimeSeriesSpecificFields:
         """
         # Given
         fake_date = "2023-11-20"
-        fake_epiweek = 46
+        fake_epiweek = 47
         fake_embargo = "2023-11-30"
 
         # When

--- a/tests/unit/ingestion/data_transfer_models/validation/test_epiweek.py
+++ b/tests/unit/ingestion/data_transfer_models/validation/test_epiweek.py
@@ -1,0 +1,40 @@
+import datetime
+
+import pytest
+
+from ingestion.data_transfer_models.validation.epiweek import validate_epiweek
+
+
+class TestValidateEpiweek:
+    @pytest.mark.parametrize(
+        "input_epiweek, input_date",
+        (
+            [44, "2022-11-01"],
+            [45, "2022-11-09"],
+            [46, "2022-11-18"],
+            [46, "2022-11-20"],
+            [49, "2022-12-09"],
+            [50, "2022-12-14"],
+            [52, "2022-12-31"],
+            [52, "2023-01-01"],
+            [1, "2023-01-02"],
+            [2, "2023-01-09"],
+        ),
+    )
+    def test_validates_successfully(self, input_epiweek: int, input_date: str):
+        """
+        Given a valid pairing of epiweek and date
+        When `validate_epiweek()` is called
+        Then no error is raised
+        """
+        # Given
+        epiweek = input_epiweek
+        provided_date = datetime.datetime.strptime(input_date, "%Y-%m-%d").date()
+
+        # When
+        validated_epiweek = validate_epiweek(
+            input_epiweek=epiweek, input_date=provided_date
+        )
+
+        # Then
+        assert validated_epiweek == input_epiweek

--- a/tests/unit/ingestion/data_transfer_models/validation/test_epiweek.py
+++ b/tests/unit/ingestion/data_transfer_models/validation/test_epiweek.py
@@ -38,3 +38,32 @@ class TestValidateEpiweek:
 
         # Then
         assert validated_epiweek == input_epiweek
+
+    @pytest.mark.parametrize(
+        "input_epiweek, input_date",
+        (
+            [1, "2022-11-01"],
+            [2, "2022-11-09"],
+            [3, "2022-11-18"],
+            [4, "2022-11-20"],
+            [5, "2022-12-09"],
+            [6, "2022-12-14"],
+            [7, "2022-12-31"],
+            [9, "2023-01-01"],
+            [9, "2023-01-02"],
+            [10, "2023-01-09"],
+        ),
+    )
+    def test_raises_error_for_invalid_date(self, input_epiweek: int, input_date: str):
+        """
+        Given an invalid pairing of epiweek and date
+        When `validate_epiweek()` is called
+        Then a `ValueError` is raised
+        """
+        # Given
+        epiweek = input_epiweek
+        provided_date = datetime.datetime.strptime(input_date, "%Y-%m-%d").date()
+
+        # When / Then
+        with pytest.raises(ValueError):
+            validate_epiweek(input_epiweek=epiweek, input_date=provided_date)


### PR DESCRIPTION
# Description

This PR includes the following:

- Validates the epiweek corresponds to the date for timeseries data with the epiweeks package using the ISO system

Fixes #CDD-1944

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
