### PR TITLE
CDD-2548: Validation rule updates for chemical exposure

### DIFF
--- a/ingestion/utils/enums/theme_and_topic_enums.py
+++ b/ingestion/utils/enums/theme_and_topic_enums.py
@@ -23,10 +23,15 @@ class _NonCommunicableChildTheme(Enum):
 
 class _ClimateAndEnvironmentChildTheme(Enum):
     VECTORS = "vectors"
+    CHEMICAL_EXPOSURE = "chemical_exposure"
 
 
 class _VectorsTopic(Enum):
     TICKS = "ticks"
+
+
+class _ChemicalExposureTopic(Enum):
+    LEAD = "Lead"
 
 
 class _VaccinePreventableTopic(Enum):
@@ -119,3 +124,4 @@ class Topic(BaseEnum):
     VECTORS = _VectorsTopic
     INVASIVE_BACTERIAL_INFECTIONS = _InvasiveBacterialInfectionsTopic
     CHILDHOOD_ILLNESS = _ChildhoodIllnessTopic
+    CHEMICAL_EXPOSURE = _ChemicalExposureTopic

--- a/tests/unit/ingestion/data_transfer_models/validation/successful/parameters.py
+++ b/tests/unit/ingestion/data_transfer_models/validation/successful/parameters.py
@@ -62,4 +62,11 @@ VALID_PARAMETERS = [
         "hepatitis-c_prevention_PWIDproportionNSP",
         "prevention",
     ),
+    (
+        "climate_and_environment",
+        "chemical_exposure",
+        "Lead",
+        "lead_headline_percentByDeprivationLatest",
+        "headline",
+    ),
 ]

--- a/tests/unit/ingestion/data_transfer_models/validation/unsuccessful/parameters.py
+++ b/tests/unit/ingestion/data_transfer_models/validation/unsuccessful/parameters.py
@@ -48,4 +48,11 @@ INVALID_PARAMETERS = [
         "hepatitis-c_cases_prevalenceByYearEstimate",
         "prevention",
     ),  # Invalid child Topic
+    (
+        "infectious_disease",
+        "chemical_exposure",
+        "Lead",
+        "lead_headline_percentByDeprivationLatest",
+        "headline",
+    ),  # Invalid parent theme
 ]


### PR DESCRIPTION
# Description

This PR includes updates to the ingestion validation rules to include `chemical_exposure` data, this update has been reflected in the validation documentation in confluence.

Fixes #CDD-2548

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
