### PR TITLE
Bug/GitHub ci python venv flaky build

### DIFF
--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -3,9 +3,6 @@ name: 'Publish image to AWS ECR'
 description: 'Builds, tags and pushes a Docker image to AWS ECR'
 
 inputs:
-  architecture:
-    description: 'The architecture to use when building the image.'
-    required: true
   dockerfile:
     description: 'The selected dockerfile to build the image from.'
     default: Dockerfile
@@ -47,6 +44,6 @@ runs:
         ECR_REPOSITORY: ${{ inputs.ecr-repository }}
         IMAGE_TAG: ${{ inputs.image-tag }}
       run: |
-          docker build --platform linux/${{ inputs.architecture }} -f ${{ inputs.dockerfile }} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker build --platform linux/arm64 -f ${{ inputs.dockerfile }} -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
       shell: bash

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,7 +18,7 @@ jobs:
 
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-cache
@@ -30,7 +30,7 @@ jobs:
   dependency-checks:
     name: Dependency checks
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-cache
@@ -43,7 +43,7 @@ jobs:
   vulnerability-checks:
     name: Vulnerability checks
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-cache
@@ -60,7 +60,7 @@ jobs:
   quality-checks:
     name: Linting
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-cache
@@ -77,7 +77,7 @@ jobs:
   architecture-checks:
     name: Architecture checks
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-cache
@@ -94,7 +94,7 @@ jobs:
   unit-tests:
     name: Unit tests
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-cache
@@ -111,7 +111,7 @@ jobs:
   integration-tests:
     name: Integration tests
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-cache
@@ -128,7 +128,7 @@ jobs:
   system-tests:
     name: System tests
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-cache
@@ -145,7 +145,7 @@ jobs:
   migration-tests:
     name: Migration tests
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-cache
@@ -162,7 +162,7 @@ jobs:
   test-coverage:
     name: Test coverage
     needs: [ build ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-cache
@@ -189,7 +189,7 @@ jobs:
       vulnerability-checks,
       architecture-checks
     ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Check out code
@@ -215,7 +215,7 @@ jobs:
       vulnerability-checks,
       architecture-checks
     ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     if: ${{ github.ref == 'refs/heads/main' }}
 
     steps:
@@ -240,7 +240,7 @@ jobs:
       publish-main-image,
       publish-ingestion-image
     ]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     if: ${{ github.ref == 'refs/heads/main' }}
     # Only deploy if the changes are being pushed to the `main` branch
 

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -199,7 +199,6 @@ jobs:
         with:
           ecr-repository: ukhsa-data-dashboard/back-end
           role-to-assume: ${{ secrets.AWS_TOOLS_ACCOUNT_ROLE }}
-          architecture: arm64
           image-tag: ${{ github.sha }}
 
   publish-ingestion-image:
@@ -227,7 +226,6 @@ jobs:
           ecr-repository: ukhsa-data-dashboard/ingestion
           role-to-assume: ${{ secrets.AWS_TOOLS_ACCOUNT_ROLE }}
           dockerfile: Dockerfile-ingestion
-          architecture: arm64
           image-tag: ${{ github.sha }}
 
   ###############################################################################

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -59,7 +59,6 @@ platformdirs==4.3.6
 plotly==6.0.0
 pluggy==1.5.0
 pyparsing==3.2.1
-psycopg2==2.9.10
 pyrsistent==0.20.0
 python-dateutil==2.9.0.post0
 pytz==2025.1

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -1,3 +1,4 @@
+-r requirements-prod-ingestion.txt
 anyascii==0.3.2
 attrs==25.1.0
 beautifulsoup4==4.11.2


### PR DESCRIPTION
# Description

This PR includes the following:

- Pins the CI runners to macos images (ARM64)
- Remove the `psycopg2` dependency as we already install `psycopg2-binary` 

Fixes #CDD-2482

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
