### PR TITLE
CDD-2481: Update hovertemplate to support headline charts

### DIFF
--- a/metrics/interfaces/charts/access.py
+++ b/metrics/interfaces/charts/access.py
@@ -15,7 +15,6 @@ from metrics.domain.charts import (
 )
 from metrics.domain.common.utils import (
     ChartTypes,
-    DataSourceFileType,
     extract_metric_group_from_metric,
 )
 from metrics.domain.models import (
@@ -137,6 +136,10 @@ class ChartsInterface:
 
         self._latest_date: str = ""
 
+    @property
+    def is_headline_data(self) -> bool:
+        return self.chart_request_params.plots[0].is_headline_data
+
     def _set_core_model_manager(self) -> Manager:
         """Returns `core_model_manager` based on the `metric_group`
 
@@ -150,7 +153,7 @@ class ChartsInterface:
         Returns:
             Manager: either `CoreTimeseries` or `CoreHeadline`
         """
-        if DataSourceFileType[self.metric_group].is_headline:
+        if self.is_headline_data:
             return DEFAULT_CORE_HEADLINE_MANAGER
 
         return DEFAULT_CORE_TIME_SERIES_MANAGER
@@ -171,7 +174,6 @@ class ChartsInterface:
         description = self.build_chart_description(
             plots_data=chart_generation_payload.plots
         )
-        is_headline = DataSourceFileType[self.metric_group].is_headline
 
         match self.chart_type:
             case ChartTypes.bar.value:
@@ -194,7 +196,7 @@ class ChartsInterface:
         return ChartOutput(
             figure=figure,
             description=description,
-            is_headline=is_headline,
+            is_headline=self.is_headline_data,
         )
 
     @classmethod

--- a/metrics/interfaces/charts/access.py
+++ b/metrics/interfaces/charts/access.py
@@ -43,6 +43,7 @@ class InvalidFileFormatError(Exception):
 class ChartOutput:
     figure: plotly.graph_objects.Figure
     description: str
+    is_headline: bool
 
     @property
     def interactive_chart_figure_output(self) -> dict:
@@ -101,8 +102,13 @@ class ChartOutput:
             `D3-time-format` specifiers. examples can be found at:
             https://d3js.org/d3-time-format
         """
+        hover_template = "%{y} (%{x|%d %b %Y})<extra></extra>"
+
+        if self.is_headline:
+            hover_template = "%{y} (%{x})<extra></extra>"
+
         for plot in self.figure.data:
-            plot.hovertemplate = "%{y} (%{x|%d %b %Y})<extra></extra>"
+            plot.hovertemplate = hover_template
 
     def _disable_clicks_on_legend(self):
         self.figure.layout.legend.itemclick = False
@@ -165,6 +171,7 @@ class ChartsInterface:
         description = self.build_chart_description(
             plots_data=chart_generation_payload.plots
         )
+        is_headline = DataSourceFileType[self.metric_group].is_headline
 
         match self.chart_type:
             case ChartTypes.bar.value:
@@ -184,7 +191,11 @@ class ChartsInterface:
                     chart_generation_payload=chart_generation_payload
                 )
 
-        return ChartOutput(figure=figure, description=description)
+        return ChartOutput(
+            figure=figure,
+            description=description,
+            is_headline=is_headline,
+        )
 
     @classmethod
     def build_chart_description(cls, *, plots_data: list[PlotGenerationData]) -> str:

--- a/tests/integration/metrics/interfaces/charts/test_access.py
+++ b/tests/integration/metrics/interfaces/charts/test_access.py
@@ -1,10 +1,18 @@
 from unittest import mock
+from typing import Any
 
 import plotly
 
-from metrics.domain.models import ChartRequestParams
+from metrics.domain.models import (
+    ChartRequestParams,
+    PlotGenerationData,
+    PlotParameters,
+    ChartGenerationPayload,
+)
+from metrics.domain.charts.line_multi_coloured import generation as line_generation
+from metrics.domain.charts.bar import generation as bar_generation
 from metrics.domain.common.utils import ChartTypes
-from metrics.interfaces.charts.access import ChartsInterface
+from metrics.interfaces.charts.access import ChartsInterface, ChartOutput
 
 
 class TestChartsInterface:
@@ -63,3 +71,104 @@ class TestChartsInterface:
         # Then
         mocked_scourstring.assert_called_once()
         assert mocked_scourstring.return_value == figure_image
+
+
+class TestChartsOutput:
+    @staticmethod
+    def _setup_chart_plot_data(
+        x_axis_values: list[Any],
+        y_axis_values: list[Any],
+        label: str = "",
+        line_type: str = "",
+        line_colour: str = "",
+        use_markers: bool = False,
+        use_smooth_lines: bool = True,
+    ) -> PlotGenerationData:
+        plot_params = PlotParameters(
+            chart_type="line_multi_coloured",
+            topic="COVID-19",
+            metric="COVID-19_cases_casesByDay",
+            stratum="default",
+            label=label,
+            line_type=line_type,
+            line_colour=line_colour,
+            use_markers=use_markers,
+            use_smooth_lines=use_smooth_lines,
+        )
+        return PlotGenerationData(
+            parameters=plot_params,
+            x_axis_values=x_axis_values,
+            y_axis_values=y_axis_values,
+        )
+
+    def test_chart_output_retuns_correct_hovertemplates_for_timeseries(self):
+        """ "
+        Given A valid Plotly `Figure`
+        When `ChartOutput` is passed the figure and `is_headline = False`
+        Then a `hovertemplate` for timeseries charts is returned.
+        """
+        # Given
+        x_axis_values = ["2025-01-01", "2025-02-01", "2025-03-01"]
+        y_axis_values = [1, 2, 3]
+        chart_plots_data = self._setup_chart_plot_data(
+            x_axis_values=x_axis_values,
+            y_axis_values=y_axis_values,
+            label="plot label",
+        )
+        payload = ChartGenerationPayload(
+            chart_height="400",
+            chart_width="600",
+            plots=[chart_plots_data],
+            x_axis_title="",
+            y_axis_title="",
+        )
+
+        figure = line_generation.generate_chart_figure(chart_generation_payload=payload)
+
+        # When
+        chart_output = ChartOutput(
+            figure=figure,
+            description="test chart",
+            is_headline=False,
+        ).interactive_chart_figure_output
+
+        expected_hover_template = "%{y} (%{x|%d %b %Y})<extra></extra>"
+
+        # Then
+        assert chart_output["data"][0]["hovertemplate"] == expected_hover_template
+
+    def test_chart_output_retuns_correct_hovertemplates_for_headline(self):
+        """ "
+        Given A valid Plotly `Figure`
+        When `ChartOutput` is passed the figure and `is_headline = True`
+        Then a `hovertemplate` for headline charts is returned.
+        """
+        # Given
+        x_axis_values = [1, 2, 3]
+        y_axis_values = ["00-01", "04-15", "35+"]
+        chart_plots_data = self._setup_chart_plot_data(
+            x_axis_values=x_axis_values,
+            y_axis_values=y_axis_values,
+            label="plot label",
+        )
+        payload = ChartGenerationPayload(
+            chart_height="400",
+            chart_width="600",
+            plots=[chart_plots_data],
+            x_axis_title="",
+            y_axis_title="",
+        )
+
+        figure = bar_generation.generate_chart_figure(chart_generation_payload=payload)
+
+        # When
+        chart_output = ChartOutput(
+            figure=figure,
+            description="test chart",
+            is_headline=True,
+        ).interactive_chart_figure_output
+
+        expected_hover_template = "%{y} (%{x})<extra></extra>"
+
+        # Then
+        assert chart_output["data"][0]["hovertemplate"] == expected_hover_template

--- a/tests/unit/metrics/interfaces/charts/test_access.py
+++ b/tests/unit/metrics/interfaces/charts/test_access.py
@@ -80,6 +80,7 @@ class TestChartsInterface:
         chart_output = ChartOutput(
             figure=spy_generate_line_with_shaded_section_chart.return_value,
             description=charts_interface.build_chart_description(plots_data=[]),
+            is_headline=False,
         )
         assert generated_chart_output == chart_output
 
@@ -192,6 +193,7 @@ class TestChartsInterface:
         charts_output = ChartOutput(
             figure=spy_generate_line_single_simplified.return_value,
             description=charts_interface.build_chart_description(plots_data=[]),
+            is_headline=False,
         )
         assert generated_chart_output == charts_output
 
@@ -699,7 +701,9 @@ class TestChartsInterface:
         mocked_plots_collection.plots = [fake_chart_plot_parameters]
         mocked_figure = mock.MagicMock()
         mocked_figure.to_image.return_value = "abc"
-        chart_output = ChartOutput(figure=mocked_figure, description="")
+        chart_output = ChartOutput(
+            figure=mocked_figure, description="", is_headline=False
+        )
 
         charts_interface = ChartsInterface(chart_request_params=mocked_plots_collection)
 
@@ -734,7 +738,7 @@ class TestChartsInterface:
         mocked_plots_collection.plots = [fake_chart_plot_parameters]
         fake_description = "abcdef"
         chart_output = ChartOutput(
-            figure=mock.MagicMock(), description=fake_description
+            figure=mock.MagicMock(), description=fake_description, is_headline=False
         )
 
         charts_interface = ChartsInterface(chart_request_params=mocked_plots_collection)
@@ -908,7 +912,9 @@ class TestGenerateEncodedChart:
         fake_chart_plots = fake_chart_request_params
         mocked_figure = mock.Mock()
         mocked_figure.to_image.return_value = "abc"
-        chart_output = ChartOutput(figure=mocked_figure, description="")
+        chart_output = ChartOutput(
+            figure=mocked_figure, description="", is_headline=False
+        )
         mocked_generate_chart_output.return_value = chart_output
 
         # When
@@ -962,6 +968,7 @@ class TestChartOutput:
         chart_output = ChartOutput(
             figure=fake_figure,
             description="abc",
+            is_headline=False,
         )
 
         # When


### PR DESCRIPTION
# Description

This PR includes an update to `ChartOutput` to alter the `hovertemplate` for headline charts:

Fixes #CDD-2481

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
