### PR TITLE
Add `x_axis_title` and `y_axis_title` to charts API as optional fields

### DIFF
--- a/metrics/api/serializers/charts.py
+++ b/metrics/api/serializers/charts.py
@@ -94,6 +94,13 @@ class ChartsSerializer(serializers.Serializer):
         help_text=help_texts.CHART_X_AXIS,
         default=DEFAULT_X_AXIS,
     )
+    x_axis_title = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        default="",
+        help_text=help_texts.CHART_X_AXIS_TITLE,
+    )
     y_axis = serializers.ChoiceField(
         choices=ChartAxisFields.choices(),
         required=False,
@@ -101,6 +108,13 @@ class ChartsSerializer(serializers.Serializer):
         allow_null=True,
         help_text=help_texts.CHART_Y_AXIS,
         default=DEFAULT_Y_AXIS,
+    )
+    y_axis_title = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        default="",
+        help_text=help_texts.CHART_X_AXIS_TITLE,
     )
 
     plots = ChartPlotsListSerializer()
@@ -120,6 +134,8 @@ class ChartsSerializer(serializers.Serializer):
             chart_width=self.data["chart_width"] or DEFAULT_CHART_WIDTH,
             x_axis=x_axis,
             y_axis=y_axis,
+            x_axis_title=self.data.get("x_axis_title", ""),
+            y_axis_title=self.data.get("y_axis_title", ""),
         )
 
 

--- a/metrics/api/serializers/charts.py
+++ b/metrics/api/serializers/charts.py
@@ -114,7 +114,7 @@ class ChartsSerializer(serializers.Serializer):
         allow_blank=True,
         allow_null=True,
         default="",
-        help_text=help_texts.CHART_X_AXIS_TITLE,
+        help_text=help_texts.CHART_Y_AXIS_TITLE,
     )
 
     plots = ChartPlotsListSerializer()

--- a/metrics/api/serializers/help_texts.py
+++ b/metrics/api/serializers/help_texts.py
@@ -86,10 +86,16 @@ TABLES_RESPONSE: str = """
 The specified plots in a tabular format
 """
 CHART_X_AXIS: str = """
-The metric to use along the X Axis of the chart
+The metric to use along the X axis of the chart
+"""
+CHART_X_AXIS_TITLE: str = """
+An optional title to display along the X axis of the chart
 """
 CHART_Y_AXIS: str = """
 The metric to use along the Y Axis of the chart
+"""
+CHART_Y_AXIS_TITLE: str = """
+An optional title to display along the Y axis of the chart
 """
 ENCODED_CHARTS_RESPONSE: str = """
 The specified chart in the requested format as a URI encoded string (default format = svg)

--- a/metrics/api/views/charts.py
+++ b/metrics/api/views/charts.py
@@ -115,6 +115,18 @@ class ChartsView(APIView):
 
         `y_axis` Example: `y_axis: "stratum"`
 
+        ---
+
+        # Choosing what to display as the x and/or y axis titles
+
+        By default, nothing will be displayed on the x axis or y axis titles.
+        If you want to override either/both of these values then you can do so as follows:
+
+        `x_axis_title` Example: `x_axis_title: "Dates"`
+
+        `y_axis_title` Example: `y_axis_title: "Number of cases"`
+
+
         """
         request_serializer = ChartsSerializer(data=request.data)
         request_serializer.is_valid(raise_exception=True)
@@ -228,6 +240,17 @@ class EncodedChartsView(APIView):
         `x_axis` Example: `x_axis: "stratum"`
 
         `y_axis` Example: `y_axis: "stratum"`
+
+        ---
+
+        # Choosing what to display as the x and/or y axis titles
+
+        By default, nothing will be displayed on the x axis or y axis titles.
+        If you want to override either/both of these values then you can do so as follows:
+
+        `x_axis_title` Example: `x_axis_title: "Dates"`
+
+        `y_axis_title` Example: `y_axis_title: "Number of cases"`
 
         """
         request_serializer = EncodedChartsRequestSerializer(data=request.data)


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds the `x_axis_title` and `y_axis_title` fields to the Charts API

Fixes #CDD-2336

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
