### PR TITLE
CDD-2326: Migrate audit urls to cms admin

### DIFF
--- a/metrics/api/urls_construction.py
+++ b/metrics/api/urls_construction.py
@@ -240,6 +240,7 @@ def construct_urlpatterns(
                 app_mode=app_mode
             )
             constructed_url_patterns += django_admin_urlpatterns
+            constructed_url_patterns += audit_api_urlpatterns
         case enums.AppMode.PUBLIC_API.value:
             constructed_url_patterns += construct_public_api_urlpatterns(
                 app_mode=app_mode
@@ -251,8 +252,6 @@ def construct_urlpatterns(
         case enums.AppMode.INGESTION.value:
             # Ingestion mode does not expose any endpoints
             return constructed_url_patterns
-        case enums.AppMode.AUDIT_API.value:
-            constructed_url_patterns += audit_api_urlpatterns
         case _:
             constructed_url_patterns += construct_cms_admin_urlpatterns(
                 app_mode=app_mode

--- a/metrics/api/views/audit/audit_api_timeseries.py
+++ b/metrics/api/views/audit/audit_api_timeseries.py
@@ -1,7 +1,9 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
-from rest_framework import viewsets
+from rest_framework import permissions, viewsets
 
+import config
+from metrics.api.enums import AppMode
 from metrics.data.managers.api_models.time_series import APITimeSeriesQuerySet
 from metrics.data.models.api_models import APITimeSeries
 
@@ -73,6 +75,12 @@ class AuditAPITimeSeriesViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = AuditAPITimeSeriesSerializer
     pagination_class = AuditEndpointPagination
     filter_backends = [DjangoFilterBackend]
+
+    def get_permissions(self) -> list[type[permissions.BasePermission]]:
+        if AppMode.CMS_ADMIN.value == config.APP_MODE:
+            return [permissions.IsAuthenticated()]
+
+        return super().get_permissions()
 
     def get_queryset(self) -> APITimeSeriesQuerySet:
         queryset = super().get_queryset()

--- a/metrics/api/views/audit/audit_core_headline.py
+++ b/metrics/api/views/audit/audit_core_headline.py
@@ -1,7 +1,9 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import extend_schema
-from rest_framework import viewsets
+from rest_framework import permissions, viewsets
 
+import config
+from metrics.api.enums import AppMode
 from metrics.data.managers.core_models.headline import CoreHeadlineQuerySet
 from metrics.data.models.core_models.headline import CoreHeadline
 
@@ -71,6 +73,12 @@ class AuditCoreHeadlineViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = AuditCoreHeadlineSerializer
     pagination_class = AuditEndpointPagination
     filter_backends = [DjangoFilterBackend]
+
+    def get_permissions(self) -> list[type[permissions.BasePermission]]:
+        if AppMode.CMS_ADMIN.value == config.APP_MODE:
+            return [permissions.IsAuthenticated()]
+
+        return super().get_permissions()
 
     def get_queryset(self) -> CoreHeadlineQuerySet:
         queryset = super().get_queryset()

--- a/metrics/api/views/audit/audit_core_timeseries.py
+++ b/metrics/api/views/audit/audit_core_timeseries.py
@@ -1,6 +1,8 @@
 from drf_spectacular.utils import extend_schema
-from rest_framework import viewsets
+from rest_framework import permissions, viewsets
 
+import config
+from metrics.api.enums import AppMode
 from metrics.data.managers.core_models.time_series import CoreTimeSeriesQuerySet
 from metrics.data.models.core_models import CoreTimeSeries
 
@@ -71,6 +73,12 @@ class AuditCoreTimeseriesViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = CoreTimeSeries.objects.all().order_by("date")
     serializer_class = AuditCoreTimeseriesSerializer
     pagination_class = AuditEndpointPagination
+
+    def get_permissions(self) -> list[type[permissions.BasePermission]]:
+        if AppMode.CMS_ADMIN.value == config.APP_MODE:
+            return [permissions.IsAuthenticated()]
+
+        return super().get_permissions()
 
     def get_queryset(self) -> CoreTimeSeriesQuerySet:
         queryset = super().get_queryset()

--- a/tests/unit/metrics/api/test_urls_construction.py
+++ b/tests/unit/metrics/api/test_urls_construction.py
@@ -232,7 +232,8 @@ class TestConstructUrlpatterns:
         "excluded_endpoint_path",
         PUBLIC_API_ENDPOINT_PATHS
         + CMS_ADMIN_ENDPOINT_PATHS
-        + FEEDBACK_API_ENDPOINT_PATHS,
+        + FEEDBACK_API_ENDPOINT_PATHS
+        + AUDIT_API_ENDPOINT_PATHS,
     )
     def test_private_api_mode_does_not_return_other_urls(
         self, excluded_endpoint_path: str
@@ -277,7 +278,8 @@ class TestConstructUrlpatterns:
         "excluded_endpoint_path",
         PRIVATE_API_ENDPOINT_PATHS
         + CMS_ADMIN_ENDPOINT_PATHS
-        + FEEDBACK_API_ENDPOINT_PATHS,
+        + FEEDBACK_API_ENDPOINT_PATHS
+        + AUDIT_API_ENDPOINT_PATHS,
     )
     def test_public_api_mode_does_not_return_other_urls(
         self, excluded_endpoint_path: str
@@ -314,6 +316,27 @@ class TestConstructUrlpatterns:
 
         # Then
         assert any("admin" in str(x.pattern) for x in urlpatterns)
+
+    @pytest.mark.parametrize(
+        "included_endpoint_path",
+        AUDIT_API_ENDPOINT_PATHS,
+    )
+    def test_cms_admin_mode_returns_all_expected_urls(
+        self, included_endpoint_path: str
+    ):
+        """
+        Given an `app_mode` of "CMS_ADMIN"
+        When `construct_urlpatterns()` is called
+        Then the urlpatterns returned contain the audit api endpoints
+        """
+        # Given
+        app_mode = enums.AppMode.CMS_ADMIN.value
+
+        # When
+        urlpatterns = construct_urlpatterns(app_mode=app_mode)
+
+        # Then
+        assert any(included_endpoint_path in str(x.pattern) for x in urlpatterns)
 
     @pytest.mark.parametrize(
         "excluded_endpoint_path",
@@ -404,29 +427,14 @@ class TestConstructUrlpatterns:
         # Then
         assert not any(excluded_endpoint_path in str(x.pattern) for x in urlpatterns)
 
-    # Tests for audit endpoints
-    def test_audit_api_app_mode_returns_audit_urls(self):
-        """
-        Given an `app_mode` of "AUDIT"
-        When `construct_urlpatterns()` is called
-        Then the urlpatterns returned contain the audit API endpoints
-        """
-        # Given
-        app_mode = enums.AppMode.AUDIT_API.value
-
-        # When
-        urlpatterns = construct_urlpatterns(app_mode=app_mode)
-
-        # Then
-        assert any("audit" in str(x.pattern) for x in urlpatterns)
-
     # Tests for common/shared endpoints
     @pytest.mark.parametrize(
         "endpoint_path",
         PRIVATE_API_ENDPOINT_PATHS
         + PUBLIC_API_ENDPOINT_PATHS
         + CMS_ADMIN_ENDPOINT_PATHS
-        + FEEDBACK_API_ENDPOINT_PATHS,
+        + FEEDBACK_API_ENDPOINT_PATHS
+        + AUDIT_API_ENDPOINT_PATHS,
     )
     def test_no_specific_app_mode_returns_all_urls(self, endpoint_path: str):
         """

--- a/tests/unit/metrics/api/views/audit/test_audit_api_timeseries.py
+++ b/tests/unit/metrics/api/views/audit/test_audit_api_timeseries.py
@@ -12,6 +12,7 @@ class TestAuditAPITimeseriesViewSet:
     def test_authentication_is_required_when_app_mode_cms(
         self,
         spy_permissions_is_authenticated: mock.MagicMock,
+        monkeypatch,
     ):
         """
         Given the application is running with an APP_MODE of `CMS_ADMIN`
@@ -19,15 +20,15 @@ class TestAuditAPITimeseriesViewSet:
         Then rest_frameworks's `IsAuthenticated()` will be called.
         """
         # Given
-        config.APP_MODE = "CMS_ADMIN"
-        audit_api_timeseries_viewset = AuditAPITimeSeriesViewSet()
+        with monkeypatch.context() as m:
+            m.setattr(target=config, name="APP_MODE", value="CMS_ADMIN")
+            audit_api_timeseries_viewset = AuditAPITimeSeriesViewSet()
 
-        # When
-        audit_api_timeseries_viewset.get_permissions()
+            # When
+            audit_api_timeseries_viewset.get_permissions()
 
         # Then
         spy_permissions_is_authenticated.assert_called_once()
-        config.APP_MODE = ""
 
     def test_sets_no_api_key_restrictions(self):
         """

--- a/tests/unit/metrics/api/views/audit/test_audit_api_timeseries.py
+++ b/tests/unit/metrics/api/views/audit/test_audit_api_timeseries.py
@@ -1,11 +1,34 @@
 from unittest import mock
 import pytest
+from rest_framework import permissions
 
+import config
 from metrics.api.views.audit.audit_api_timeseries import AuditAPITimeSeriesViewSet
 from metrics.data.managers.api_models.time_series import APITimeSeriesQuerySet
 
 
 class TestAuditAPITimeseriesViewSet:
+    @mock.patch.object(permissions, "IsAuthenticated")
+    def test_authentication_is_required_when_app_mode_cms(
+        self,
+        spy_permissions_is_authenticated: mock.MagicMock,
+    ):
+        """
+        Given the application is running with an APP_MODE of `CMS_ADMIN`
+        When `get_permissions()` is called from the API timeseries view set
+        Then rest_frameworks's `IsAuthenticated()` will be called.
+        """
+        # Given
+        config.APP_MODE = "CMS_ADMIN"
+        audit_api_timeseries_viewset = AuditAPITimeSeriesViewSet()
+
+        # When
+        audit_api_timeseries_viewset.get_permissions()
+
+        # Then
+        spy_permissions_is_authenticated.assert_called_once()
+        config.APP_MODE = ""
+
     def test_sets_no_api_key_restrictions(self):
         """
         Given an instance of the `AuditAPITimeseriesViewSet`

--- a/tests/unit/metrics/api/views/audit/test_audit_core_headline.py
+++ b/tests/unit/metrics/api/views/audit/test_audit_core_headline.py
@@ -1,11 +1,34 @@
 from unittest import mock
 import pytest
+from rest_framework import permissions
 
+import config
 from metrics.api.views.audit.audit_core_headline import AuditCoreHeadlineViewSet
 from metrics.data.managers.core_models.headline import CoreHeadlineQuerySet
 
 
 class TestAuditCoreHeadlineViewSet:
+    @mock.patch.object(permissions, "IsAuthenticated")
+    def test_authentication_is_required_when_app_mode_cms_admin(
+        self,
+        spy_permissions_is_authenticated: mock.MagicMock,
+    ):
+        """
+        Given the application is running with an APP_MODE of `CMS_ADMIN`
+        When `get_permissions()` is called from the Core headline view set
+        Then rest_frameworks's `IsAuthenticated()` will be called.
+        """
+        # Given
+        config.APP_MODE = "CMS_ADMIN"
+        audit_core_headline_viewset = AuditCoreHeadlineViewSet()
+
+        # When
+        audit_core_headline_viewset.get_permissions()
+
+        # Then
+        spy_permissions_is_authenticated.assert_called_once()
+        config.APP_MODE = ""
+
     def test_sets_no_api_key_restrictions(self):
         """
         Given an instance of the `AuditCoreTimeseriesViewSet`

--- a/tests/unit/metrics/api/views/audit/test_audit_core_headline.py
+++ b/tests/unit/metrics/api/views/audit/test_audit_core_headline.py
@@ -12,6 +12,7 @@ class TestAuditCoreHeadlineViewSet:
     def test_authentication_is_required_when_app_mode_cms_admin(
         self,
         spy_permissions_is_authenticated: mock.MagicMock,
+        monkeypatch,
     ):
         """
         Given the application is running with an APP_MODE of `CMS_ADMIN`
@@ -19,15 +20,15 @@ class TestAuditCoreHeadlineViewSet:
         Then rest_frameworks's `IsAuthenticated()` will be called.
         """
         # Given
-        config.APP_MODE = "CMS_ADMIN"
-        audit_core_headline_viewset = AuditCoreHeadlineViewSet()
+        with monkeypatch.context() as m:
+            m.setattr(target=config, name="APP_MODE", value="CMS_ADMIN")
+            audit_core_headline_viewset = AuditCoreHeadlineViewSet()
 
-        # When
-        audit_core_headline_viewset.get_permissions()
+            # When
+            audit_core_headline_viewset.get_permissions()
 
         # Then
         spy_permissions_is_authenticated.assert_called_once()
-        config.APP_MODE = ""
 
     def test_sets_no_api_key_restrictions(self):
         """

--- a/tests/unit/metrics/api/views/audit/test_audit_core_timeseries.py
+++ b/tests/unit/metrics/api/views/audit/test_audit_core_timeseries.py
@@ -1,11 +1,34 @@
 from unittest import mock
 import pytest
+from rest_framework import permissions
 
+import config
 from metrics.api.views.audit.audit_core_timeseries import AuditCoreTimeseriesViewSet
 from metrics.data.managers.core_models.time_series import CoreTimeSeriesQuerySet
 
 
 class TestAuditCoreTimeseriesViewSet:
+    @mock.patch.object(permissions, "IsAuthenticated")
+    def test_authentication_is_required_when_app_mode_cms_admin(
+        self,
+        spy_permissions_is_authenticated: mock.MagicMock,
+    ):
+        """
+        Given the application is running with an APP_MODE of `CMS_ADMIN`
+        When `get_permission()` is called from the Core timeseries view set
+        Then rest_framework's `IsAuthenticated()` will be called.
+        """
+        # Given
+        config.APP_MODE = "CMS_ADMIN"
+        audit_core_timeseries_viewset = AuditCoreTimeseriesViewSet()
+
+        # When
+        audit_core_timeseries_viewset.get_permissions()
+
+        # Then
+        spy_permissions_is_authenticated.assert_called_once()
+        config.APP_MODE = ""
+
     def test_sets_no_api_key_restrictions(self):
         """
         Given an instance of the `AuditCoreTimeseriesViewSet`

--- a/tests/unit/metrics/api/views/audit/test_audit_core_timeseries.py
+++ b/tests/unit/metrics/api/views/audit/test_audit_core_timeseries.py
@@ -12,6 +12,7 @@ class TestAuditCoreTimeseriesViewSet:
     def test_authentication_is_required_when_app_mode_cms_admin(
         self,
         spy_permissions_is_authenticated: mock.MagicMock,
+        monkeypatch,
     ):
         """
         Given the application is running with an APP_MODE of `CMS_ADMIN`
@@ -19,15 +20,15 @@ class TestAuditCoreTimeseriesViewSet:
         Then rest_framework's `IsAuthenticated()` will be called.
         """
         # Given
-        config.APP_MODE = "CMS_ADMIN"
-        audit_core_timeseries_viewset = AuditCoreTimeseriesViewSet()
+        with monkeypatch.context() as m:
+            m.setattr(target=config, name="APP_MODE", value="CMS_ADMIN")
+            audit_core_timeseries_viewset = AuditCoreTimeseriesViewSet()
 
-        # When
-        audit_core_timeseries_viewset.get_permissions()
+            # When
+            audit_core_timeseries_viewset.get_permissions()
 
         # Then
         spy_permissions_is_authenticated.assert_called_once()
-        config.APP_MODE = ""
 
     def test_sets_no_api_key_restrictions(self):
         """


### PR DESCRIPTION
# Description

This PR includes and update to the audit endpoints, moving them to the cms admin app mode and adding in a permissions check so that users can only make requests to these endpoints if they are logged in as an admin user.


Fixes #CDD-2326

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [x] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
