### PR TITLE
Set up handlers to build and send email against the form fields on th…

### DIFF
--- a/feedback/email_server.py
+++ b/feedback/email_server.py
@@ -3,7 +3,7 @@ import logging
 from django.core.mail import EmailMessage
 
 import config
-from feedback.email_template import build_body_for_email
+from feedback.email_template import build_body_for_email, build_body_for_email_v2
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +45,40 @@ def send_email(
     return bool(email.send(fail_silently=fail_silently))
 
 
+def send_email_v2(
+    *,
+    suggestions: dict[str, str],
+    subject: str = DEFAULT_FEEDBACK_EMAIL_SUBJECT,
+    recipient_email_address: str = DEFAULT_FEEDBACK_EMAIL_RECIPIENT_ADDRESS,
+    fail_silently: bool = True,
+) -> bool:
+    """Sends a feedback email to the `recipient_email_address`
+
+    Args:
+        suggestions: Dict of feedback suggestions from the user
+            E.g. {"question": "some question", "answer": "some answer"}
+        subject: The subject line to set on the email message
+            Defaults to "Suggestions Feedback for UKHSA data dashboard"
+        recipient_email_address: The recipient to send the email to
+            Defaults to the environment variable
+                `FEEDBACK_EMAIL_RECIPIENT_ADDRESS`
+        fail_silently: Switch to raise an exception
+            if the email failed and was not successfully sent.
+            Defaults to True
+
+    Returns:
+        A boolean to describe whether the email has been sent successfully
+
+    """
+    email = create_email_message_v2(
+        suggestions=suggestions,
+        subject=subject,
+        recipient_email_address=recipient_email_address,
+    )
+
+    return bool(email.send(fail_silently=fail_silently))
+
+
 def create_email_message(
     *,
     suggestions: dict[str, str],
@@ -70,6 +104,39 @@ def create_email_message(
 
     """
     body: str = build_body_for_email(suggestions=suggestions)
+
+    return EmailMessage(
+        subject=subject,
+        body=body,
+        to=[recipient_email_address],
+    )
+
+
+def create_email_message_v2(
+    *,
+    suggestions: dict[str, str],
+    subject: str = DEFAULT_FEEDBACK_EMAIL_SUBJECT,
+    recipient_email_address: str = DEFAULT_FEEDBACK_EMAIL_RECIPIENT_ADDRESS,
+) -> EmailMessage:
+    """Creates an `EmailMessage` object for a feedback email
+
+    Notes:
+        This returns an `EmailMessage` object which **has not been sent**
+
+    Args:
+        suggestions: Dict of feedback suggestions from the user
+            E.g. {"question": "some question", "answer": "some answer"}
+        subject: The subject line to set on the email message
+            Defaults to "Suggestions Feedback for UKHSA data dashboard"
+        recipient_email_address: The recipient to send the email to
+            Defaults to the environment variable
+                `FEEDBACK_EMAIL_RECIPIENT_ADDRESS`
+    Returns:
+        An `EmailMessage` object with the subject, body and recipient
+        set on the object
+
+    """
+    body: str = build_body_for_email_v2(suggestions=suggestions)
 
     return EmailMessage(
         subject=subject,

--- a/feedback/email_template.py
+++ b/feedback/email_template.py
@@ -1,6 +1,11 @@
 from enum import Enum
 
+from django.db.models import Manager
+
+from cms.forms.models import FormPage
+
 FALLBACK_DID_YOU_FIND_EVERYTHING_ANSWER: str = "User provided no input"
+DEFAULT_FORM_PAGE_MANAGER = FormPage.objects
 
 
 def build_body_for_email(*, suggestions: dict[str, str]) -> str:
@@ -18,6 +23,25 @@ def build_body_for_email(*, suggestions: dict[str, str]) -> str:
     """
     enriched_suggestions: dict[str, str] = _enrich_suggestions_with_long_form_questions(
         suggestions=suggestions
+    )
+    return _build_body_from_suggestions(suggestions=enriched_suggestions)
+
+
+def build_body_for_email_v2(*, suggestions: dict[str, str]) -> str:
+    """Builds the suggestions email body as a string to be sent to the email server
+
+    Args:
+        suggestions: A dict containing:
+            keys - Shortform questions
+            values - Answers provided by the user
+
+    Returns:
+        A continuous string which represents
+        the body of the feedback email
+
+    """
+    enriched_suggestions: dict[str, str] = (
+        _enrich_suggestions_with_long_form_questions_v2(suggestions=suggestions)
     )
     return _build_body_from_suggestions(suggestions=enriched_suggestions)
 
@@ -71,6 +95,32 @@ def _enrich_suggestions_with_long_form_questions(
     )
 
     return long_form_suggestions
+
+
+def _enrich_suggestions_with_long_form_questions_v2(
+    *,
+    suggestions: dict[str, str],
+    form_page_manager: Manager = DEFAULT_FORM_PAGE_MANAGER,
+) -> dict[str, str]:
+    """Enriches the question keys in the given `suggestions` with the long form versions
+
+    Examples:
+        `suggestions` is provided with the following key value pair:
+            `"reason": "some answer"`
+            Then the return key value pair would be:
+            `"What was your reason for visiting the dashboard today?": "some answer"`
+
+    Args:
+        suggestions: Dict of feedback suggestions from the user
+
+    Returns:
+        A dict of feedback suggestions with longform questions as the keys
+        and answers for the values.
+
+    """
+    form_fields = form_page_manager.get_feedback_page_form_fields()
+
+    return {field.label: suggestions.get(field.clean_name) for field in form_fields}
 
 
 def _build_body_from_suggestions(*, suggestions: dict[str, str]) -> str:

--- a/feedback/email_template.py
+++ b/feedback/email_template.py
@@ -2,10 +2,10 @@ from enum import Enum
 
 from django.db.models import Manager
 
-from cms.forms.models import FormPage
+from feedback.cms_interface import CMSInterface
 
 FALLBACK_DID_YOU_FIND_EVERYTHING_ANSWER: str = "User provided no input"
-DEFAULT_FORM_PAGE_MANAGER = FormPage.objects
+DEFAULT_FORM_PAGE_MANAGER = CMSInterface().get_form_page_manager()
 
 
 def build_body_for_email(*, suggestions: dict[str, str]) -> str:

--- a/tests/unit/feedback/test_email_server.py
+++ b/tests/unit/feedback/test_email_server.py
@@ -6,6 +6,8 @@ from feedback.email_server import (
     DEFAULT_FEEDBACK_EMAIL_SUBJECT,
     create_email_message,
     send_email,
+    create_email_message_v2,
+    send_email_v2,
 )
 
 MODULE_PATH = "feedback.email_server"
@@ -123,6 +125,130 @@ class TestCreateEmailMessage:
         assert self.fake_recipient_email_address in email_message.recipients()
 
 
+class TestCreateEmailMessageV2:
+    fake_recipient_email_address = "not.real@test.com"
+
+    @mock.patch(f"{MODULE_PATH}.build_body_for_email_v2")
+    def test_returns_email_message(
+        self, mocked_build_body_for_email_v2: mock.MagicMock
+    ):
+        """
+        Given a suggestions dict and a recipient email address
+        When `create_email_message()` is called
+        Then an instance of `EmailMessage` is returned
+        """
+        # Given
+        mocked_suggestions = mock.MagicMock()
+        fake_subject = "Test subject"
+
+        # When
+        email_message: EmailMessage = create_email_message_v2(
+            suggestions=mocked_suggestions,
+            subject=fake_subject,
+            recipient_email_address=self.fake_recipient_email_address,
+        )
+
+        # Then
+        assert type(email_message) is EmailMessage
+
+    @mock.patch(f"{MODULE_PATH}.build_body_for_email_v2")
+    def test_sets_correct_body_on_email_message(
+        self, spy_build_body_for_email: mock.MagicMock
+    ):
+        """
+        Given a suggestions dict and a recipient email address
+        When `create_email_message()` is called
+        The body is set by delegating a call to `build_body_for_email()`
+
+        Patches:
+            `spy_build_body_for_email`: For the main assertion.
+                To check this is used for the `body`
+                of the created `EmailMessage`
+        """
+        # Given
+        mocked_suggestions = mock.Mock()
+        fake_subject = "Test subject"
+
+        # When
+        email_message: EmailMessage = create_email_message_v2(
+            suggestions=mocked_suggestions,
+            subject=fake_subject,
+            recipient_email_address=self.fake_recipient_email_address,
+        )
+
+        # Then
+        spy_build_body_for_email.assert_called_once_with(suggestions=mocked_suggestions)
+        assert email_message.body == spy_build_body_for_email.return_value
+
+    @mock.patch(f"{MODULE_PATH}.build_body_for_email_v2")
+    def test_sets_default_subject_on_email_message_when_not_provided(
+        self, mocked_build_body_for_email_v2: mock.MagicMock
+    ):
+        """
+        Given a suggestions dict and a recipient email address
+        When `create_email_message()` is called
+        Then the default subject line is set on the email message
+        """
+        # Given
+        mocked_suggestions = mock.MagicMock()
+
+        # When
+        email_message: EmailMessage = create_email_message_v2(
+            suggestions=mocked_suggestions,
+            recipient_email_address=self.fake_recipient_email_address,
+        )
+
+        # Then
+        assert email_message.subject == DEFAULT_FEEDBACK_EMAIL_SUBJECT
+
+    @mock.patch(f"{MODULE_PATH}.build_body_for_email_v2")
+    def test_sets_specified_subject_on_email_message_when_provided(
+        self, mocked_build_body_for_email_v2: mock.MagicMock
+    ):
+        """
+        Given a suggestions dict and a recipient email address
+        And a specified non-default subject line
+        When `create_email_message()` is called
+        Then the specified subject line is set on the email message
+        """
+        # Given
+        mocked_suggestions = mock.MagicMock()
+        fake_non_default_subject = "Specified example subject"
+
+        # When
+        email_message: EmailMessage = create_email_message_v2(
+            suggestions=mocked_suggestions,
+            recipient_email_address=self.fake_recipient_email_address,
+            subject=fake_non_default_subject,
+        )
+
+        # Then
+        assert email_message.subject == fake_non_default_subject
+
+    @mock.patch(f"{MODULE_PATH}.build_body_for_email_v2")
+    def test_sets_specified_recipient_on_email_message_when_provided(
+        self, mocked_build_body_for_email_v2: mock.MagicMock
+    ):
+        """
+        Given a suggestions dict and a specified recipient email address
+        When `create_email_message()` is called
+        Then the specified recipient is set on the recipients of the email message
+        """
+        # Given
+        mocked_suggestions = mock.MagicMock()
+        fake_non_default_subject = "Specified example subject"
+
+        # When
+        email_message: EmailMessage = create_email_message_v2(
+            suggestions=mocked_suggestions,
+            recipient_email_address=self.fake_recipient_email_address,
+            subject=fake_non_default_subject,
+        )
+
+        # Then
+        assert self.fake_recipient_email_address in email_message.recipients()
+
+
 class TestSendEmail:
     @mock.patch(f"{MODULE_PATH}.create_email_message")
     def test_delegates_call_to_create_email_message(
@@ -179,6 +305,73 @@ class TestSendEmail:
 
         # When
         send_email(
+            suggestions=mocked_suggestions,
+            recipient_email_address=mocked_recipient_email_address,
+            subject=mocked_subject,
+            fail_silently=fail_silently,
+        )
+
+        # Then
+        email_message = spy_create_email_message.return_value
+        email_message.send.assert_called_once_with(fail_silently=fail_silently)
+
+
+class TestSendEmailV2:
+    @mock.patch(f"{MODULE_PATH}.create_email_message_v2")
+    def test_delegates_call_to_create_email_message(
+        self, spy_create_email_message: mock.MagicMock
+    ):
+        """
+        Given a suggestions dict, a recipient email address and a subject line
+        When `send_email()` is called
+        Then the call is delegated to `create_email_message()`
+
+        Patches:
+            `spy_create_email_message`: For the main assertion.
+                To check the email message object is initialized
+                with the correct arguments
+        """
+        # Given
+        mocked_suggestions = mock.Mock()
+        mocked_recipient_email_address = mock.Mock()
+        mocked_subject = mock.Mock()
+
+        # When
+        send_email_v2(
+            suggestions=mocked_suggestions,
+            recipient_email_address=mocked_recipient_email_address,
+            subject=mocked_subject,
+        )
+
+        # Then
+        spy_create_email_message.assert_called_once_with(
+            suggestions=mocked_suggestions,
+            subject=mocked_subject,
+            recipient_email_address=mocked_recipient_email_address,
+        )
+
+    @mock.patch(f"{MODULE_PATH}.create_email_message_v2")
+    def test_calls_send_on_email_message(
+        self, spy_create_email_message: mock.MagicMock
+    ):
+        """
+        Given a suggestions dict, a recipient email address and a subject line
+        When `send_email()` is called
+        Then the `send()` is called from the returned `EmailMessage`
+
+        Patches:
+            `spy_create_email_message`: To capture and spy on
+                the returned `EmailMessage`.
+                And to check `send()` is called from the `EmailMessage`
+        """
+        # Given
+        mocked_suggestions = mock.Mock()
+        mocked_recipient_email_address = mock.Mock()
+        mocked_subject = mock.Mock()
+        fail_silently = True
+
+        # When
+        send_email_v2(
             suggestions=mocked_suggestions,
             recipient_email_address=mocked_recipient_email_address,
             subject=mocked_subject,

--- a/tests/unit/feedback/test_email_template.py
+++ b/tests/unit/feedback/test_email_template.py
@@ -2,12 +2,15 @@ from unittest import mock
 
 import pytest
 
+from cms.forms.models import FormField
 from feedback.email_template import (
     FALLBACK_DID_YOU_FIND_EVERYTHING_ANSWER,
     FeedbackQuestion,
     _build_body_from_suggestions,
     _enrich_suggestions_with_long_form_questions,
     build_body_for_email,
+    build_body_for_email_v2,
+    _enrich_suggestions_with_long_form_questions_v2,
 )
 
 REASON_ANSWER = "I wanted to understand infection rates of Disease X in my local area"
@@ -17,10 +20,41 @@ IMPROVE_EXPERIENCE_ANSWER = (
 LIKE_TO_SEE_ANSWER = (
     "It would be good to see more localised/regional data on the dashboard"
 )
-DID_YOU_FIND_EVERYTHING_ANSWER = "no"
+DID_YOU_FIND_EVERYTHING_ANSWER = "No"
 
 
 MODULE_PATH = "feedback.email_template"
+
+
+@pytest.fixture
+def example_feedback_form_fields() -> list[FormField]:
+    return [
+        FormField(
+            clean_name="how_could_we_improve_your_experience_with_the_dashboard",
+            label="How could we improve your experience with the dashboard?",
+            field_type="multiline",
+            required=False,
+        ),
+        FormField(
+            clean_name="what_would_you_like_to_see_on_the_dashboard_in_the_future",
+            label="What would you like to see on the dashboard in the future?",
+            field_type="multiline",
+            required=False,
+        ),
+        FormField(
+            clean_name="did_you_find_everything_you_were_looking_for",
+            label="Did you find everything you were looking for?",
+            field_type="radio",
+            required=False,
+            choices="Yes\r\nNo",
+        ),
+        FormField(
+            clean_name="what_was_your_reason_for_visiting_the_dashboard_today",
+            label="What was your reason for visiting the dashboard today?",
+            field_type="multiline",
+            required=False,
+        ),
+    ]
 
 
 class TestFeedbackQuestion:
@@ -144,6 +178,69 @@ class TestEnrichSuggestionsWithLongFormQuestions:
         )
 
 
+class TestEnrichSuggestionsWithLongFormQuestionsV2:
+    @staticmethod
+    def _build_base_suggestions() -> dict[str, str]:
+        return {
+            FeedbackQuestion.reason.name: "N/A",
+            FeedbackQuestion.improve_experience.name: "N/A",
+            FeedbackQuestion.like_to_see.name: "N/A",
+            FeedbackQuestion.did_you_find_everything.name: "no",
+        }
+
+    @pytest.mark.parametrize(
+        "question, answer",
+        (
+            [
+                FeedbackQuestion.reason,
+                REASON_ANSWER,
+            ],
+            [
+                FeedbackQuestion.improve_experience,
+                IMPROVE_EXPERIENCE_ANSWER,
+            ],
+            [
+                FeedbackQuestion.like_to_see,
+                LIKE_TO_SEE_ANSWER,
+            ],
+            [FeedbackQuestion.did_you_find_everything, DID_YOU_FIND_EVERYTHING_ANSWER],
+        ),
+    )
+    def test_returns_correct_dict(
+        self,
+        question: FeedbackQuestion,
+        answer: str,
+        example_feedback_form_fields: list[FormField],
+    ):
+        """
+        Given a `suggestions` dict
+        When `_enrich_suggestions_with_long_form_questions()` is called
+        Then a dict is returned with longform questions as the keys
+        """
+        # Given
+        suggestions = {
+            "how_could_we_improve_your_experience_with_the_dashboard": IMPROVE_EXPERIENCE_ANSWER,
+            "what_would_you_like_to_see_on_the_dashboard_in_the_future": LIKE_TO_SEE_ANSWER,
+            "did_you_find_everything_you_were_looking_for": DID_YOU_FIND_EVERYTHING_ANSWER,
+            "what_was_your_reason_for_visiting_the_dashboard_today": REASON_ANSWER,
+        }
+        mocked_form_page_manager = mock.Mock()
+        mocked_form_page_manager.get_feedback_page_form_fields.return_value = (
+            example_feedback_form_fields
+        )
+
+        # When
+        enriched_suggestions: dict[str, str] = (
+            _enrich_suggestions_with_long_form_questions_v2(
+                suggestions=suggestions,
+                form_page_manager=mocked_form_page_manager,
+            )
+        )
+
+        # Then
+        assert enriched_suggestions[question.value] == answer
+
+
 class TestBuildBodyFromSuggestions:
     def test_returns_expected_string(self):
         """
@@ -222,6 +319,75 @@ class TestBuildBodyForEmail:
 
         # When
         build_body_for_email(suggestions=mocked_suggestions)
+
+        # Then
+        spy_enrich_suggestions_with_long_form_questions.assert_called_once_with(
+            suggestions=mocked_suggestions
+        )
+        spy_build_body_from_suggestions.assert_called_once_with(
+            suggestions=spy_enrich_suggestions_with_long_form_questions.return_value
+        )
+
+
+class TestBuildBodyForEmailV2:
+    @mock.patch(f"{MODULE_PATH}._enrich_suggestions_with_long_form_questions_v2")
+    def test_returns_correct_string(
+        self, spy_enrich_suggestions_with_long_form_questions_v2: mock.MagicMock
+    ):
+        """
+        Given a suggestions dict containing question and answers
+        When `build_body_for_email()` is called
+        Then a string is returned containing the question and answers
+        """
+        # Given
+        mocked_suggestions = mock.Mock()
+        enriched_suggestions = {
+            "How could we improve your experience with the dashboard?": IMPROVE_EXPERIENCE_ANSWER,
+            "What would you like to see on the dashboard in the future?": LIKE_TO_SEE_ANSWER,
+            "Did you find everything you were looking for?": DID_YOU_FIND_EVERYTHING_ANSWER,
+            "What was your reason for visiting the dashboard today?": REASON_ANSWER,
+        }
+        spy_enrich_suggestions_with_long_form_questions_v2.return_value = (
+            enriched_suggestions
+        )
+
+        # When
+        email_body: str = build_body_for_email_v2(suggestions=mocked_suggestions)
+
+        # Then
+        spy_enrich_suggestions_with_long_form_questions_v2.assert_called_once_with(
+            suggestions=mocked_suggestions
+        )
+        expected_email_body = _build_body_from_suggestions(
+            suggestions=enriched_suggestions
+        )
+        assert email_body == expected_email_body
+
+    @mock.patch(f"{MODULE_PATH}._build_body_from_suggestions")
+    @mock.patch(f"{MODULE_PATH}._enrich_suggestions_with_long_form_questions_v2")
+    def test_delegates_calls_correctly(
+        self,
+        spy_enrich_suggestions_with_long_form_questions: mock.MagicMock,
+        spy_build_body_from_suggestions: mock.MagicMock,
+    ):
+        """
+        Given a suggestions dict containing question and answers
+        When `build_body_for_email()` is called
+        Then the call is delegated accordingly
+
+        Patches:
+            `spy_enrich_suggestions_with_long_form_questions`: To check
+                the initial input suggestions dict is parsed and
+                enriched with the longform question first
+            `spy_build_body_from_suggestions`: To check the
+                call is delegated to the correct callee function
+                with the return value from the previous call
+        """
+        # Given
+        mocked_suggestions = mock.Mock()
+
+        # When
+        build_body_for_email_v2(suggestions=mocked_suggestions)
 
         # Then
         spy_enrich_suggestions_with_long_form_questions.assert_called_once_with(


### PR DESCRIPTION
# Description

This PR includes the following:

- Sets up the handlers which build and send emails against the form fields from the feedback page

Fixes #CDD-2103

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
