### PR TITLE
Use correct venv activate command when running `uhd venv create`

### DIFF
--- a/scripts/_venv.sh
+++ b/scripts/_venv.sh
@@ -47,7 +47,7 @@ function _venv_deactivate() {
 function _venv_create() {
     local python_version=`cat .python-version`
     python${python_version} -m venv --upgrade-deps .venv
-    _activate
+    _venv_activate
     pip install -r requirements.txt
 }
 


### PR DESCRIPTION
# Description

This PR includes the following:

- Uses the correct CLI command when activating the venv as part of the `uhd venv create` command

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
