### PR TITLE
Return geographies in descending alphabetical order, grouped by geography type then by georgaphy name

### DIFF
--- a/metrics/data/managers/core_models/time_series.py
+++ b/metrics/data/managers/core_models/time_series.py
@@ -426,7 +426,7 @@ class CoreTimeSeriesQuerySet(models.QuerySet):
             .values_list(
                 "geography__name", "geography__geography_type__name", named=True
             )
-            .order_by("geography__geography_type")
+            .order_by("geography__geography_type__name", "geography__name")
             .distinct()
         )
 


### PR DESCRIPTION
# Description

This PR includes the following:

- Returns the geographies given in the area selector in descending alphabetical order

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
