### PR TITLE
Enforce `sex`, `age`, `stratum`, `geography` and `geography_type` fields to be required at API level for headline data

### DIFF
--- a/metrics/api/serializers/headlines.py
+++ b/metrics/api/serializers/headlines.py
@@ -34,27 +34,27 @@ class HeadlinesQuerySerializer(serializers.Serializer):
     )
     geography = serializers.ChoiceField(
         choices=[],
-        required=False,
+        required=True,
         help_text=help_texts.GEOGRAPHY_FIELD,
     )
     geography_type = serializers.ChoiceField(
         choices=[],
-        required=False,
+        required=True,
         help_text=help_texts.GEOGRAPHY_TYPE_FIELD,
     )
     stratum = serializers.ChoiceField(
         choices=[],
-        required=False,
+        required=True,
         help_text=help_texts.STRATUM_FIELD,
     )
     age = serializers.ChoiceField(
         choices=[],
-        required=False,
+        required=True,
         help_text=help_texts.AGE_FIELD,
     )
     sex = serializers.ChoiceField(
         choices=["all", "m", "f"],
-        required=False,
+        required=True,
         help_text=help_texts.SEX_FIELD,
     )
 


### PR DESCRIPTION
# Description

This PR includes the following:

- Enforces the `sex`, `age`, `stratum`, `geography` and `geography_type` fields at the API level for headline type data. We already do this in the CMS, so this just aligns us there as well as with the serialization layer which also enforces those fields

Fixes #CDD-2531
---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
