### PR TITLE
Task/add headline number cards to topic pages/cdd 2275

### DIFF
--- a/cms/dashboard/management/commands/build_cms_site.py
+++ b/cms/dashboard/management/commands/build_cms_site.py
@@ -115,19 +115,27 @@ class Command(BaseCommand):
 
     @classmethod
     def _respiratory_viruses_section(cls, root_page: UKHSARootPage) -> None:
+        covid_19_page = build_cms_site_helpers.create_topic_page(
+            name="covid_19", parent_page=root_page
+        )
+        influenza_page = build_cms_site_helpers.create_topic_page(
+            name="influenza", parent_page=root_page
+        )
+        other_respiratory_viruses_page = build_cms_site_helpers.create_topic_page(
+            name="other_respiratory_viruses", parent_page=root_page
+        )
+        # Because the index page links to these pages
+        # they need to be created first, referenced and then moved under the index page
+
         respiratory_viruses_index_page = build_cms_site_helpers.create_index_page(
             name="respiratory-viruses", parent_page=root_page
         )
 
-        build_cms_site_helpers.create_topic_page(
-            name="covid_19", parent_page=respiratory_viruses_index_page
+        other_respiratory_viruses_page.move(
+            target=respiratory_viruses_index_page, pos="last-child"
         )
-        build_cms_site_helpers.create_topic_page(
-            name="influenza", parent_page=respiratory_viruses_index_page
-        )
-        build_cms_site_helpers.create_topic_page(
-            name="other_respiratory_viruses", parent_page=respiratory_viruses_index_page
-        )
+        influenza_page.move(target=respiratory_viruses_index_page, pos="last-child")
+        covid_19_page.move(target=respiratory_viruses_index_page, pos="last-child")
 
     @classmethod
     def _build_common_pages(cls, root_page: UKHSARootPage) -> None:

--- a/cms/dashboard/management/commands/build_cms_site.py
+++ b/cms/dashboard/management/commands/build_cms_site.py
@@ -57,15 +57,80 @@ class Command(BaseCommand):
             is_default_site=True,
         )
 
-        covid_19_page = build_cms_site_helpers.create_topic_page(
-            name="covid_19", parent_page=root_page
+        self._build_common_pages(root_page=root_page)
+
+        self._build_access_our_data_section(root_page=root_page)
+        self._build_whats_new_section(root_page=root_page)
+
+        create_metrics_documentation_parent_page_and_child_entries()
+
+        self._build_weather_health_alerts_section(root_page=root_page)
+        self._respiratory_viruses_section(root_page=root_page)
+
+        build_cms_site_helpers.create_landing_page(parent_page=root_page)
+
+        build_cms_site_helpers.create_feedback_page(
+            name="feedback", parent_page=root_page
         )
-        influenza_page = build_cms_site_helpers.create_topic_page(
-            name="influenza", parent_page=root_page
+        build_cms_site_helpers.create_menu_snippet()
+
+    @classmethod
+    def _build_whats_new_section(cls, root_page: UKHSARootPage) -> None:
+        whats_new_parent_page = build_cms_site_helpers.create_whats_new_parent_page(
+            name="whats_new", parent_page=root_page
         )
-        other_respiratory_viruses_page = build_cms_site_helpers.create_topic_page(
-            name="other_respiratory_viruses", parent_page=root_page
+        build_cms_site_helpers.create_whats_new_child_entry(
+            name="whats_new_soft_launch_of_the_ukhsa_data_dashboard",
+            parent_page=whats_new_parent_page,
         )
+
+    @classmethod
+    def _build_weather_health_alerts_section(cls, root_page: UKHSARootPage) -> None:
+        weather_health_alerts_page = build_cms_site_helpers.create_composite_page(
+            name="weather_health_alerts", parent_page=root_page
+        )
+        build_cms_site_helpers.create_composite_page(
+            name="heat_health_alerts", parent_page=weather_health_alerts_page
+        )
+        build_cms_site_helpers.create_composite_page(
+            name="cold_health_alerts", parent_page=weather_health_alerts_page
+        )
+
+    @classmethod
+    def _build_access_our_data_section(cls, root_page: UKHSARootPage) -> None:
+        access_our_data_parent_page = build_cms_site_helpers.create_composite_page(
+            name="access_our_data_parent_page", parent_page=root_page
+        )
+        build_cms_site_helpers.create_composite_page(
+            name="access_our_data_getting_started",
+            parent_page=access_our_data_parent_page,
+        )
+        build_cms_site_helpers.create_composite_page(
+            name="access_our_data_data_structure",
+            parent_page=access_our_data_parent_page,
+        )
+        build_cms_site_helpers.create_bulk_downloads_page(
+            name="bulk_downloads", parent_page=root_page
+        )
+
+    @classmethod
+    def _respiratory_viruses_section(cls, root_page: UKHSARootPage) -> None:
+        respiratory_viruses_index_page = build_cms_site_helpers.create_index_page(
+            name="respiratory-viruses", parent_page=root_page
+        )
+
+        build_cms_site_helpers.create_topic_page(
+            name="covid_19", parent_page=respiratory_viruses_index_page
+        )
+        build_cms_site_helpers.create_topic_page(
+            name="influenza", parent_page=respiratory_viruses_index_page
+        )
+        build_cms_site_helpers.create_topic_page(
+            name="other_respiratory_viruses", parent_page=respiratory_viruses_index_page
+        )
+
+    @classmethod
+    def _build_common_pages(cls, root_page: UKHSARootPage) -> None:
         build_cms_site_helpers.create_common_page(name="about", parent_page=root_page)
         build_cms_site_helpers.create_common_page(
             name="location_based_data", parent_page=root_page
@@ -80,60 +145,6 @@ class Command(BaseCommand):
         build_cms_site_helpers.create_common_page(
             name="compliance", parent_page=root_page
         )
-        whats_new_parent_page = build_cms_site_helpers.create_whats_new_parent_page(
-            name="whats_new", parent_page=root_page
-        )
-
-        build_cms_site_helpers.create_bulk_downloads_page(
-            name="bulk_downloads", parent_page=root_page
-        )
-
-        # Create access our data parent and child page
-        access_our_data_parent_page = build_cms_site_helpers.create_composite_page(
-            name="access_our_data_parent_page", parent_page=root_page
-        )
-        build_cms_site_helpers.create_composite_page(
-            name="access_our_data_getting_started",
-            parent_page=access_our_data_parent_page,
-        )
-        build_cms_site_helpers.create_composite_page(
-            name="access_our_data_data_structure",
-            parent_page=access_our_data_parent_page,
-        )
-
-        build_cms_site_helpers.create_whats_new_child_entry(
-            name="whats_new_soft_launch_of_the_ukhsa_data_dashboard",
-            parent_page=whats_new_parent_page,
-        )
-
-        create_metrics_documentation_parent_page_and_child_entries()
-
-        weather_health_alerts_page = build_cms_site_helpers.create_composite_page(
-            name="weather_health_alerts", parent_page=root_page
-        )
-        build_cms_site_helpers.create_composite_page(
-            name="heat_health_alerts", parent_page=weather_health_alerts_page
-        )
-        build_cms_site_helpers.create_composite_page(
-            name="cold_health_alerts", parent_page=weather_health_alerts_page
-        )
-
-        respiratory_viruses_index_page = build_cms_site_helpers.create_index_page(
-            name="respiratory-viruses", parent_page=root_page
-        )
-        other_respiratory_viruses_page.move(
-            target=respiratory_viruses_index_page, pos="last-child"
-        )
-        influenza_page.move(target=respiratory_viruses_index_page, pos="last-child")
-        covid_19_page.move(target=respiratory_viruses_index_page, pos="last-child")
-
-        # landing page version two
-        build_cms_site_helpers.create_landing_page(parent_page=root_page)
-
-        build_cms_site_helpers.create_feedback_page(
-            name="feedback", parent_page=root_page
-        )
-        build_cms_site_helpers.create_menu_snippet()
 
     @staticmethod
     def _clear_cms() -> None:

--- a/cms/dashboard/management/commands/build_cms_site_helpers/landing_page.py
+++ b/cms/dashboard/management/commands/build_cms_site_helpers/landing_page.py
@@ -123,13 +123,13 @@ def create_landing_page_body_wih_page_links() -> list[dict]:
         {
             "type": "section",
             "value": {
-                "heading": "Weather health alerts",
+                "heading": "Weather and climate risks",
                 "page_link": weather_health_alerts_page.id,
                 "content": [
                     {
                         "type": "weather_health_alert_card",
                         "value": {
-                            "title": "weather health alerts",
+                            "title": "Heat health alerts",
                             "sub_title": "Across England",
                             "alert_type": "heat",
                         },

--- a/cms/dashboard/management/commands/build_cms_site_helpers/menu.py
+++ b/cms/dashboard/management/commands/build_cms_site_helpers/menu.py
@@ -38,11 +38,48 @@ def _create_menu_data() -> list[dict]:
                     {
                         "type": "column",
                         "value": {
-                            "heading": "",
+                            "heading": "Health topics",
+                            "links": {
+                                "primary_link": {
+                                    "title": "COVID-19",
+                                    "body": '<p data-block-key="o0pz4">COVID-19 respiratory infection statistics</p>',
+                                    "page": covid_page.id,
+                                    "html_url": covid_page.full_url,
+                                },
+                                "secondary_links": [
+                                    {
+                                        "type": "secondary_link",
+                                        "value": {
+                                            "title": "Influenza",
+                                            "body": '<p data-block-key="fnj00">Flu ICU and HDU admissions and other statistics</p>',
+                                            "page": flu_page.id,
+                                            "html_url": flu_page.full_url,
+                                        },
+                                        "id": "0f41af0a-c4b7-4c68-9cf7-eddd18ceecae",
+                                    },
+                                    {
+                                        "type": "secondary_link",
+                                        "value": {
+                                            "title": "Other respiratory viruses",
+                                            "body": '<p data-block-key="fnj00">Other common respiratory viruses including adenovirus, hMPV &amp; parainfluenza</p>',
+                                            "page": other_respiratory_viruses_page.id,
+                                            "html_url": other_respiratory_viruses_page.full_url,
+                                        },
+                                        "id": "acd7c46f-b871-48ae-943f-9e95656bde6e",
+                                    },
+                                ],
+                            },
+                        },
+                        "id": "2758ae51-c976-46d2-8e38-c566bf6661b6",
+                    },
+                    {
+                        "type": "column",
+                        "value": {
+                            "heading": "Services and information",
                             "links": {
                                 "primary_link": {
                                     "title": "Homepage",
-                                    "body": "",
+                                    "body": '<p data-block-key="o0pz4">The UKHSA data dashboard</p>',
                                     "page": landing_page.id,
                                     "html_url": landing_page.full_url,
                                 },
@@ -50,118 +87,48 @@ def _create_menu_data() -> list[dict]:
                                     {
                                         "type": "secondary_link",
                                         "value": {
-                                            "title": "COVID-19",
-                                            "body": "",
-                                            "page": covid_page.id,
-                                            "html_url": covid_page.full_url,
+                                            "title": "Weather health alerts",
+                                            "body": '<p data-block-key="fnj00">Weather health alerting system provided by UKHSA</p>',
+                                            "page": weather_health_alerts_page.id,
+                                            "html_url": weather_health_alerts_page.full_url,
                                         },
-                                        "id": "c14de8da-5852-41b2-80bb-aa7ea92ff9b1",
+                                        "id": "5e595a50-1ef9-48cc-9208-9d02d9ba6006",
                                     },
                                     {
                                         "type": "secondary_link",
                                         "value": {
-                                            "title": "Influenza",
-                                            "body": "",
-                                            "page": flu_page.id,
-                                            "html_url": flu_page.full_url,
+                                            "title": "About",
+                                            "body": '<p data-block-key="fnj00">About the dashboard</p>',
+                                            "page": about_page.id,
+                                            "html_url": about_page.full_url,
                                         },
-                                        "id": "ebe1dcf7-bd06-485c-bd56-6b96ed639ef8",
+                                        "id": "8409731d-c41c-4cba-8e4c-2685fbcdd9de",
                                     },
                                     {
                                         "type": "secondary_link",
                                         "value": {
-                                            "title": "Other respiratory viruses",
-                                            "body": "",
-                                            "page": other_respiratory_viruses_page.id,
-                                            "html_url": other_respiratory_viruses_page.full_url,
+                                            "title": "Metrics documentation",
+                                            "body": '<p data-block-key="fnj00">See all available metrics</p>',
+                                            "page": metrics_docs_page.id,
+                                            "html_url": metrics_docs_page.full_url,
                                         },
-                                        "id": "8f6fa7aa-8283-48ca-bb73-f8fecf059b78",
+                                        "id": "31f49d81-37fe-403b-a169-3f7c89c05db8",
+                                    },
+                                    {
+                                        "type": "secondary_link",
+                                        "value": {
+                                            "title": "Access our data",
+                                            "body": '<p data-block-key="fnj00">API developer&#x27;s guide</p>',
+                                            "page": access_our_data_page.id,
+                                            "html_url": access_our_data_page.full_url,
+                                        },
+                                        "id": "e651e6cb-5de3-412e-90d2-813d88584e44",
                                     },
                                 ],
                             },
                         },
-                        "id": "9b1ea5e1-3a8e-4600-ac19-9a94ed0de509",
-                    }
-                ]
-            },
-            "id": "7c65b301-1226-4db1-8dbd-2a2342f8b523",
-        },
-        {
-            "type": "row",
-            "value": {
-                "columns": [
-                    {
-                        "type": "column",
-                        "value": {
-                            "heading": "",
-                            "links": {
-                                "primary_link": {
-                                    "title": "Weather health alerts",
-                                    "body": "",
-                                    "page": weather_health_alerts_page.id,
-                                    "html_url": weather_health_alerts_page.full_url,
-                                },
-                                "secondary_links": [],
-                            },
-                        },
-                        "id": "17120416-69d7-4ca7-88f4-f9c4752f0933",
-                    }
-                ]
-            },
-            "id": "8fc1b945-0c7d-440d-82df-5135efcd6082",
-        },
-        {
-            "type": "row",
-            "value": {
-                "columns": [
-                    {
-                        "type": "column",
-                        "value": {
-                            "heading": "",
-                            "links": {
-                                "primary_link": {
-                                    "title": "About",
-                                    "body": "",
-                                    "page": about_page.id,
-                                    "html_url": about_page.full_url,
-                                },
-                                "secondary_links": [],
-                            },
-                        },
-                        "id": "0c3514bb-bbe3-4047-a210-1ecd3e5704df",
-                    }
-                ]
-            },
-            "id": "5919756a-b432-4b56-8531-5cd58d00c86d",
-        },
-        {
-            "type": "row",
-            "value": {
-                "columns": [
-                    {
-                        "type": "column",
-                        "value": {
-                            "heading": "",
-                            "links": {
-                                "primary_link": {
-                                    "title": "Metrics documentation",
-                                    "body": "",
-                                    "page": metrics_docs_page.id,
-                                    "html_url": metrics_docs_page.full_url,
-                                },
-                                "secondary_links": [],
-                            },
-                        },
-                        "id": "6718fbcd-1d0f-457f-ba2a-af3db223000f",
-                    }
-                ]
-            },
-            "id": "0c0e6da8-abfe-4141-9145-80c65d1cd427",
-        },
-        {
-            "type": "row",
-            "value": {
-                "columns": [
+                        "id": "f5e762e6-15c6-4058-8913-7a4e4edbff4d",
+                    },
                     {
                         "type": "column",
                         "value": {
@@ -169,65 +136,28 @@ def _create_menu_data() -> list[dict]:
                             "links": {
                                 "primary_link": {
                                     "title": "What's new",
-                                    "body": "",
+                                    "body": '<p data-block-key="o0pz4">Timeline of changes</p>',
                                     "page": whats_new_page.id,
                                     "html_url": whats_new_page.full_url,
                                 },
-                                "secondary_links": [],
+                                "secondary_links": [
+                                    {
+                                        "type": "secondary_link",
+                                        "value": {
+                                            "title": "What's coming",
+                                            "body": "",
+                                            "page": whats_coming_page.id,
+                                            "html_url": whats_coming_page.full_url,
+                                        },
+                                        "id": "110d74f3-3bb3-478a-9385-71e2600a8490",
+                                    }
+                                ],
                             },
                         },
-                        "id": "15a86699-851a-48bd-b28b-7af51ac8d771",
-                    }
+                        "id": "0816b736-312c-46ce-8b6e-98d18a0ce463",
+                    },
                 ]
             },
-            "id": "fbf95d3d-e695-488a-a588-2df83bf789a0",
-        },
-        {
-            "type": "row",
-            "value": {
-                "columns": [
-                    {
-                        "type": "column",
-                        "value": {
-                            "heading": "",
-                            "links": {
-                                "primary_link": {
-                                    "title": "What's coming",
-                                    "body": "",
-                                    "page": whats_coming_page.id,
-                                    "html_url": whats_coming_page.full_url,
-                                },
-                                "secondary_links": [],
-                            },
-                        },
-                        "id": "6feddadb-b1c7-4bbf-8f4d-cafc5e222088",
-                    }
-                ]
-            },
-            "id": "6fded286-2cfc-47c8-91d1-a60995581ec0",
-        },
-        {
-            "type": "row",
-            "value": {
-                "columns": [
-                    {
-                        "type": "column",
-                        "value": {
-                            "heading": "",
-                            "links": {
-                                "primary_link": {
-                                    "title": "Access our data",
-                                    "body": "",
-                                    "page": access_our_data_page.id,
-                                    "html_url": access_our_data_page.full_url,
-                                },
-                                "secondary_links": [],
-                            },
-                        },
-                        "id": "95565e6e-1577-4b4e-a0ec-40b8f416f219",
-                    }
-                ]
-            },
-            "id": "7c6579b2-041d-4ef7-b4ca-d4fbe9d3387e",
-        },
+            "id": "dcd6d76c-a3b3-4b44-8326-8177d609b50b",
+        }
     ]

--- a/cms/dashboard/templates/cms_starting_pages/covid_19.json
+++ b/cms/dashboard/templates/cms_starting_pages/covid_19.json
@@ -162,7 +162,7 @@
                                                     "geography": "England",
                                                     "geography_type": "Nation",
                                                     "sex": "all",
-                                                    "age": "75-79",
+                                                    "age": "75+",
                                                     "stratum": "default",
                                                     "body": "Spring booster uptake"
                                                 },

--- a/cms/dashboard/templates/cms_starting_pages/covid_19.json
+++ b/cms/dashboard/templates/cms_starting_pages/covid_19.json
@@ -1,30 +1,208 @@
 {
-    "id": 5,
+    "id": 4,
     "meta": {
         "seo_title": "COVID-19 | UKHSA data dashboard",
         "search_description": "Overall summary of COVID-19 in circulation within the UK",
         "type": "topic.TopicPage",
-        "detail_url": "https://localhost/api/pages/5/",
-        "html_url": "https://localhost/topics/covid-19/",
+        "detail_url": "https://localhost/api/pages/4/",
+        "html_url": "https://localhost/respiratory-viruses/covid-19/",
         "slug": "covid-19",
-        "show_in_menus": true,
-        "first_published_at": "2024-07-11T14:55:39.220846+01:00",
+        "show_in_menus": false,
+        "first_published_at": "2024-10-25T10:10:50.196959+01:00",
         "alias_of": null,
         "parent": {
-            "id": 4,
+            "id": 78,
             "meta": {
-                "type": "home.HomePage",
-                "detail_url": "https://localhost/api/pages/4/",
+                "type": "composite.CompositePage",
+                "detail_url": "https://localhost/api/pages/78/",
                 "html_url": null
             },
-            "title": "UKHSA data dashboard"
+            "title": "Respiratory viruses"
         }
     },
     "title": "COVID-19",
     "seo_change_frequency": 5,
     "seo_priority": "0.5",
+    "last_updated_at": "2024-10-25T14:05:39.327926+01:00",
     "page_description": "<p data-block-key=\"sud2w\">COVID-19 is a respiratory infection caused by the SARS-CoV-2 virus. Find out more about <a href=\"https://www.gov.uk/government/publications/sources-of-surveillance-data-for-influenza-covid-19-and-other-respiratory-viruses/sources-of-surveillance-data-for-influenza-covid-19-and-other-respiratory-viruses\">data collection for COVID-19</a>.</p><p data-block-key=\"6nbtl\"><b>The UKHSA data dashboard is still undergoing statistical review. For reporting and analytical purposes, use the</b> <a href=\"https://coronavirus.data.gov.uk/\"><b>COVID-19 dashboard</b></a><b> and the</b> <a href=\"https://www.gov.uk/government/statistics/national-flu-and-covid-19-surveillance-reports-2023-to-2024-season\"><b>weekly surveillance report</b></a><b>.</b></p>",
     "body": [
+        {
+            "type": "section",
+            "value": {
+                "heading": "Headlines",
+                "content": [
+                    {
+                        "type": "headline_numbers_row_card",
+                        "value": {
+                            "columns": [
+                                {
+                                    "type": "column",
+                                    "value": {
+                                        "title": "Cases",
+                                        "rows": [
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "COVID-19_headline_cases_7DayTotals",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "all",
+                                                    "stratum": "default",
+                                                    "body": "Weekly"
+                                                },
+                                                "id": "c0e44b81-ce1e-4849-8942-80113dbfda4a"
+                                            },
+                                            {
+                                                "type": "trend_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "COVID-19_headline_cases_7DayChange",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "all",
+                                                    "stratum": "default",
+                                                    "body": "7 days",
+                                                    "percentage_metric": "COVID-19_headline_cases_7DayPercentChange"
+                                                },
+                                                "id": "d61cbd89-479e-4494-9bf6-715ce18168a9"
+                                            }
+                                        ]
+                                    },
+                                    "id": "5897a989-0caf-4162-bf66-6448d67aeff3"
+                                },
+                                {
+                                    "type": "column",
+                                    "value": {
+                                        "title": "Deaths",
+                                        "rows": [
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "COVID-19_headline_ONSdeaths_7DayTotals",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "all",
+                                                    "stratum": "default",
+                                                    "body": "Weekly"
+                                                },
+                                                "id": "462d2334-5f89-4e58-aef0-60768a302fa2"
+                                            },
+                                            {
+                                                "type": "trend_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "COVID-19_headline_ONSdeaths_7DayChange",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "all",
+                                                    "stratum": "default",
+                                                    "body": "7 days",
+                                                    "percentage_metric": "COVID-19_headline_ONSdeaths_7DayPercentChange"
+                                                },
+                                                "id": "0fa65e06-e3eb-440d-a2db-fd9e32fd55f7"
+                                            }
+                                        ]
+                                    },
+                                    "id": "9362f06a-58ed-488a-bf7e-c1eedfdb09ff"
+                                },
+                                {
+                                    "type": "column",
+                                    "value": {
+                                        "title": "Healthcare",
+                                        "rows": [
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "COVID-19_headline_7DayAdmissions",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "all",
+                                                    "stratum": "default",
+                                                    "body": "Patients admitted"
+                                                },
+                                                "id": "20b42af9-68cc-499d-832d-31991a819c31"
+                                            },
+                                            {
+                                                "type": "trend_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "COVID-19_headline_7DayAdmissionsChange",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "all",
+                                                    "stratum": "default",
+                                                    "body": "7 days",
+                                                    "percentage_metric": "COVID-19_headline_7DayAdmissionsPercentChange"
+                                                },
+                                                "id": "a1a8402e-c6f8-40f4-a9de-dc6477b9bdcb"
+                                            }
+                                        ]
+                                    },
+                                    "id": "94da4b1f-ed5d-421c-9db4-00f666c8a8e7"
+                                },
+                                {
+                                    "type": "column",
+                                    "value": {
+                                        "title": "Vaccines",
+                                        "rows": [
+                                            {
+                                                "type": "percentage_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "COVID-19_headline_vaccines_autumn23Uptake",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "75-79",
+                                                    "stratum": "default",
+                                                    "body": "Spring booster uptake"
+                                                },
+                                                "id": "13878e99-2dc8-4bd5-912f-405074f11762"
+                                            }
+                                        ]
+                                    },
+                                    "id": "0806e555-91e8-4739-9391-4020484f85ae"
+                                },
+                                {
+                                    "type": "column",
+                                    "value": {
+                                        "title": "Testing",
+                                        "rows": [
+                                            {
+                                                "type": "percentage_number",
+                                                "value": {
+                                                    "topic": "COVID-19",
+                                                    "metric": "COVID-19_headline_positivity_latest",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "all",
+                                                    "stratum": "default",
+                                                    "body": "Virus tests positivity"
+                                                },
+                                                "id": "5d9d02e1-3f5d-45e8-9991-ad0122bb836d"
+                                            }
+                                        ]
+                                    },
+                                    "id": "34752769-ec63-4ed9-bcb0-521513df6c65"
+                                }
+                            ]
+                        },
+                        "id": "000e07aa-6799-4f50-bb0c-db2218829395"
+                    }
+                ]
+            },
+            "id": "3873a214-6c74-433b-b33b-d0998cab3b5d"
+        },
         {
             "type": "section",
             "value": {
@@ -42,6 +220,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -84,6 +263,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -118,6 +298,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "date",
                                         "y_axis": "metric",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -190,6 +371,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -224,6 +406,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -275,6 +458,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -309,6 +493,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -360,6 +545,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -394,6 +580,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -445,6 +632,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -479,6 +667,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -542,6 +731,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -576,6 +766,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -779,6 +970,7 @@
             "id": "14175b86-36fa-46ee-b0f4-b56dc0a3c70a"
         }
     ],
+    "related_links_layout": "Footer",
     "related_links": [
         {
             "id": 1,
@@ -835,7 +1027,7 @@
             "body": "<p data-block-key=\"wvdly\">Provisional counts of the number of deaths registered in England and Wales (including deaths involving COVID-19), by age, sex and region in the latest weeks for which data is available.</p>"
         }
     ],
-    "last_published_at": "2024-07-11T15:50:32.581888+01:00",
+    "last_published_at": "2024-10-25T14:05:39.327926+01:00",
     "enable_area_selector": false,
     "selected_topics": [
         "COVID-19"

--- a/cms/dashboard/templates/cms_starting_pages/influenza.json
+++ b/cms/dashboard/templates/cms_starting_pages/influenza.json
@@ -1,30 +1,109 @@
 {
-    "id": 6,
+    "id": 5,
     "meta": {
         "seo_title": "Influenza | UKHSA data dashboard",
         "search_description": "Detailed summary of Influenza in circulation within the UK",
         "type": "topic.TopicPage",
-        "detail_url": "https://localhost/api/pages/6/",
-        "html_url": "https://localhost/topics/influenza/",
+        "detail_url": "https://localhost/api/pages/5/",
+        "html_url": "https://localhost/respiratory-viruses/influenza/",
         "slug": "influenza",
-        "show_in_menus": true,
-        "first_published_at": "2024-07-11T14:55:39.253862+01:00",
+        "show_in_menus": false,
+        "first_published_at": "2024-10-25T10:10:50.225447+01:00",
         "alias_of": null,
         "parent": {
-            "id": 4,
+            "id": 78,
             "meta": {
-                "type": "home.HomePage",
-                "detail_url": "https://localhost/api/pages/4/",
+                "type": "composite.CompositePage",
+                "detail_url": "https://localhost/api/pages/78/",
                 "html_url": null
             },
-            "title": "UKHSA data dashboard"
+            "title": "Respiratory viruses"
         }
     },
     "title": "Influenza",
     "seo_change_frequency": 5,
     "seo_priority": "0.5",
+    "last_updated_at": "2024-10-25T14:08:47.386252+01:00",
     "page_description": "<p data-block-key=\"z3vrp\">Influenza (commonly known as flu) is a respiratory infection.</p><p data-block-key=\"f9pfj\">The healthcare data we have for influenza comes from a sentinel surveillance system (a data collection method used to monitor trends). This means the influenza healthcare data is not a count of every person being treated for influenza in hospital. Find out more about <a href=\"https://www.gov.uk/government/publications/sources-of-surveillance-data-for-influenza-covid-19-and-other-respiratory-viruses/sources-of-surveillance-data-for-influenza-covid-19-and-other-respiratory-viruses\">data collection for influenza</a>.</p><p data-block-key=\"fjsfr\"><b>The UKHSA data dashboard is still undergoing statistical review. For reporting and analytical purposes, use the</b> <a href=\"https://coronavirus.data.gov.uk/\"><b>COVID-19 dashboard</b></a><b> and the</b> <a href=\"https://www.gov.uk/government/statistics/national-flu-and-covid-19-surveillance-reports-2023-to-2024-season\"><b>weekly surveillance report</b></a><b>.</b></p>",
     "body": [
+        {
+            "type": "section",
+            "value": {
+                "heading": "Headlines",
+                "content": [
+                    {
+                        "type": "headline_numbers_row_card",
+                        "value": {
+                            "columns": [
+                                {
+                                    "type": "column",
+                                    "value": {
+                                        "title": "Testing",
+                                        "rows": [
+                                            {
+                                                "type": "percentage_number",
+                                                "value": {
+                                                    "topic": "Influenza",
+                                                    "metric": "influenza_headline_positivityLatest",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "all",
+                                                    "stratum": "default",
+                                                    "body": "Virus tests positivity"
+                                                },
+                                                "id": "89d619d2-fc81-40a8-858a-3d0ed1cfec4b"
+                                            }
+                                        ]
+                                    },
+                                    "id": "446083e9-74ad-406e-80aa-6ff485947ad9"
+                                },
+                                {
+                                    "type": "column",
+                                    "value": {
+                                        "title": "Healthcare",
+                                        "rows": [
+                                            {
+                                                "type": "headline_number",
+                                                "value": {
+                                                    "topic": "Influenza",
+                                                    "metric": "influenza_headline_ICUHDUadmissionRateLatest",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "all",
+                                                    "stratum": "default",
+                                                    "body": "Hospital admission rate (per 100,000)"
+                                                },
+                                                "id": "66ca82f6-17ef-4bd2-b262-e946f22a7221"
+                                            },
+                                            {
+                                                "type": "trend_number",
+                                                "value": {
+                                                    "topic": "Influenza",
+                                                    "metric": "influenza_headline_ICUHDUadmissionRateChange",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "all",
+                                                    "stratum": "default",
+                                                    "body": "Last 7 days",
+                                                    "percentage_metric": "influenza_headline_ICUHDUadmissionRatePercentChange"
+                                                },
+                                                "id": "f6de590e-3876-49b9-8e37-039f783a4bde"
+                                            }
+                                        ]
+                                    },
+                                    "id": "9c1909b4-b93b-460d-ba14-ac3945ecff6e"
+                                }
+                            ]
+                        },
+                        "id": "a72b8963-da4d-4900-8258-569b44770911"
+                    }
+                ]
+            },
+            "id": "2708ce3b-1913-4f52-9f55-5b101609a882"
+        },
         {
             "type": "section",
             "value": {
@@ -42,6 +121,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -76,6 +156,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -274,6 +355,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -308,6 +390,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -427,6 +510,7 @@
             "id": "0f9dae99-697b-4d7d-8c92-f977ffbcd622"
         }
     ],
+    "related_links_layout": "Footer",
     "related_links": [
         {
             "id": 7,
@@ -456,7 +540,7 @@
             "body": "<p data-block-key=\"chb3o\">The symptoms, diagnosis, management and epidemiology of human parainfluenza viruses (HPIVs).</p>"
         }
     ],
-    "last_published_at": "2024-07-11T15:54:04.810830+01:00",
+    "last_published_at": "2024-10-25T14:08:47.386252+01:00",
     "enable_area_selector": false,
     "selected_topics": [
         "Influenza"

--- a/cms/dashboard/templates/cms_starting_pages/other_respiratory_viruses.json
+++ b/cms/dashboard/templates/cms_starting_pages/other_respiratory_viruses.json
@@ -1,30 +1,140 @@
 {
-    "id": 7,
+    "id": 6,
     "meta": {
         "seo_title": "Other Respiratory Viruses | UKHSA data dashboard",
         "search_description": "Overall summary of other respiratory viruses in circulation within the UK",
         "type": "topic.TopicPage",
-        "detail_url": "https://localhost/api/pages/7/",
-        "html_url": "https://localhost/topics/other-respiratory-viruses/",
+        "detail_url": "https://localhost/api/pages/6/",
+        "html_url": "https://localhost/respiratory-viruses/other-respiratory-viruses/",
         "slug": "other-respiratory-viruses",
-        "show_in_menus": true,
-        "first_published_at": "2024-07-11T14:55:39.280059+01:00",
+        "show_in_menus": false,
+        "first_published_at": "2024-10-25T10:10:50.248963+01:00",
         "alias_of": null,
         "parent": {
-            "id": 4,
+            "id": 78,
             "meta": {
-                "type": "home.HomePage",
-                "detail_url": "https://localhost/api/pages/4/",
+                "type": "composite.CompositePage",
+                "detail_url": "https://localhost/api/pages/78/",
                 "html_url": null
             },
-            "title": "UKHSA data dashboard"
+            "title": "Respiratory viruses"
         }
     },
     "title": "Other respiratory viruses",
     "seo_change_frequency": 5,
     "seo_priority": "0.5",
+    "last_updated_at": "2024-10-25T14:12:46.381960+01:00",
     "page_description": "<p data-block-key=\"rjyu9\">Other common respiratory viruses include adenovirus, human metapneumovirus (hMPV), parainfluenza, rhinovirus and respiratory syncytial virus (RSV).</p><p data-block-key=\"47elv\">The healthcare data we have for other respiratory viruses comes from a sentinel surveillance system (a data collection method used to monitor trends). This means the healthcare data is not a count of every person being treated for the respiratory virus in hospital. Find out more about <a href=\"https://www.gov.uk/government/publications/sources-of-surveillance-data-for-influenza-covid-19-and-other-respiratory-viruses/sources-of-surveillance-data-for-influenza-covid-19-and-other-respiratory-viruses\">data collection for other respiratory viruses</a>.</p><p data-block-key=\"3t8e7\"><b>The UKHSA data dashboard is still undergoing statistical review. For reporting and analytical purposes, use the</b> <a href=\"https://coronavirus.data.gov.uk/\"><b>COVID-19 dashboard</b></a><b> and the</b> <a href=\"https://www.gov.uk/government/statistics/national-flu-and-covid-19-surveillance-reports-2023-to-2024-season\"><b>weekly surveillance report</b></a><b>.</b></p>",
     "body": [
+        {
+            "type": "section",
+            "value": {
+                "heading": "Headlines",
+                "content": [
+                    {
+                        "type": "headline_numbers_row_card",
+                        "value": {
+                            "columns": [
+                                {
+                                    "type": "column",
+                                    "value": {
+                                        "title": "Adenovirus",
+                                        "rows": [
+                                            {
+                                                "type": "percentage_number",
+                                                "value": {
+                                                    "topic": "Adenovirus",
+                                                    "metric": "adenovirus_headline_positivityLatest",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "all",
+                                                    "stratum": "default",
+                                                    "body": "Weekly positivity"
+                                                },
+                                                "id": "03e456fb-0467-4a3c-80c2-e4b4f1f8c557"
+                                            }
+                                        ]
+                                    },
+                                    "id": "510140fd-1f90-4950-af31-0eb909fc9542"
+                                },
+                                {
+                                    "type": "column",
+                                    "value": {
+                                        "title": "Human metapneumovirus (hMPV)",
+                                        "rows": [
+                                            {
+                                                "type": "percentage_number",
+                                                "value": {
+                                                    "topic": "hMPV",
+                                                    "metric": "hMPV_headline_positivityLatest",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "all",
+                                                    "stratum": "default",
+                                                    "body": "Weekly positivity"
+                                                },
+                                                "id": "9222e4d3-ca38-49b6-a9f6-e6398bb4cb26"
+                                            }
+                                        ]
+                                    },
+                                    "id": "c90cf91e-4ede-46e7-a915-8f66d41d22e1"
+                                },
+                                {
+                                    "type": "column",
+                                    "value": {
+                                        "title": "Parainfluenza",
+                                        "rows": [
+                                            {
+                                                "type": "percentage_number",
+                                                "value": {
+                                                    "topic": "Parainfluenza",
+                                                    "metric": "parainfluenza_headline_positivityLatest",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "all",
+                                                    "stratum": "default",
+                                                    "body": "Weekly positivity"
+                                                },
+                                                "id": "624ae7d3-ffad-41d7-adc5-8006a8da0210"
+                                            }
+                                        ]
+                                    },
+                                    "id": "744bb766-f037-4f8a-aff4-db2b4deff4c3"
+                                },
+                                {
+                                    "type": "column",
+                                    "value": {
+                                        "title": "Rhinovirus",
+                                        "rows": [
+                                            {
+                                                "type": "percentage_number",
+                                                "value": {
+                                                    "topic": "Rhinovirus",
+                                                    "metric": "rhinovirus_headline_positivityLatest",
+                                                    "geography": "England",
+                                                    "geography_type": "Nation",
+                                                    "sex": "all",
+                                                    "age": "all",
+                                                    "stratum": "default",
+                                                    "body": "Weekly positivity"
+                                                },
+                                                "id": "dbc6692a-8871-4926-a93a-b60b8780b35a"
+                                            }
+                                        ]
+                                    },
+                                    "id": "9dfcd1f7-57f7-4e0c-8644-a05e424716c5"
+                                }
+                            ]
+                        },
+                        "id": "18364314-a7c9-44b7-aba1-96b4dc07cbda"
+                    }
+                ]
+            },
+            "id": "7bbcf9ff-e7de-4aaa-bb23-616d3826c44e"
+        },
         {
             "type": "section",
             "value": {
@@ -42,6 +152,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -240,6 +351,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -282,6 +394,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -324,6 +437,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -366,6 +480,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -408,6 +523,7 @@
                                         "tag_manager_event_id": "",
                                         "x_axis": "",
                                         "y_axis": "",
+                                        "show_tooltips": false,
                                         "chart": [
                                             {
                                                 "type": "plot",
@@ -443,6 +559,7 @@
             "id": "0086c9ed-1b53-41f6-a6b4-4c2012925ed8"
         }
     ],
+    "related_links_layout": "Footer",
     "related_links": [
         {
             "id": 10,
@@ -490,13 +607,13 @@
             "body": "<p data-block-key=\"4kyrm\">Read more about the sources of data for surveillance systems used to monitor COVID-19, influenza and other seasonal respiratory viruses in England.</p>"
         }
     ],
-    "last_published_at": "2024-07-11T15:52:06.801790+01:00",
+    "last_published_at": "2024-10-25T14:12:46.381960+01:00",
     "enable_area_selector": false,
     "selected_topics": [
         "Adenovirus",
-        "Parainfluenza",
+        "Rhinovirus",
         "hMPV",
-        "RSV",
-        "Rhinovirus"
+        "Parainfluenza",
+        "RSV"
     ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ lint.ignore = [
                     # into components which have numerous dependencies during initialization
     "PLR0911",  # Too many return statements
     "C901",     # Considers function to be too complex, due to switch case statements
+    "E501",     # Ignore line-length in template for populating CMS menu snippet
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/tests/system/test_build_cms_site.py
+++ b/tests/system/test_build_cms_site.py
@@ -477,8 +477,8 @@ class TestBuildCMSSite:
 
         # Then
         menu_data = response.data["active_menu"]
-        # There should be 7 rows in the menu
-        assert len(menu_data) == 7
+        # There should be 1 row in the menu
+        assert len(menu_data) == 1
 
         def extract_primary_link_info(row_index, column_index) -> dict:
             return menu_data[row_index]["value"]["columns"][column_index]["value"][
@@ -492,15 +492,16 @@ class TestBuildCMSSite:
                 "links"
             ]["secondary_links"][secondary_link_index]["value"]
 
-        landing_page = LandingPage.objects.last()
-        landing_page_data = extract_primary_link_info(row_index=0, column_index=0)
-        assert landing_page_data["title"] == "Homepage"
-        assert landing_page_data["page"] == landing_page.id
-        assert landing_page_data["html_url"] == landing_page.full_url
+        # landing_page = LandingPage.objects.last()
+        # landing_page_data = extract_primary_link_info(row_index=0, column_index=0)
+        # assert landing_page_data["title"] == "COVID-19"
+        # assert landing_page_data["page"] == landing_page.id
+        # assert landing_page_data["html_url"] == landing_page.full_url
 
         covid_page = TopicPage.objects.get(slug="covid-19")
-        covid_page_data = extract_secondary_link_info(
-            row_index=0, column_index=0, secondary_link_index=0
+        covid_page_data = extract_primary_link_info(
+            row_index=0,
+            column_index=0,
         )
         assert covid_page_data["title"] == "COVID-19"
         assert covid_page_data["page"] == covid_page.id
@@ -508,7 +509,7 @@ class TestBuildCMSSite:
 
         flu_page = TopicPage.objects.get(slug="influenza")
         flu_page_data = extract_secondary_link_info(
-            row_index=0, column_index=0, secondary_link_index=1
+            row_index=0, column_index=0, secondary_link_index=0
         )
         assert flu_page_data["title"] == "Influenza"
         assert flu_page_data["page"] == flu_page.id
@@ -518,7 +519,7 @@ class TestBuildCMSSite:
             slug="other-respiratory-viruses"
         )
         other_respiratory_viruses_page_data = extract_secondary_link_info(
-            row_index=0, column_index=0, secondary_link_index=2
+            row_index=0, column_index=0, secondary_link_index=1
         )
         assert (
             other_respiratory_viruses_page_data["title"] == "Other respiratory viruses"
@@ -530,17 +531,4 @@ class TestBuildCMSSite:
         assert (
             other_respiratory_viruses_page_data["html_url"]
             == other_respiratory_viruses_page.full_url
-        )
-
-        weather_health_alerts_page = CompositePage.objects.get(
-            slug="weather-health-alerts"
-        )
-        weather_health_alerts_page_data = extract_primary_link_info(
-            row_index=1, column_index=0
-        )
-        assert weather_health_alerts_page_data["title"] == "Weather health alerts"
-        assert weather_health_alerts_page_data["page"] == weather_health_alerts_page.id
-        assert (
-            weather_health_alerts_page_data["html_url"]
-            == weather_health_alerts_page.full_url
         )

--- a/tests/unit/cms/topic/test_models.py
+++ b/tests/unit/cms/topic/test_models.py
@@ -30,30 +30,35 @@ class TestTemplateCOVID19Page:
         body = template_covid_19_page.body
 
         # Then
-        assert len(body) == 5
-        cases_section = body[0]
-        deaths_section = body[1]
-        healthcare_section = body[2]
-        testing_section = body[3]
-        vaccinations_section = body[4]
+        assert len(body) == 6
+        headlines_section = body[0]
+        cases_section = body[1]
+        deaths_section = body[2]
+        healthcare_section = body[3]
+        testing_section = body[4]
+        vaccinations_section = body[5]
 
-        # Check that the 1st item is a `section` type for `Cases`
+        # Check that the 1st item is a `section` type for `Headlines`
+        assert headlines_section.block_type == "section"
+        assert headlines_section.value["heading"] == "Headlines"
+
+        # Check that the 2nd item is a `section` type for `Cases`
         assert cases_section.block_type == "section"
         assert cases_section.value["heading"] == "Cases"
 
-        # Check that the 2nd item is a `section` type for `Deaths`
+        # Check that the 3rd item is a `section` type for `Deaths`
         assert deaths_section.block_type == "section"
         assert deaths_section.value["heading"] == "Deaths"
 
-        # Check that the 3rd item is a `section` type for `Healthcare`
+        # Check that the 4th item is a `section` type for `Healthcare`
         assert healthcare_section.block_type == "section"
         assert healthcare_section.value["heading"] == "Healthcare"
 
-        # Check that the 4th item is a `section` type for `Testing`
+        # Check that the 5th item is a `section` type for `Testing`
         assert testing_section.block_type == "section"
         assert testing_section.value["heading"] == "Testing"
 
-        # Check that the 5th item is a `section` type for `Vaccinations`
+        # Check that the 6th item is a `section` type for `Vaccinations`
         assert vaccinations_section.block_type == "section"
         assert vaccinations_section.value["heading"] == "Vaccinations"
 
@@ -72,7 +77,7 @@ class TestTemplateCOVID19Page:
         body = template_covid_19_page.body
 
         # Then
-        cases_section = body[0]
+        cases_section = body[1]
         chart_row_card = cases_section.value["content"][0]
         chart_row_card_value = chart_row_card.value
 
@@ -296,6 +301,14 @@ class TestTemplateCOVID19Page:
             "COVID-19_vaccinations_autumn22_uptakeByDay",
             "COVID-19_vaccinations_spring23_dosesByDay",
             "COVID-19_vaccinations_spring23_uptakeByDay",
+            "COVID-19_headline_7DayAdmissions",
+            "COVID-19_headline_7DayAdmissionsChange",
+            "COVID-19_headline_ONSdeaths_7DayChange",
+            "COVID-19_headline_ONSdeaths_7DayTotals",
+            "COVID-19_headline_cases_7DayChange",
+            "COVID-19_headline_cases_7DayTotals",
+            "COVID-19_headline_positivity_latest",
+            "COVID-19_headline_vaccines_autumn23Uptake",
         }
         assert selected_metrics == expected_metrics
 
@@ -345,7 +358,7 @@ class TestTemplateInfluenzaPage:
 
     @staticmethod
     def _retrieve_nested_chart_block(body):
-        testing_section = body[1]
+        testing_section = body[2]
         chart_row_card = testing_section.value["content"][0]
         chart_row_card_value = chart_row_card.value
 
@@ -559,6 +572,9 @@ class TestTemplateInfluenzaPage:
         expected_metrics = {
             "influenza_healthcare_ICUHDUadmissionRateByWeek",
             "influenza_testing_positivityByWeek",
+            "influenza_headline_ICUHDUadmissionRateChange",
+            "influenza_headline_ICUHDUadmissionRateLatest",
+            "influenza_headline_positivityLatest",
         }
         assert selected_metrics == expected_metrics
 
@@ -617,5 +633,9 @@ class TestTemplateOtherRespiratoryVirusesPage:
             "hMPV_testing_positivityByWeek",
             "parainfluenza_testing_positivityByWeek",
             "rhinovirus_testing_positivityByWeek",
+            "adenovirus_headline_positivityLatest",
+            "hMPV_headline_positivityLatest",
+            "parainfluenza_headline_positivityLatest",
+            "rhinovirus_headline_positivityLatest",
         }
         assert selected_metrics == expected_metrics


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds the headline number row cards to the templates of the topic pages to suit the migration from home page -> landing page

Fixes #CDD-2275

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
