### PR TITLE
Add chart axes titles to cache crawler

### DIFF
--- a/caching/private_api/crawler/request_payload_builder.py
+++ b/caching/private_api/crawler/request_payload_builder.py
@@ -77,6 +77,8 @@ class RequestPayloadBuilder:
             "chart_height": 260,
             "x_axis": chart_block.get("x_axis", ""),
             "y_axis": chart_block.get("y_axis", ""),
+            "x_axis_title": chart_block.get("x_axis_title", ""),
+            "y_axis_title": chart_block.get("y_axis_title", ""),
         }
 
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,6 +240,8 @@ def example_chart_block() -> dict[str, str | list[dict]]:
         "body": "Age breakdown of people admitted to hospital.",
         "x_axis": "stratum",
         "y_axis": "metric",
+        "x_axis_title": "Age",
+        "y_axis_title": "Admissions",
         "chart": [
             {
                 "type": "plot",

--- a/tests/unit/caching/private_api/crawler/test_request_payload_builder.py
+++ b/tests/unit/caching/private_api/crawler/test_request_payload_builder.py
@@ -151,6 +151,8 @@ class TestRequestPayloadBuilder:
             "chart_height": 260,
             "x_axis": chart_block_data["x_axis"],
             "y_axis": chart_block_data["y_axis"],
+            "x_axis_title": chart_block_data["x_axis_title"],
+            "y_axis_title": chart_block_data["y_axis_title"],
         }
         assert chart_request_data == expected_chart_request_data
 


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds the chart axes titles in the cache crawler

Fixes #CDD-2336

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
