### PR TITLE
Task/add rest of uk to possible geographies/cdd 1083

### DIFF
--- a/ingestion/data_transfer_models/base.py
+++ b/ingestion/data_transfer_models/base.py
@@ -117,6 +117,7 @@ class IncomingBaseDataModel(BaseModel):
         validation.validate_geography_code(
             geography_code=self.geography_code,
             geography_type=self.geography_type,
+            geography=self.geography,
         )
         return self
 

--- a/ingestion/data_transfer_models/validation/geography_code.py
+++ b/ingestion/data_transfer_models/validation/geography_code.py
@@ -9,13 +9,16 @@ GOVERNMENT_OFFICE_REGION_GEOGRAPHY_CODE_PREFIX = "E12"
 UKHSA_SUPER_REGION_PREFIX = "X2500"
 
 
-def validate_geography_code(*, geography_code: str, geography_type: str) -> str | None:
+def validate_geography_code(
+    *, geography_code: str, geography_type: str, geography: str
+) -> str | None:
     """Validates the `geography_code` value to check it conforms to the accepted format
 
     Args:
         geography_code: The associated geography code being validated
         geography_type: The `geography_type` which was
             included in the payload alongside the `geography_code`
+        geography: The name of the geography to be validated
 
     Returns:
         The input `geography_code` unchanged if
@@ -27,7 +30,10 @@ def validate_geography_code(*, geography_code: str, geography_type: str) -> str 
     """
     match geography_type:
         case enums.GeographyType.NATION.value:
-            return _validate_nation_geography_code(geography_code=geography_code)
+            return _validate_nation_geography_code(
+                geography_code=geography_code,
+                geography=geography,
+            )
         case enums.GeographyType.UPPER_TIER_LOCAL_AUTHORITY.value:
             return _validate_upper_tier_local_authority_geography_code(
                 geography_code=geography_code

--- a/ingestion/data_transfer_models/validation/geography_code.py
+++ b/ingestion/data_transfer_models/validation/geography_code.py
@@ -73,7 +73,8 @@ def validate_geography_code(
             )
         case enums.GeographyType.UNITED_KINGDOM.value:
             return _validate_united_kingdom_geography_code(
-                geography_code=geography_code
+                geography_code=geography_code,
+                geography=geography,
             )
 
 
@@ -194,8 +195,11 @@ def _validate_ukhsa_super_region_geography_code(*, geography_code: str) -> str:
     return geography_code
 
 
-def _validate_united_kingdom_geography_code(*, geography_code: str):
+def _validate_united_kingdom_geography_code(*, geography: str, geography_code: str):
     if geography_code != UNITED_KINGDOM_GEOGRAPHY_CODE:
+        raise ValueError
+
+    if geography != "United Kingdom":
         raise ValueError
 
     return geography_code

--- a/ingestion/data_transfer_models/validation/geography_code.py
+++ b/ingestion/data_transfer_models/validation/geography_code.py
@@ -1,6 +1,6 @@
 from ingestion.utils import enums
 
-NATION_GEOGRAPHY_CODE_PREFIX = "E92"
+UNITED_KINGDOM_GEOGRAPHY_CODE = "K02000001"
 NATION_GEOGRAPHY_CODES = {
     "England": "E92000001",
     "Scotland": "S92000003",
@@ -69,6 +69,10 @@ def validate_geography_code(
             )
         case enums.GeographyType.UKHSA_SUPER_REGION.value:
             return _validate_ukhsa_super_region_geography_code(
+                geography_code=geography_code
+            )
+        case enums.GeographyType.UNITED_KINGDOM.value:
+            return _validate_united_kingdom_geography_code(
                 geography_code=geography_code
             )
 
@@ -185,6 +189,13 @@ def _validate_ukhsa_super_region_geography_code(*, geography_code: str) -> str:
         raise ValueError
 
     if not geography_code[-1].isdigit():
+        raise ValueError
+
+    return geography_code
+
+
+def _validate_united_kingdom_geography_code(*, geography_code: str):
+    if geography_code != UNITED_KINGDOM_GEOGRAPHY_CODE:
         raise ValueError
 
     return geography_code

--- a/ingestion/data_transfer_models/validation/geography_code.py
+++ b/ingestion/data_transfer_models/validation/geography_code.py
@@ -1,6 +1,13 @@
 from ingestion.utils import enums
 
 NATION_GEOGRAPHY_CODE_PREFIX = "E92"
+NATION_GEOGRAPHY_CODES = {
+    "England": "E92000001",
+    "Scotland": "S92000003",
+    "Wales": "W92000004",
+    "Northern Ireland": "N92000002",
+}
+
 LOWER_TIER_LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIXES = ("E06", "E07", "E08", "E09")
 UPPER_TIER_LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIXES = ("E06", "E07", "E08", "E09", "E10")
 NHS_REGION_GEOGRAPHY_CODE_PREFIX = "E40"
@@ -66,10 +73,17 @@ def validate_geography_code(
             )
 
 
-def _validate_nation_geography_code(*, geography_code: str) -> str:
-    if geography_code.startswith(NATION_GEOGRAPHY_CODE_PREFIX):
-        return geography_code
-    raise ValueError
+def _validate_nation_geography_code(*, geography_code: str, geography: str) -> str:
+    try:
+        extracted_geography_code: str = NATION_GEOGRAPHY_CODES[geography]
+    except KeyError as error:
+        error_message = f"Invalid `Nation` geography: {geography}"
+        raise ValueError(error_message) from error
+
+    if geography_code != extracted_geography_code:
+        raise ValueError
+
+    return geography_code
 
 
 def _validate_lower_tier_local_authority_geography_code(*, geography_code: str) -> str:

--- a/ingestion/utils/enums/geographies_enums.py
+++ b/ingestion/utils/enums/geographies_enums.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class GeographyType(Enum):
+    UNITED_KINGDOM = "United Kingdom"
     NATION = "Nation"
     LOWER_TIER_LOCAL_AUTHORITY = "Lower Tier Local Authority"
     NHS_REGION = "NHS Region"

--- a/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_code.py
+++ b/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_code.py
@@ -491,6 +491,34 @@ class TestIncomingBaseValidationForUnitedKingdomGeographyCode:
         with pytest.raises(ValidationError):
             IncomingBaseDataModel(**payload)
 
+    @pytest.mark.parametrize(
+        "geography",
+        (
+            "united kingdom",
+            "UK",
+            "England",
+            "Great Britain",
+        ),
+    )
+    def test_invalid_geography_name_throws_error(
+        self, geography: str, valid_payload_for_base_model: dict[str, str]
+    ):
+        """
+        Given a payload containing a `geography`
+            which is not valid for
+            the "United Kingdom" `geography_type`
+        When the `IncomingBaseDataModel` model is initialized
+        Then a `ValidationError` is raised
+        """
+        # Given
+        payload = valid_payload_for_base_model
+        payload["geography_type"] = enums.GeographyType.UNITED_KINGDOM.value
+        payload["geography_code"] = UNITED_KINGDOM_GEOGRAPHY_CODE
+
+        # When / Then
+        with pytest.raises(ValidationError):
+            IncomingBaseDataModel(**payload)
+
 
 class TestIncomingBaseValidationForGovernmentOfficeRegionGeographyCode:
     def test_valid_geography_code_validates_successfully(

--- a/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_code.py
+++ b/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_code.py
@@ -7,7 +7,7 @@ from ingestion.data_transfer_models.validation.geography_code import (
 )
 from ingestion.utils import enums
 
-VALID_NATION_CODE = "E92000001"
+VALID_ENGLAND_NATION_CODE = "E92000001"
 VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE = "E06000059"
 VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE = "E10000024"
 VALID_NHS_REGION_CODE = "E40000003"
@@ -59,7 +59,7 @@ class TestIncomingBaseValidationForNHSTrustGeographyCode:
     @pytest.mark.parametrize(
         "geography_code",
         (
-            VALID_NATION_CODE,
+            VALID_ENGLAND_NATION_CODE,
             VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE,
             VALID_NHS_REGION_CODE,
             VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE,
@@ -171,7 +171,7 @@ class TestIncomingBaseValidationForLowerTierLocalAuthorityGeographyCode:
     @pytest.mark.parametrize(
         "geography_code",
         (
-            VALID_NATION_CODE,
+            VALID_ENGLAND_NATION_CODE,
             VALID_NHS_TRUST_CODE,
             VALID_NHS_REGION_CODE,
             VALID_UKHSA_REGION_CODE,
@@ -239,7 +239,7 @@ class TestIncomingBaseValidationForUpperTierLocalAuthorityGeographyCode:
     @pytest.mark.parametrize(
         "geography_code",
         (
-            VALID_NATION_CODE,
+            VALID_ENGLAND_NATION_CODE,
             VALID_NHS_TRUST_CODE,
             VALID_NHS_REGION_CODE,
             VALID_UKHSA_REGION_CODE,
@@ -305,7 +305,7 @@ class TestIncomingBaseValidationForNHSRegionGeographyCode:
     @pytest.mark.parametrize(
         "geography_code",
         (
-            VALID_NATION_CODE,
+            VALID_ENGLAND_NATION_CODE,
             VALID_NHS_TRUST_CODE,
             VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE,
             VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE,
@@ -463,7 +463,7 @@ class TestIncomingBaseValidationForUnitedKingdomGeographyCode:
     @pytest.mark.parametrize(
         "geography_code",
         (
-            VALID_NATION_CODE,
+            VALID_ENGLAND_NATION_CODE,
             VALID_NHS_REGION_CODE,
             VALID_NHS_TRUST_CODE,
             VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE,
@@ -552,7 +552,7 @@ class TestIncomingBaseValidationForGovernmentOfficeRegionGeographyCode:
             VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE,
             VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE,
             VALID_UKHSA_REGION_CODE,
-            VALID_NATION_CODE,
+            VALID_ENGLAND_NATION_CODE,
         ),
     )
     def test_invalid_geography_code_throws_error(
@@ -616,7 +616,7 @@ class TestIncomingBaseValidationForUKHSARegionGeographyCode:
     @pytest.mark.parametrize(
         "geography_code",
         (
-            VALID_NATION_CODE,
+            VALID_ENGLAND_NATION_CODE,
             VALID_NHS_TRUST_CODE,
             VALID_NHS_REGION_CODE,
             VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE,
@@ -680,7 +680,7 @@ class TestIncomingBaseValidationForUKHSASuperRegionGeographyCode:
     @pytest.mark.parametrize(
         "geography_code",
         (
-            VALID_NATION_CODE,
+            VALID_ENGLAND_NATION_CODE,
             VALID_NHS_TRUST_CODE,
             VALID_NHS_REGION_CODE,
             VALID_UKHSA_REGION_CODE,
@@ -748,7 +748,7 @@ class TestIncomingBaseValidationForIntegratedCareBoardCode:
     @pytest.mark.parametrize(
         "geography_code",
         (
-            VALID_NATION_CODE,
+            VALID_ENGLAND_NATION_CODE,
             VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE,
             VALID_NHS_REGION_CODE,
             VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE,
@@ -862,7 +862,7 @@ class TestIncomingBaseValidationForSubIntegratedCareBoardCode:
     @pytest.mark.parametrize(
         "geography_code",
         (
-            VALID_NATION_CODE,
+            VALID_ENGLAND_NATION_CODE,
             VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE,
             VALID_NHS_REGION_CODE,
             VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE,

--- a/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_type.py
+++ b/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_type.py
@@ -2,6 +2,9 @@ import pytest
 from pydantic_core._pydantic_core import ValidationError
 
 from ingestion.data_transfer_models.base import IncomingBaseDataModel
+from ingestion.data_transfer_models.validation.geography_code import (
+    UNITED_KINGDOM_GEOGRAPHY_CODE,
+)
 
 VALID_ENGLAND_NATION_CODE = "E92000001"
 VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE = "E06000059"
@@ -16,7 +19,7 @@ class TestIncomingBaseValidationForGeographyType:
     @pytest.mark.parametrize(
         "geography_type, geography_code",
         (
-            ("Nation", VALID_NATION_CODE),
+            ("United Kingdom", UNITED_KINGDOM_GEOGRAPHY_CODE),
             ("Nation", VALID_ENGLAND_NATION_CODE),
             ("Lower Tier Local Authority", VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE),
             ("NHS Region", VALID_NHS_REGION_CODE),
@@ -54,10 +57,8 @@ class TestIncomingBaseValidationForGeographyType:
     @pytest.mark.parametrize(
         "geography_type, geography_code",
         (
-            ("nation", VALID_NATION_CODE),
-            ("national", VALID_NATION_CODE),
-            ("NATION", VALID_NATION_CODE),
-            ("NATIONAL", VALID_NATION_CODE),
+            ("united kingdom", UNITED_KINGDOM_GEOGRAPHY_CODE),
+            ("uk", UNITED_KINGDOM_GEOGRAPHY_CODE),
             ("nation", VALID_ENGLAND_NATION_CODE),
             ("national", VALID_ENGLAND_NATION_CODE),
             ("NATION", VALID_ENGLAND_NATION_CODE),

--- a/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_type.py
+++ b/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_type.py
@@ -3,7 +3,7 @@ from pydantic_core._pydantic_core import ValidationError
 
 from ingestion.data_transfer_models.base import IncomingBaseDataModel
 
-VALID_NATION_CODE = "E92000001"
+VALID_ENGLAND_NATION_CODE = "E92000001"
 VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE = "E06000059"
 VALID_NHS_REGION_CODE = "E40000003"
 VALID_NHS_TRUST_CODE = "RY6"
@@ -17,6 +17,7 @@ class TestIncomingBaseValidationForGeographyType:
         "geography_type, geography_code",
         (
             ("Nation", VALID_NATION_CODE),
+            ("Nation", VALID_ENGLAND_NATION_CODE),
             ("Lower Tier Local Authority", VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE),
             ("NHS Region", VALID_NHS_REGION_CODE),
             ("NHS Trust", VALID_NHS_TRUST_CODE),
@@ -57,6 +58,10 @@ class TestIncomingBaseValidationForGeographyType:
             ("national", VALID_NATION_CODE),
             ("NATION", VALID_NATION_CODE),
             ("NATIONAL", VALID_NATION_CODE),
+            ("nation", VALID_ENGLAND_NATION_CODE),
+            ("national", VALID_ENGLAND_NATION_CODE),
+            ("NATION", VALID_ENGLAND_NATION_CODE),
+            ("NATIONAL", VALID_ENGLAND_NATION_CODE),
             ("lower tier local authority", VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE),
             ("LTLA", VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE),
             ("ltla", VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE),

--- a/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_type.py
+++ b/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_type.py
@@ -19,7 +19,6 @@ class TestIncomingBaseValidationForGeographyType:
     @pytest.mark.parametrize(
         "geography_type, geography_code",
         (
-            ("United Kingdom", UNITED_KINGDOM_GEOGRAPHY_CODE),
             ("Nation", VALID_ENGLAND_NATION_CODE),
             ("Lower Tier Local Authority", VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE),
             ("NHS Region", VALID_NHS_REGION_CODE),


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds *Scotland*, *Wales* and *Northern Ireland* to possible **Nation** `geography_types
- Enforces stricter checks on the **Nation** geographies. Now the provided values much match to the exact names and codes for the above as well as `England`
- Adds `United Kingdom` as a new geography type which has to be given a specific name and geography code

Fixes #CDD-2480

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
