### PR TITLE
Inject `PUBLIC_API_TEST_DOMAIN` into public API integration tests to allow for pointing tests at remote servers

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -179,3 +179,12 @@ The ARN of the database credentials secret in AWS SecretsManager.
 
 When running in `INGESTION` mode, the `POSTGRES_PASSWORD` is 
 fetched from SecretsManager directly when the application is initialized.
+
+---
+
+### Tests configuration
+
+#### `PUBLIC_API_TEST_DOMAIN`
+
+The domain of the target public API host to run integration tests against.
+If not specified, this will default to `"http://testserver"` i.e. the local test django server.

--- a/tests/integration/public_api/views/test_api.py
+++ b/tests/integration/public_api/views/test_api.py
@@ -1,10 +1,10 @@
 import datetime
-from collections import OrderedDict
+import os
 from http import HTTPStatus
 
 import pytest
-from rest_framework.response import Response
-from rest_framework.test import APIClient
+from requests.models import Response
+from rest_framework.test import RequestsClient
 
 from metrics.data.models.api_models import APITimeSeries
 
@@ -15,12 +15,12 @@ class TestPublicAPINestedLinkViews:
         return "/api/public/timeseries/"
 
     @property
-    def test_server_base_name(self) -> str:
-        return "http://testserver"
+    def target_domain(self) -> str:
+        return os.environ.get("PUBLIC_API_TEST_DOMAIN", "http://testserver")
 
     @property
     def api_base_path(self) -> str:
-        return f"{self.test_server_base_name}{self.path}"
+        return f"{self.target_domain}{self.path}"
 
     @staticmethod
     def _setup_api_time_series(
@@ -114,13 +114,15 @@ class TestPublicAPINestedLinkViews:
         ]
 
     @pytest.mark.django_db
-    def test_returns_correct_links_to_subsequent_views(self, client: APIClient):
+    def test_returns_correct_links_to_subsequent_views(self):
         """
         Given a valid request and a number of matching `APITimeSeries` records
         When the `GET /api/public/timeseries/` API is used
         Then the response contains links which will direct the caller to the subsequent views
         """
         # Given
+        client = RequestsClient()
+
         theme_name = "infectious_disease"
         sub_theme_name = "respiratory"
         topic_name = "COVID-19"
@@ -150,15 +152,17 @@ class TestPublicAPINestedLinkViews:
         )
 
         path = f"{self.path}themes/"
+        url = f"{self.target_domain}{path}"
+
         for (
             metadata_field,
             link_field,
             expected_metadata_field_value,
             expected_link_field_value,
         ) in expected_response_fields:
-            response: Response = client.get(path=path, format="json")
+            response: Response = client.get(url)
             assert response.status_code == HTTPStatus.OK
-            response_data: OrderedDict = response.data
+            response_data: list[dict] = response.json()
 
             # Then
             # Check that the metadata field matches up to expected value
@@ -177,10 +181,10 @@ class TestPublicAPINestedLinkViews:
             )
 
             # Point the next request to the link field provided by the previous response
-            path = link_field_from_response
+            url = link_field_from_response
 
     @pytest.mark.django_db
-    def test_returns_correct_data_at_final_view(self, client: APIClient):
+    def test_returns_correct_data_at_final_view(self):
         """
         Given a set of `APITimeSeries` records
         And a list of parameters to filter for a subset of those records
@@ -189,6 +193,8 @@ class TestPublicAPINestedLinkViews:
         And the response is paginated as expected
         """
         # Given
+        client = RequestsClient()
+
         theme_name = "infectious_disease"
         sub_theme_name = "respiratory"
         topic_name = "COVID-19"
@@ -240,7 +246,8 @@ class TestPublicAPINestedLinkViews:
             )
 
         # When
-        path = (
+        target_url = (
+            f"{self.target_domain}"
             f"{self.path}themes/"
             f"{theme_name}/sub_themes/"
             f"{sub_theme_name}/topics/"
@@ -249,16 +256,16 @@ class TestPublicAPINestedLinkViews:
             f"{geography_name}/metrics/"
             f"{metric_name}"
         )
-        response: Response = client.get(path=path, format="json")
+        response: Response = client.get(target_url)
 
         # Then
         # Check that the filtering has been applied correctly
         # And that only the requested time series records are returned
-        response_data: OrderedDict = response.data
+        response_data: list[dict] = response.json()
         assert response_data["count"] == expected_matching_time_series_count
 
         # Check that API returns a link to the next page of the paginated data
-        assert response_data["next"] == f"{self.test_server_base_name}{path}?page=2"
+        assert response_data["next"] == f"{target_url}?page=2"
         assert response_data["previous"] is None
 
         # Check that by default, the page size is returned as 5
@@ -280,9 +287,7 @@ class TestPublicAPINestedLinkViews:
             assert result["in_reporting_delay_period"] == in_reporting_delay_period
 
     @pytest.mark.django_db
-    def test_returns_correct_data_at_final_view_with_query_parameters(
-        self, client: APIClient
-    ):
+    def test_returns_correct_data_at_final_view_with_query_parameters(self):
         """
         Given a set of `APITimeSeries` records
         And a list of parameters to filter for a subset of those records
@@ -291,6 +296,8 @@ class TestPublicAPINestedLinkViews:
         Then the response contains the correct filtered `APITimeSeries` records
         """
         # Given
+        client = RequestsClient()
+
         theme_name = "infectious_disease"
         sub_theme_name = "respiratory"
         topic_name = "COVID-19"
@@ -334,7 +341,8 @@ class TestPublicAPINestedLinkViews:
             )
 
         # When
-        path = (
+        target_url = (
+            f"{self.target_domain}"
             f"{self.path}themes/"
             f"{theme_name}/sub_themes/"
             f"{sub_theme_name}/topics/"
@@ -343,14 +351,12 @@ class TestPublicAPINestedLinkViews:
             f"{geography_name}/metrics/"
             f"{metric_name}"
         )
-        response: Response = client.get(
-            path=path, format="json", data={"sex": sex, "age": age}
-        )
+        response: Response = client.get(target_url, params={"sex": sex, "age": age})
 
         # Then
         # Check that the filtering has been applied correctly
         # And that only the requested time series records are returned
-        response_data: OrderedDict = response.data
+        response_data: list[dict] = response.json()
         assert response_data["count"] == expected_matching_time_series_count
 
         # Check that API returns no paginated links
@@ -373,6 +379,7 @@ class TestPublicAPINestedLinkViews:
             assert result["sex"] == sex != other_sex
             assert result["age"] == age != other_age
 
+    @pytest.mark.django_db
     def test_root_view(self):
         """
         Given no existing `APITimeSeries` records
@@ -380,13 +387,13 @@ class TestPublicAPINestedLinkViews:
         Then the correct response is returned
         """
         # Given
-        client = APIClient()
-        path = self.path
+        client = RequestsClient()
+        target_url = self.api_base_path
 
         # When
-        response: Response = client.get(path=path, format="json")
+        response: Response = client.get(target_url)
 
         # Then
         assert response.status_code == 200
         expected_response = {"links": {"themes": f"{self.api_base_path}themes/"}}
-        assert response.data == expected_response
+        assert response.json() == expected_response


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds a new env var called `PUBLIC_API_TEST_DOMAIN` which can be used to point integration tests at remote server to run tests against. If nothing is provided, we'll just fall back to `http://testserver` i.e the local django server which we were implicitly using before
- Switches those tests to use `RequestsClient` instead of `APIClient` so that target url can be injected in

Fixes #CDD-2457

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
