### PR TITLE
Task/use axes titles on tables if available/cdd 2336

### DIFF
--- a/caching/private_api/crawler/request_payload_builder.py
+++ b/caching/private_api/crawler/request_payload_builder.py
@@ -77,6 +77,8 @@ class RequestPayloadBuilder:
             "chart_height": 260,
             "x_axis": chart_block.get("x_axis", ""),
             "y_axis": chart_block.get("y_axis", ""),
+            "x_axis_title": chart_block.get("x_axis_title", ""),
+            "y_axis_title": chart_block.get("y_axis_title", ""),
         }
 
     @classmethod

--- a/metrics/api/serializers/charts.py
+++ b/metrics/api/serializers/charts.py
@@ -94,6 +94,13 @@ class ChartsSerializer(serializers.Serializer):
         help_text=help_texts.CHART_X_AXIS,
         default=DEFAULT_X_AXIS,
     )
+    x_axis_title = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        default="",
+        help_text=help_texts.CHART_X_AXIS_TITLE,
+    )
     y_axis = serializers.ChoiceField(
         choices=ChartAxisFields.choices(),
         required=False,
@@ -101,6 +108,13 @@ class ChartsSerializer(serializers.Serializer):
         allow_null=True,
         help_text=help_texts.CHART_Y_AXIS,
         default=DEFAULT_Y_AXIS,
+    )
+    y_axis_title = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        default="",
+        help_text=help_texts.CHART_X_AXIS_TITLE,
     )
 
     plots = ChartPlotsListSerializer()
@@ -120,6 +134,8 @@ class ChartsSerializer(serializers.Serializer):
             chart_width=self.data["chart_width"] or DEFAULT_CHART_WIDTH,
             x_axis=x_axis,
             y_axis=y_axis,
+            x_axis_title=self.data.get("x_axis_title", ""),
+            y_axis_title=self.data.get("y_axis_title", ""),
         )
 
 

--- a/metrics/api/serializers/help_texts.py
+++ b/metrics/api/serializers/help_texts.py
@@ -86,10 +86,16 @@ TABLES_RESPONSE: str = """
 The specified plots in a tabular format
 """
 CHART_X_AXIS: str = """
-The metric to use along the X Axis of the chart
+The metric to use along the X axis of the chart
+"""
+CHART_X_AXIS_TITLE: str = """
+An optional title to display along the X axis of the chart
 """
 CHART_Y_AXIS: str = """
 The metric to use along the Y Axis of the chart
+"""
+CHART_Y_AXIS_TITLE: str = """
+An optional title to display along the Y axis of the chart
 """
 ENCODED_CHARTS_RESPONSE: str = """
 The specified chart in the requested format as a URI encoded string (default format = svg)

--- a/metrics/api/serializers/tables.py
+++ b/metrics/api/serializers/tables.py
@@ -46,6 +46,13 @@ class TablesSerializer(serializers.Serializer):
         help_text=help_texts.CHART_X_AXIS,
         default=DEFAULT_X_AXIS,
     )
+    x_axis_title = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        default="",
+        help_text=help_texts.CHART_X_AXIS_TITLE,
+    )
     y_axis = serializers.ChoiceField(
         choices=ChartAxisFields.choices(),
         required=False,
@@ -53,6 +60,13 @@ class TablesSerializer(serializers.Serializer):
         allow_null=True,
         help_text=help_texts.CHART_Y_AXIS,
         default=DEFAULT_Y_AXIS,
+    )
+    y_axis_title = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+        default="",
+        help_text=help_texts.CHART_X_AXIS_TITLE,
     )
 
     def __init__(self, *args, **kwargs):
@@ -66,7 +80,9 @@ class TablesSerializer(serializers.Serializer):
             chart_height=DEFAULT_CHART_HEIGHT,
             chart_width=DEFAULT_CHART_WIDTH,
             x_axis=self.data.get("x_axis") or DEFAULT_X_AXIS,
+            x_axis_title=self.data.get("x_axis_title", ""),
             y_axis=self.data.get("y_axis") or DEFAULT_Y_AXIS,
+            y_axis_title=self.data.get("y_axis_title", ""),
         )
 
 

--- a/metrics/api/views/charts.py
+++ b/metrics/api/views/charts.py
@@ -115,6 +115,18 @@ class ChartsView(APIView):
 
         `y_axis` Example: `y_axis: "stratum"`
 
+        ---
+
+        # Choosing what to display as the x and/or y axis titles
+
+        By default, nothing will be displayed on the x axis or y axis titles.
+        If you want to override either/both of these values then you can do so as follows:
+
+        `x_axis_title` Example: `x_axis_title: "Dates"`
+
+        `y_axis_title` Example: `y_axis_title: "Number of cases"`
+
+
         """
         request_serializer = ChartsSerializer(data=request.data)
         request_serializer.is_valid(raise_exception=True)
@@ -228,6 +240,17 @@ class EncodedChartsView(APIView):
         `x_axis` Example: `x_axis: "stratum"`
 
         `y_axis` Example: `y_axis: "stratum"`
+
+        ---
+
+        # Choosing what to display as the x and/or y axis titles
+
+        By default, nothing will be displayed on the x axis or y axis titles.
+        If you want to override either/both of these values then you can do so as follows:
+
+        `x_axis_title` Example: `x_axis_title: "Dates"`
+
+        `y_axis_title` Example: `y_axis_title: "Number of cases"`
 
         """
         request_serializer = EncodedChartsRequestSerializer(data=request.data)

--- a/metrics/api/views/tables.py
+++ b/metrics/api/views/tables.py
@@ -6,6 +6,7 @@ from rest_framework.views import APIView
 
 from caching.private_api.decorators import cache_response
 from metrics.api.serializers.tables import TablesResponseSerializer, TablesSerializer
+from metrics.domain.models import ChartRequestParams
 from metrics.interfaces.plots.access import (
     DataNotFoundForAnyPlotError,
     InvalidPlotParametersError,
@@ -90,11 +91,11 @@ class TablesView(APIView):
         request_serializer = TablesSerializer(data=request.data)
         request_serializer.is_valid(raise_exception=True)
 
-        plots_collection = request_serializer.to_models()
+        chart_request_params: ChartRequestParams = request_serializer.to_models()
 
         try:
             tabular_data: list[dict[str, str]] = access.generate_table_for_full_plots(
-                plots_collection=plots_collection
+                chart_request_params=chart_request_params
             )
         except (InvalidPlotParametersError, DataNotFoundForAnyPlotError) as error:
             return Response(

--- a/metrics/domain/charts/chart_settings.py
+++ b/metrics/domain/charts/chart_settings.py
@@ -36,6 +36,7 @@ class ChartSettings:
         return isinstance(self.plots_data[0].x_axis_values[0], datetime.date)
 
     def get_x_axis_config(self) -> dict[str, str | bool | DICT_OF_STR_ONLY]:
+        tick_font = self.get_tick_font_config()
         base_x_axis_config = {
             "showspikes": True,
             "spikecolor": "#b1b4b6",
@@ -57,6 +58,12 @@ class ChartSettings:
             "tickfont": self.get_tick_font_config(),
         }
 
+        if self._chart_generation_payload.x_axis_title:
+            base_x_axis_config["title"] = {
+                "text": self._chart_generation_payload.x_axis_title,
+                "font": tick_font,
+            }
+
         x_axis_type_config = (
             self.get_x_axis_date_type()
             if self.is_date_type_x_axis
@@ -66,7 +73,8 @@ class ChartSettings:
         return {**base_x_axis_config, **x_axis_type_config}
 
     def get_y_axis_config(self) -> dict[str, bool | DICT_OF_STR_ONLY]:
-        return {
+        tick_font = self.get_tick_font_config()
+        base_y_axis_config = {
             "ticks": "outside",
             "tickson": "boundaries",
             "tickcolor": "rgba(0,0,0,0)",
@@ -74,9 +82,17 @@ class ChartSettings:
             "showticklabels": True,
             "fixedrange": True,
             "gridcolor": "#000",
-            "tickfont": self.get_tick_font_config(),
+            "tickfont": tick_font,
             "rangemode": "tozero",
         }
+
+        if self._chart_generation_payload.y_axis_title:
+            base_y_axis_config["title"] = {
+                "text": self._chart_generation_payload.y_axis_title,
+                "font": tick_font,
+            }
+
+        return base_y_axis_config
 
     def get_base_chart_config(self):
         return {

--- a/metrics/domain/tables/generation.py
+++ b/metrics/domain/tables/generation.py
@@ -7,7 +7,6 @@ from metrics.domain.common.utils import (
     DataSourceFileType,
     extract_metric_group_from_metric,
 )
-from metrics.domain.models import ChartRequestParams
 
 IN_REPORTING_DELAY_PERIOD = "in_reporting_delay_period"
 
@@ -22,7 +21,7 @@ class TabularData:
         self,
         *,
         plots: list["PlotGenerationData"],
-        chart_request_params: ChartRequestParams,
+        chart_request_params: "ChartRequestParams",
     ):
         self.chart_request_params = chart_request_params
         self.plots = plots

--- a/metrics/domain/tables/generation.py
+++ b/metrics/domain/tables/generation.py
@@ -7,6 +7,7 @@ from metrics.domain.common.utils import (
     DataSourceFileType,
     extract_metric_group_from_metric,
 )
+from metrics.domain.models import ChartRequestParams
 
 IN_REPORTING_DELAY_PERIOD = "in_reporting_delay_period"
 
@@ -17,7 +18,13 @@ DEFAULT_PLOT_LABEL = "Plot"
 
 
 class TabularData:
-    def __init__(self, *, plots: list["PlotGenerationData"]):
+    def __init__(
+        self,
+        *,
+        plots: list["PlotGenerationData"],
+        chart_request_params: ChartRequestParams,
+    ):
+        self.chart_request_params = chart_request_params
         self.plots = plots
         self.metric_group = extract_metric_group_from_metric(
             metric=self.plots[0].parameters.metric
@@ -73,7 +80,8 @@ class TabularData:
         in_reporting_delay_period_lookup = in_reporting_delay_period_lookup or {}
 
         for key, value in plot_data.items():
-            result = {plot_label: str(value)}
+            label = plot_label or self.chart_request_params.x_axis_title
+            result = {label: str(value)}
             in_reporting_delay_period_value = self._fetch_reporting_delay_period(
                 in_reporting_delay_period_lookup=in_reporting_delay_period_lookup,
                 key=key,

--- a/metrics/interfaces/tables/access.py
+++ b/metrics/interfaces/tables/access.py
@@ -18,18 +18,18 @@ class TablesInterface:
     def __init__(
         self,
         *,
-        plots_collection: ChartRequestParams,
+        chart_request_params: ChartRequestParams,
         core_model_manager: CORE_MODEL_MANAGER_TYPE | None = None,
         plots_interface: PlotsInterface | None = None,
     ):
-        self.plots_collection = plots_collection
+        self.chart_request_params = chart_request_params
         self.metric_group = extract_metric_group_from_metric(
-            metric=self.plots_collection.plots[0].metric
+            metric=self.chart_request_params.plots[0].metric
         )
         self.core_model_manager = core_model_manager or self._get_core_model_manager()
 
         self.plots_interface = plots_interface or PlotsInterface(
-            chart_request_params=self.plots_collection,
+            chart_request_params=self.chart_request_params,
             core_model_manager=self.core_model_manager,
         )
 
@@ -53,7 +53,7 @@ class TablesInterface:
 
     def _build_tabular_data_from_plots_data(self) -> TabularData:
         plots = self.plots_interface.build_plots_data()
-        return TabularData(plots=plots)
+        return TabularData(plots=plots, chart_request_params=self.chart_request_params)
 
     def generate_full_plots_for_table(self) -> list[dict[str, str]]:
         """Create a list of plots from the request
@@ -78,7 +78,7 @@ class TablesInterface:
 
 def generate_table_for_full_plots(
     *,
-    plots_collection: ChartRequestParams,
+    chart_request_params: ChartRequestParams,
 ) -> list[dict[str, str]]:
     """Validates and creates tabular output based off the parameters provided within the `plots_collection` model
 
@@ -88,7 +88,7 @@ def generate_table_for_full_plots(
         then 365 data points will be returned in the output.
 
     Args:
-        plots_collection: The requested table plots parameters
+        chart_request_params: The requested table plots parameters
             encapsulated as a model
 
     Returns:
@@ -105,6 +105,6 @@ def generate_table_for_full_plots(
             returned any data from the underlying queries
     """
     tables_interface = TablesInterface(
-        plots_collection=plots_collection,
+        chart_request_params=chart_request_params,
     )
     return tables_interface.generate_full_plots_for_table()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,6 +240,8 @@ def example_chart_block() -> dict[str, str | list[dict]]:
         "body": "Age breakdown of people admitted to hospital.",
         "x_axis": "stratum",
         "y_axis": "metric",
+        "x_axis_title": "Age",
+        "y_axis_title": "Admissions",
         "chart": [
             {
                 "type": "plot",

--- a/tests/unit/caching/private_api/crawler/test_request_payload_builder.py
+++ b/tests/unit/caching/private_api/crawler/test_request_payload_builder.py
@@ -151,6 +151,8 @@ class TestRequestPayloadBuilder:
             "chart_height": 260,
             "x_axis": chart_block_data["x_axis"],
             "y_axis": chart_block_data["y_axis"],
+            "x_axis_title": chart_block_data["x_axis_title"],
+            "y_axis_title": chart_block_data["y_axis_title"],
         }
         assert chart_request_data == expected_chart_request_data
 

--- a/tests/unit/metrics/domain/charts/test_chart_settings.py
+++ b/tests/unit/metrics/domain/charts/test_chart_settings.py
@@ -19,8 +19,8 @@ def fake_chart_settings(fake_plot_data: PlotGenerationData) -> ChartSettings:
         chart_width=930,
         chart_height=220,
         plots=[fake_plot_data],
-        x_axis_title="",
-        y_axis_title="",
+        x_axis_title="Date",
+        y_axis_title="Cases",
     )
     return ChartSettings(chart_generation_payload=payload)
 
@@ -80,6 +80,10 @@ class TestChartSettings:
             "dtick": "M1",
             "tickformat": "%b %Y",
             "tickfont": chart_settings.get_tick_font_config(),
+            "title": {
+                "font": chart_settings.get_tick_font_config(),
+                "text": chart_settings._chart_generation_payload.x_axis_title,
+            },
         }
         expected_x_axis_config = {
             **expected_x_axis_config,
@@ -126,6 +130,10 @@ class TestChartSettings:
             "dtick": None,
             "tickformat": None,
             "tickfont": chart_settings.get_tick_font_config(),
+            "title": {
+                "font": chart_settings.get_tick_font_config(),
+                "text": chart_settings._chart_generation_payload.x_axis_title,
+            },
         }
         assert x_axis_config == expected_x_axis_config
 
@@ -152,6 +160,10 @@ class TestChartSettings:
             "tickson": "boundaries",
             "tickcolor": "rgba(0,0,0,0)",
             "tickfont": chart_settings.get_tick_font_config(),
+            "title": {
+                "font": chart_settings.get_tick_font_config(),
+                "text": chart_settings._chart_generation_payload.y_axis_title,
+            },
         }
         assert y_axis_config == expected_y_axis_config
 

--- a/tests/unit/metrics/domain/tables/test_tables_generation.py
+++ b/tests/unit/metrics/domain/tables/test_tables_generation.py
@@ -1,5 +1,6 @@
 import datetime
 from typing import Any
+from unittest import mock
 
 import pytest
 
@@ -61,7 +62,9 @@ class TestTabularData:
         """
         # Given
         fake_plot_data.parameters.x_axis = x_axis
-        tabular_data = TabularData(plots=[fake_plot_data])
+        tabular_data = TabularData(
+            plots=[fake_plot_data], chart_request_params=mock.Mock()
+        )
 
         # When
         is_date_based: bool = tabular_data._is_date_based
@@ -80,7 +83,9 @@ class TestTabularData:
         """
         # Given
         fake_plot_data.parameters.x_axis = ChartAxisFields.date.name
-        tabular_data = TabularData(plots=[fake_plot_data])
+        tabular_data = TabularData(
+            plots=[fake_plot_data], chart_request_params=mock.Mock()
+        )
 
         # When
         is_date_based: bool = tabular_data._is_date_based
@@ -110,7 +115,9 @@ class TestTabularData:
             x_axis_values=dates_x_axis_values_in_ascending_order,
             y_axis_values=y_axis_values,
         )
-        tabular_data = TabularData(plots=[original_plot_data])
+        tabular_data = TabularData(
+            plots=[original_plot_data], chart_request_params=mock.Mock()
+        )
         plot_data = dict(
             zip(original_plot_data.x_axis_values, original_plot_data.y_axis_values)
         )
@@ -168,7 +175,9 @@ class TestTabularData:
                 "in_reporting_delay_period": [False for _ in range(len(y_axis_values))]
             },
         )
-        tabular_data = TabularData(plots=[earlier_plot_data, later_plot_data])
+        tabular_data = TabularData(
+            plots=[earlier_plot_data, later_plot_data], chart_request_params=mock.Mock()
+        )
 
         # When
         tabular_plots = tabular_data.create_tabular_plots()
@@ -273,7 +282,10 @@ class TestTabularData:
             x_axis_values=complete_dates_x_axis_values_in_ascending_order,
             y_axis_values=y_axis_values,
         )
-        tabular_data = TabularData(plots=[incomplete_plot_data, complete_plot_data])
+        tabular_data = TabularData(
+            plots=[incomplete_plot_data, complete_plot_data],
+            chart_request_params=mock.Mock(),
+        )
 
         # When
         tabular_plots = tabular_data.create_tabular_plots()
@@ -381,7 +393,7 @@ class TestAddPlotDataToCombinedPlots:
         }
 
         # When
-        tabular_data = TabularData(plots=[plot_data])
+        tabular_data = TabularData(plots=[plot_data], chart_request_params=mock.Mock())
         tabular_data.add_plot_data_to_combined_plots(
             plot_data=first_chart_plots_data,
             plot_label=PLOT_1_LABEL,
@@ -419,7 +431,7 @@ class TestAddPlotDataToCombinedPlots:
         }
 
         # When
-        tabular_data = TabularData(plots=[plot_data])
+        tabular_data = TabularData(plots=[plot_data], chart_request_params=mock.Mock())
 
         tabular_data.add_plot_data_to_combined_plots(
             plot_data=first_chart_plots_data,
@@ -455,7 +467,9 @@ class TestCombineAllPlots:
         )
 
         # When
-        tabular_data = TabularData(plots=[first_chart_plots_data])
+        tabular_data = TabularData(
+            plots=[first_chart_plots_data], chart_request_params=mock.Mock()
+        )
         tabular_data.combine_all_plots()
 
         # Then
@@ -553,7 +567,7 @@ class TestCreateMultiPlotOutput:
         )
 
         # When
-        tabular_data = TabularData(plots=[plot_data])
+        tabular_data = TabularData(plots=[plot_data], chart_request_params=mock.Mock())
         tabular_data.plot_labels = plot_labels
         tabular_data.combined_plots = combined_plots
         tabular_data.column_heading = "date"
@@ -646,7 +660,7 @@ class TestCreateMultiPlotOutput:
         )
 
         # When
-        tabular_data = TabularData(plots=[plot_data])
+        tabular_data = TabularData(plots=[plot_data], chart_request_params=mock.Mock())
         tabular_data.plot_labels = plot_labels
         tabular_data.combined_plots = combined_plots
         tabular_data.column_heading = "date"
@@ -709,7 +723,7 @@ class TestCreateMultiPlotOutput:
         )
 
         # When
-        tabular_data = TabularData(plots=[plot_data])
+        tabular_data = TabularData(plots=[plot_data], chart_request_params=mock.Mock())
         tabular_data.plot_labels = plot_labels
         tabular_data.combined_plots = combined_plots
         actual_output = tabular_data.create_multi_plot_output()

--- a/tests/unit/metrics/interfaces/tables/test_access.py
+++ b/tests/unit/metrics/interfaces/tables/test_access.py
@@ -48,7 +48,7 @@ class TestTablesInterface:
 
         # When
         tables_interface = TablesInterface(
-            plots_collection=fake_chart_request_params,
+            chart_request_params=fake_chart_request_params,
             core_model_manager=mocked_core_time_series_manager,
         )
 
@@ -79,7 +79,7 @@ class TestTablesInterface:
 
         # When
         tables_interface = TablesInterface(
-            plots_collection=fake_chart_request_params,
+            chart_request_params=fake_chart_request_params,
         )
 
         # Then
@@ -116,7 +116,7 @@ class TestTablesInterface:
         )
 
         tables_interface = TablesInterface(
-            plots_collection=plots_collection,
+            chart_request_params=plots_collection,
             core_model_manager=fake_core_time_series_manager,
         )
 
@@ -151,7 +151,7 @@ class TestGenerateTableForFullPlots:
         plots_collection = fake_chart_request_params
 
         # When
-        table = generate_table_for_full_plots(plots_collection=plots_collection)
+        table = generate_table_for_full_plots(chart_request_params=plots_collection)
 
         # Then
         assert table == spy_generate_full_plots_for_table.return_value


### PR DESCRIPTION
# Description

This PR includes the following:

- Passes the enriched `ChartRequestParams` model into the tables interface. There's no functional change here but it prepares us to be able to apply chart axes titles as the column headers

Fixes #CDD-2336

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
