### PR TITLE
CDD-2263: Update landing page template and chart margin

### DIFF
--- a/cms/dashboard/management/commands/build_cms_site_helpers/landing_page.py
+++ b/cms/dashboard/management/commands/build_cms_site_helpers/landing_page.py
@@ -43,6 +43,8 @@ def create_landing_page_body_wih_page_links() -> list[dict]:
                                                     "age": "all",
                                                     "stratum": "default",
                                                     "chart_type": "line_single_simplified",
+                                                    "date_from": "2022-10-14",
+                                                    "date_to": "2023-10-14",
                                                 },
                                                 "id": "0cb2a953-8737-4978-9886-d3943b76820a",
                                             }
@@ -71,6 +73,8 @@ def create_landing_page_body_wih_page_links() -> list[dict]:
                                                     "age": "all",
                                                     "stratum": "default",
                                                     "chart_type": "line_single_simplified",
+                                                    "date_from": "2022-10-14",
+                                                    "date_to": "2023-10-14",
                                                 },
                                                 "id": "7423460c-aa0c-482d-8fd5-ab9c62396657",
                                             }
@@ -99,6 +103,8 @@ def create_landing_page_body_wih_page_links() -> list[dict]:
                                                     "age": "all",
                                                     "stratum": "default",
                                                     "chart_type": "line_single_simplified",
+                                                    "date_from": "2022-10-14",
+                                                    "date_to": "2023-10-14",
                                                 },
                                                 "id": "f9eb94ff-0d92-4265-a88b-d52bf73532a5",
                                             }

--- a/metrics/domain/charts/chart_settings.py
+++ b/metrics/domain/charts/chart_settings.py
@@ -138,9 +138,7 @@ class ChartSettings:
         # Chart Config
         chart_config = self.get_base_chart_config()
         chart_config["showlegend"] = False
-        chart_config["margin"]["l"] = 25
-        chart_config["margin"]["r"] = 25
-        chart_config["margin"]["pad"] = 25
+        chart_config["margin"]["r"] = 23
 
         # x_axis config
         chart_config["xaxis"]["showgrid"] = False

--- a/tests/integration/metrics/domain/charts/line_single_simplified/test_generation.py
+++ b/tests/integration/metrics/domain/charts/line_single_simplified/test_generation.py
@@ -45,7 +45,7 @@ class TestLineSingleSimplified:
         assert main_layout.height == chart_height
         assert main_layout.width == chart_width
 
-        assert figure.layout.margin.l == figure.layout.margin.r == 25
+        assert figure.layout.margin.r == 23
 
         assert figure.layout.xaxis.tickvals == (
             fake_plot_data.x_axis_values[0],

--- a/tests/unit/metrics/domain/charts/test_chart_settings.py
+++ b/tests/unit/metrics/domain/charts/test_chart_settings.py
@@ -379,9 +379,7 @@ class TestChartSettings:
         expected_chart_config = chart_settings.get_base_chart_config()
         # Chart settings
         expected_chart_config["showlegend"] = False
-        expected_chart_config["margin"]["l"] = 25
-        expected_chart_config["margin"]["r"] = 25
-        expected_chart_config["margin"]["pad"] = 25
+        expected_chart_config["margin"]["r"] = 23
 
         # x_axis settings
         expected_chart_config["xaxis"]["showgrid"] = False


### PR DESCRIPTION
# Description

This PR includes the following:

- Updates the landing page starter template to include `date_from` and `date_to` fields.
- Removed left margin and padding from `line_single_simplified` chart

Fixes #CDD-2263

---

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
