### PR TITLE
CDD-2555: Add padding days to time series to avoid cropping

### DIFF
--- a/metrics/domain/charts/chart_settings.py
+++ b/metrics/domain/charts/chart_settings.py
@@ -79,6 +79,7 @@ class ChartSettings:
             "dtick": "M1",
             "tickformat": "%b %Y",
             "tickfont": self._get_tick_font_config(),
+            "autotickangles": [0, 90],
         }
 
         if self._chart_generation_payload.x_axis_title:
@@ -441,7 +442,7 @@ class ChartSettings:
         return {
             "legend": {
                 "orientation": "h",
-                "y": -0.25,
+                "y": -0.35,
                 "x": 0,
             },
         }

--- a/metrics/domain/charts/chart_settings.py
+++ b/metrics/domain/charts/chart_settings.py
@@ -337,6 +337,71 @@ class ChartSettings:
             return "M6"
         return "M12"
 
+    @staticmethod
+    def get_timeseries_margin_days(interval: str | int) -> int:
+        """Returns a number of days as an integer based on the provided interval.
+
+        Note:
+            This value is used to shift the start and end date on timeseries charts
+            to avoid cropping issues with Plotly by padding out the timeframe of a chart.
+
+            The interval, which is used for `dtick` attribute of a chart can be either
+            a `str` or `int` this is because while we use the D3 time interval convention
+            of `M1`, `M3`, `M12` etc. for weekly and fortnightly intervals
+            milliseconds are used due to a lack of support for these intervals in string
+            format.
+
+        Returns:
+            number of days as an integer
+        """
+        if interval == "M1":
+            return 15
+        if interval == "M3":
+            return 45
+        if interval == "M6":
+            return 90
+        if interval == "M12":
+            return 178
+        return 1
+
+    def get_x_axis_range(
+        self, min_date: int, max_date: int, interval: str | int
+    ) -> list[datetime.date]:
+        """Returns the first and last date to make up the timeseries date range.
+
+        Note:
+            Plotly can sometimes crop or partially hide the first and last data points
+            in charts. To prevent this rendering issue, we adjust the date range:
+            - Shift the first date backwards by half the current time interval
+            - Shift the last date forwards by half the current time interval
+            - If timeseries intervals are less than 1 month we shift the dates by 1 day
+
+            Eg:
+            - For 1-year interval, 178 days (just under 6 months)
+            - For 6-month interval, shift by 90 days
+            - For 1-month interval, shift by 1 day
+
+            This ensures all data points are fully visible and not cut off at the
+            chart's edges.
+
+        Returns:
+            A list containing two dates, the first in the timeseries and the last `list[datetime.date]`
+        """
+        return [
+            (
+                min_date
+                - datetime.timedelta(
+                    days=self.get_timeseries_margin_days(interval=interval)
+                )
+            ),
+            (
+                max_date
+                + datetime.timedelta(
+                    days=self.get_timeseries_margin_days(interval=interval)
+                )
+            ),
+        ]
+
     def get_x_axis_date_type(self) -> DICT_OF_STR_ONLY:
         min_date, max_date = self.get_min_and_max_x_axis_values()
 
@@ -358,7 +423,9 @@ class ChartSettings:
             "tick0": tick0,
             "dtick": dtick,
             "tickformat": self._get_date_tick_format(weekly=weekly),
-            "range": [tick0, max_date],
+            "range": self.get_x_axis_range(
+                min_date=tick0, max_date=max_date, interval=dtick
+            ),
         }
 
     @staticmethod

--- a/tests/unit/metrics/domain/charts/test_chart_settings.py
+++ b/tests/unit/metrics/domain/charts/test_chart_settings.py
@@ -82,6 +82,7 @@ class TestChartSettings:
             "dtick": "M1",
             "tickformat": "%b %Y",
             "tickfont": chart_settings._get_tick_font_config(),
+            "autotickangles": [0, 90],
             "title": {
                 "font": chart_settings._get_tick_font_config(),
                 "text": chart_settings._chart_generation_payload.x_axis_title,
@@ -132,6 +133,7 @@ class TestChartSettings:
             "dtick": None,
             "tickformat": None,
             "tickfont": chart_settings._get_tick_font_config(),
+            "autotickangles": [0, 90],
             "title": {
                 "font": chart_settings._get_tick_font_config(),
                 "text": chart_settings._chart_generation_payload.x_axis_title,
@@ -398,6 +400,8 @@ class TestChartSettings:
             ["M3", 45],
             ["M6", 90],
             ["M12", 178],
+            [WEEK_IN_MILLISECONDS, 1],
+            [TWO_WEEKS_IN_MILLISECONDS, 1],
         ),
     )
     def test_date_range_is_padding_correctly_based_on_x_axis_interval(
@@ -742,7 +746,7 @@ class TestChartSettings:
             "barmode": "group",
             "legend": {
                 "orientation": "h",
-                "y": -0.25,
+                "y": -0.35,
                 "x": 0,
             },
         }
@@ -768,7 +772,7 @@ class TestChartSettings:
         expected_legend_bottom_left_config = {
             "legend": {
                 "orientation": "h",
-                "y": -0.25,
+                "y": -0.35,
                 "x": 0,
             },
         }

--- a/tests/unit/metrics/domain/charts/test_chart_settings.py
+++ b/tests/unit/metrics/domain/charts/test_chart_settings.py
@@ -381,9 +381,54 @@ class TestChartSettings:
             "dtick": "M1",
             "tick0": tick0,
             "tickformat": "%b<br>%Y",
-            "range": [min_date, max_date],
+            "range": [
+                # shift first and last date 15 days for monthly intervals
+                tick0 - datetime.timedelta(days=15),
+                max_date + datetime.timedelta(days=15),
+            ],
         }
+
         assert x_axis_date_type == expected_axis_config
+
+    @pytest.mark.parametrize(
+        "interval, number_of_days",
+        (
+            ["D7", 1],
+            ["M1", 15],
+            ["M3", 45],
+            ["M6", 90],
+            ["M12", 178],
+        ),
+    )
+    def test_date_range_is_padding_correctly_based_on_x_axis_interval(
+        self,
+        interval: str,
+        number_of_days: int,
+        fake_plot_data: PlotGenerationData,
+    ):
+        """
+        Given a valid `dtick` (the chart x-axis interval)
+        When the `get_timeseries_margin_days()` method is called
+        Then the correct number of days to use as padding is returned.
+        """
+        # Given
+        dtick = interval
+        payload = ChartGenerationPayload(
+            chart_width=435,
+            chart_height=220,
+            plots=[fake_plot_data],
+            x_axis_title="",
+            y_axis_title="",
+        )
+        chart_settings = ChartSettings(chart_generation_payload=payload)
+
+        # When
+        expected_number_of_days = chart_settings.get_timeseries_margin_days(
+            interval=dtick
+        )
+
+        # Then
+        assert expected_number_of_days == number_of_days
 
     def test_get_x_axis_date_type_breaks_line_for_narrow_charts(
         self, fake_plot_data: PlotGenerationData


### PR DESCRIPTION
# Description

This PR includes includes an update to `chart_settings` introducing `padding` days to timeseries charts to avoid cropping by Plotly that can lead to missing tick values and cropped bar charts.

Fixes #CDD-2555

---

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [x] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
