### PR TITLE
Add `send_email_via_ses()` handler

### DIFF
--- a/feedback/email_server.py
+++ b/feedback/email_server.py
@@ -1,5 +1,8 @@
 import logging
+import os
 
+import boto3
+from botocore.exceptions import ClientError
 from django.core.mail import EmailMessage
 
 import config
@@ -9,6 +12,46 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_FEEDBACK_EMAIL_RECIPIENT_ADDRESS = config.FEEDBACK_EMAIL_RECIPIENT_ADDRESS
 DEFAULT_FEEDBACK_EMAIL_SUBJECT = "Suggestions Feedback for UKHSA data dashboard"
+
+ses_client = boto3.client("ses", region_name="eu-west-2")
+
+
+def send_email_via_ses(*, email_message: EmailMessage) -> None:
+    """Sends the given `email_message` via AWS SES
+
+    Notes:
+        Sends the email from the env var `FEEDBACK_EMAIL_SENDER_ADDRESS`
+        to the recipient address from the env var `FEEDBACK_EMAIL_RECIPIENT_ADDRESS`
+
+    Returns:
+        None
+
+    Raises:
+        `ClientError`: If there is an error sending the email via AWS SES
+
+    """
+    feedback_email_recipient_address = os.environ.get(
+        "FEEDBACK_EMAIL_RECIPIENT_ADDRESS"
+    )
+    feedback_email_sender_address = os.environ.get("FEEDBACK_EMAIL_SENDER_ADDRESS")
+    sender = f"UKHSA data dashboard feedback <{feedback_email_sender_address}>"
+
+    logger.info("Sending email")
+    charset = "UTF-8"
+    try:
+        response = ses_client.send_email(
+            Destination={"ToAddresses": [feedback_email_recipient_address]},
+            Message={
+                "Body": {"Text": {"Charset": charset, "Data": email_message.body}},
+                "Subject": {"Charset": charset, "Data": email_message.subject},
+            },
+            Source=sender,
+        )
+    except ClientError as error:
+        logger.info(error.response["Error"]["Message"])
+        raise
+    else:
+        logger.info("Email sent. Message ID: %s", response["MessageId"]),
 
 
 def send_email(


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds the `send_email_via_ses()` handler which will be used to route emails via SES instead of the current setup

Fixes #CDD-2364

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
