### PR TITLE
Write static v2 charts to `tmp/` dir so that they are written into mounted volume

### DIFF
--- a/metrics/interfaces/charts/access.py
+++ b/metrics/interfaces/charts/access.py
@@ -1,7 +1,7 @@
-import pathlib
 import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import Path
 
 import plotly.graph_objects
 from django.db.models import Manager
@@ -540,7 +540,7 @@ def generate_chart_as_file(*, chart_request_params: ChartRequestParams) -> str:
     charts_interface = ChartsInterface(chart_request_params=chart_request_params)
     chart_output: ChartOutput = charts_interface.generate_chart_output()
 
-    pathlib.Path.mkdir("tmp", exist_ok=True)
+    Path("tmp").mkdir(exist_ok=True)
     return charts_interface.write_figure(figure=chart_output.figure)
 
 

--- a/metrics/interfaces/charts/access.py
+++ b/metrics/interfaces/charts/access.py
@@ -1,3 +1,4 @@
+import pathlib
 import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime
@@ -471,7 +472,7 @@ class ChartsInterface:
             The filename of the image
 
         """
-        filename = f"new_chart.{self.chart_request_params.file_format}"
+        filename = f"tmp/new_chart.{self.chart_request_params.file_format}"
         figure.write_image(
             file=filename,
             format=self.chart_request_params.file_format,
@@ -539,6 +540,7 @@ def generate_chart_as_file(*, chart_request_params: ChartRequestParams) -> str:
     charts_interface = ChartsInterface(chart_request_params=chart_request_params)
     chart_output: ChartOutput = charts_interface.generate_chart_output()
 
+    pathlib.Path.mkdir("tmp", exist_ok=True)
     return charts_interface.write_figure(figure=chart_output.figure)
 
 


### PR DESCRIPTION
# Description

This PR includes the following:

- Write the v2 static charts (which is only used for debugging) to the `tmp/` dir. This is so that in the deployed envs the chart is written to a writable location. Note that this API already cleans up the file after. 

---

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
