### PR TITLE
Task/fetch rbac group permissions by group id/cdd 2531

### DIFF
--- a/metrics/api/decorators/auth.py
+++ b/metrics/api/decorators/auth.py
@@ -1,5 +1,6 @@
 from functools import wraps
 
+from django.core.exceptions import ValidationError
 from django.http import HttpRequest
 
 from metrics.api.settings.private_api import AUTH_ENABLED
@@ -29,8 +30,12 @@ def _set_rbac_group_permissions(*, request: HttpRequest, group_id: str) -> None:
     if not group_id:
         return
 
-    group_permissions: RBACGroupPermission = RBACGroupPermission.objects.get_group(
-        group_id=group_id
-    )
+    try:
+        group_permissions: RBACGroupPermission = RBACGroupPermission.objects.get_group(
+            group_id=group_id
+        )
+    except ValidationError:
+        return
+
     if group_permissions:
         request.group_permissions = list(group_permissions.permissions.all())

--- a/metrics/api/decorators/auth.py
+++ b/metrics/api/decorators/auth.py
@@ -30,7 +30,7 @@ def _set_rbac_group_permissions(*, request: HttpRequest, group_id: str) -> None:
         return
 
     group_permissions: RBACGroupPermission = RBACGroupPermission.objects.get_group(
-        name=group_id
+        group_id=group_id
     )
     if group_permissions:
         request.group_permissions = list(group_permissions.permissions.all())

--- a/metrics/api/enums.py
+++ b/metrics/api/enums.py
@@ -17,6 +17,7 @@ class AppMode(Enum):
             cls.PUBLIC_API.value,
             cls.INGESTION.value,
             cls.FEEDBACK_API.value,
+            cls.AUDIT_API.value,
         ]
 
     @classmethod

--- a/metrics/data/managers/rbac_models/rbac_group_permissions.py
+++ b/metrics/data/managers/rbac_models/rbac_group_permissions.py
@@ -6,19 +6,19 @@ from django.db import models
 class RBACGroupPermissionQuerySet(models.QuerySet):
     """Custom queryset for the `RBACGroupPermission` model."""
 
-    def get_group(self, name: str) -> Union["RBACGroupPermission", None]:
+    def get_group(self, group_id: str) -> Union["RBACGroupPermission", None]:
         """
         Retrieves a single `RBACGroupPermission` instance based on the given name.
 
         Since the `name` field has a unique constraint, this method returns at most one group.
 
         Args:
-            name (str): The name of the group permission to retrieve.
+            group_id (str): The group ID unique identifier associated with the group permission.
 
         Returns:
             RBACGroupPermission | None: The matching group permission instance if found, otherwise None.
         """
-        return self.filter(name=name).first()
+        return self.filter(group_id=group_id).first()
 
 
 class RBACGroupPermissionManager(models.Manager):
@@ -32,14 +32,14 @@ class RBACGroupPermissionManager(models.Manager):
         """
         return RBACGroupPermissionQuerySet(self.model, using=self._db)
 
-    def get_group(self, name: str) -> Union["RBACGroupPermission", None]:
+    def get_group(self, group_id: str) -> Union["RBACGroupPermission", None]:
         """
-        Retrieves a single `RBACGroupPermission` instance by name using the queryset method.
+        Retrieves a single `RBACGroupPermission` instance by the group ID
 
         Args:
-            name (str): The name of the group permission to retrieve.
+            group_id (str): The group ID unique identifier associated with the group permission.
 
         Returns:
             RBACGroupPermission | None: The matching group permission instance if found, otherwise None.
         """
-        return self.get_queryset().get_group(name)
+        return self.get_queryset().get_group(group_id)

--- a/tests/integration/metrics/api/packages/permissions/test_permissions_fluent.py
+++ b/tests/integration/metrics/api/packages/permissions/test_permissions_fluent.py
@@ -120,12 +120,12 @@ class TestFluentPermissions:
         with pytest.raises(FluentPermissionsError):
             fluent_permissions.validate()
 
-    def test_validate_raises_error_when_permission_can_be_matched(self):
+    def test_validate_raises_error_when_permission_cannot_be_matched(self):
         """
         Given a FluentPermissions instance
             with a permission for a different dataset
         When validate() is called
-        Then FluentPermissionsError is raised
+        Then a `FluentPermissionsError` is raised
         """
         # Given
         non_matching_permission = FakeRBACPermissionFactory.build_rbac_permission(
@@ -154,6 +154,40 @@ class TestFluentPermissions:
         Then no error is raised
         """
         # Given
+        fluent_permissions = FluentPermissions(
+            data=self.data, group_permissions=[fake_rbac_permission]
+        )
+        (
+            fluent_permissions.add_field("theme")
+            .add_field("sub_theme")
+            .add_field("topic")
+            .add_field("geography_type")
+            .add_field("geography")
+            .add_field("metric")
+            .add_field("age")
+            .add_field("stratum")
+            .execute()
+        )
+        # When/Then
+        fluent_permissions.validate()  # Should not raise an exception
+
+    def test_validate_passes_when_wildcard_permission_matches_requested_dataset(
+        self, fake_rbac_permission: FakeRBACPermission
+    ):
+        """
+        Given a FluentPermissions instance
+            with an `RBACPPermission` which wildcards the dataset
+        When validate() is called
+        Then no error is raised
+        """
+        # Given
+        wildcarded_permission = fake_rbac_permission
+        wildcarded_permission.metric = None
+        wildcarded_permission.topic = None
+        wildcarded_permission.age = None
+        wildcarded_permission.geography = None
+        # Permission wildcards for the selected theme & sub_theme
+
         fluent_permissions = FluentPermissions(
             data=self.data, group_permissions=[fake_rbac_permission]
         )

--- a/tests/unit/metrics/api/test_enums.py
+++ b/tests/unit/metrics/api/test_enums.py
@@ -12,6 +12,7 @@ class TestAppMode:
             "PUBLIC_API",
             "INGESTION",
             "FEEDBACK_API",
+            "AUDIT_API",
         ],
     )
     def test_dependent_on_db(self, expected_app_mode: str):


### PR DESCRIPTION
# Description

This PR includes the following:

- Queries for `RBACPermission` models by the group ID uuid instead of by name

Fixes #CDD-2531

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
