### PR TITLE
Use `DummyCache` to prevent caching for `local` development settings

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -16,6 +16,7 @@ This configures the application to run under a set of assumptions.
 
 If this is set to `LOCAL`, then a local sqlite database will be used 
 and the underlying `DEBUG` setting will be set to True.
+The cache is also swapped out in this setting, so **none of the endpoints are cached.**
 
 ##### `APIENV=STANDALONE`
 

--- a/metrics/api/settings/local.py
+++ b/metrics/api/settings/local.py
@@ -11,3 +11,9 @@ DATABASES = {
         "NAME": os.path.join(ROOT_LEVEL_BASE_DIR, "db.sqlite3"),
     }
 }
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+    }
+}


### PR DESCRIPTION
# Description

This PR includes the following:

- Drops the local memory cache for `local` env settings, to make local development easier to see changes with a local FE.
- To enable this in your local env, set the `APIENV` environment variable to `LOCAL` 

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
