### PR TITLE
Switch to `JSONOpenAPIRenderer` to replace deprecated `CoreJSONRenderer`

### DIFF
--- a/metrics/api/views/downloads.py
+++ b/metrics/api/views/downloads.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 
 from django.http import HttpResponse
 from drf_spectacular.utils import extend_schema
-from rest_framework.renderers import CoreJSONRenderer
+from rest_framework.renderers import JSONOpenAPIRenderer
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -40,7 +40,7 @@ class DownloadsView(APIView):
     headline_serializer_class = CoreHeadlineSerializer
     permission_classes = []
 
-    renderer_classes = (CoreJSONRenderer,)
+    renderer_classes = (JSONOpenAPIRenderer,)
 
     def _get_serializer_class(
         self, queryset: CoreTimeSeriesQuerySet | CoreHeadlineQuerySet, metric_group: str


### PR DESCRIPTION
# Description

This PR includes the following:

- Switches the renderer class on the downloads vie to `JSONOpenAPIRenderer` to replace the now deprecated `CoreJSONRenderer`

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
