### PR TITLE
Use dummy cache when `AUTH_ENABLED` env var is set to true

### DIFF
--- a/metrics/api/settings/private_api.py
+++ b/metrics/api/settings/private_api.py
@@ -2,7 +2,9 @@ import os
 
 import config
 
-if os.environ.get("AUTH_ENABLED"):
+AUTH_ENABLED: bool = os.environ.get("AUTH_ENABLED", "").lower() in {"true", "1"}
+
+if AUTH_ENABLED:
     CACHES = {
         "default": {
             "BACKEND": "django.core.cache.backends.dummy.DummyCache",

--- a/metrics/api/settings/private_api.py
+++ b/metrics/api/settings/private_api.py
@@ -2,7 +2,7 @@ import os
 
 import config
 
-if os.environ.get("AUTH_ENABLED", False):
+if os.environ.get("AUTH_ENABLED"):
     CACHES = {
         "default": {
             "BACKEND": "django.core.cache.backends.dummy.DummyCache",

--- a/metrics/api/settings/private_api.py
+++ b/metrics/api/settings/private_api.py
@@ -1,10 +1,18 @@
+import os
+
 import config
 
-# Only use the configured Redis cache when the application is running in private API mode
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.redis.RedisCache",
-        "LOCATION": config.REDIS_HOST,
-        "KEY_PREFIX": "ukhsa",
+if os.environ.get("AUTH_ENABLED"):
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+        }
     }
-}
+else:
+    CACHES = {
+        "default": {
+            "BACKEND": "django.core.cache.backends.redis.RedisCache",
+            "LOCATION": config.REDIS_HOST,
+            "KEY_PREFIX": "ukhsa",
+        }
+    }

--- a/metrics/api/settings/private_api.py
+++ b/metrics/api/settings/private_api.py
@@ -2,7 +2,7 @@ import os
 
 import config
 
-if os.environ.get("AUTH_ENABLED"):
+if os.environ.get("AUTH_ENABLED", False):
     CACHES = {
         "default": {
             "BACKEND": "django.core.cache.backends.dummy.DummyCache",


### PR DESCRIPTION
# Description

This is a bit of temporary fix because a number of our endpoints are cached in redis. Django gives you a dummy cache which gives you the same interface so to save time I'm just going to just swap the redis cache out for a dummy cache. 

This PR includes the following:

- Swaps the redis cache out for a dummy cache in private api mode when `AUTH_ENABLED` is set to true.
Since we'd be relying on the next.js caching system, we should not cache the private API otherwise we'd always be serving stale data.

Fixes #CDD-2428

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
