### PR TITLE
Task/write v2 charts to memory instead of to disk/cdd 2379

### DIFF
--- a/metrics/api/views/charts.py
+++ b/metrics/api/views/charts.py
@@ -1,4 +1,4 @@
-import os
+import io
 from http import HTTPStatus
 
 from django.http import FileResponse
@@ -34,6 +34,7 @@ class ChartsView(APIView):
             return [permissions.IsAuthenticated()]
         return super().get_permissions()
 
+    @classmethod
     @extend_schema(
         request=ChartsSerializer,
         responses={HTTPStatus.OK.value: ChartsResponseSerializer},
@@ -74,7 +75,7 @@ class ChartsView(APIView):
             )
         ],
     )
-    def post(self, request, *args, **kwargs):
+    def post(cls, request, *args, **kwargs):
         """This endpoint can be used to generate charts conforming to the UK Gov Specification.
 
         Multiple plots can be added as an array of objects from the request body.
@@ -197,7 +198,7 @@ class ChartsView(APIView):
         )
 
         try:
-            filename: str = access.generate_chart_as_file(
+            chart_image: bytes = access.generate_chart_as_file(
                 chart_request_params=chart_request_params,
             )
         except (InvalidPlotParametersError, DataNotFoundForAnyPlotError) as error:
@@ -205,16 +206,10 @@ class ChartsView(APIView):
                 status=HTTPStatus.BAD_REQUEST, data={"error_message": str(error)}
             )
 
-        return self._return_image(filename=filename)
-
-    @staticmethod
-    def _return_image(*, filename: str) -> FileResponse:
-        image = open(filename, "rb")
-        response = FileResponse(image)
-
-        os.remove(filename)
-
-        return response
+        return FileResponse(
+            io.BytesIO(chart_image),
+            content_type=f"image/{chart_request_params.file_format}",
+        )
 
 
 class EncodedChartsView(APIView):

--- a/metrics/interfaces/charts/access.py
+++ b/metrics/interfaces/charts/access.py
@@ -1,3 +1,4 @@
+import io
 import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime
@@ -488,7 +489,7 @@ class ChartsInterface:
 
         return encoded_chart
 
-    def write_figure(self, *, figure: plotly.graph_objects.Figure) -> str:
+    def write_figure(self, *, figure: plotly.graph_objects.Figure) -> bytes:
         """
         Convert a figure to a static image and write to a file in the desired image format
 
@@ -496,17 +497,19 @@ class ChartsInterface:
             figure: The figure object or a dictionary representing a figure
 
         Returns:
-            The filename of the image
+            The image in memory
 
         """
-        filename = f"new_chart.{self.chart_request_params.file_format}"
+        file = io.BytesIO()
+
         figure.write_image(
-            file=filename,
+            file=file,
             format=self.chart_request_params.file_format,
             validate=False,
         )
 
-        return filename
+        file.seek(0)
+        return file.getvalue()
 
     @staticmethod
     def calculate_change_in_metric_value(*, values, metric_name) -> int | float:
@@ -543,27 +546,7 @@ class ChartsInterface:
         }
 
 
-def generate_chart_as_file(*, chart_request_params: ChartRequestParams) -> str:
-    """Validates and creates a chart figure based on the parameters provided within the `chart_plots` model
-
-    Args:
-        chart_request_params: The requested chart request
-            parameters encapsulated as a model
-
-    Returns:
-        The filename of the created image
-
-    Raises:
-        `InvalidPlotParametersError`: If an underlying
-            validation check has failed.
-            This could be because there is
-            an invalid topic and metric selection.
-            Or because the selected dates are not in
-            the expected chronological order.
-        `DataNotFoundForAnyPlotError`: If no plots
-            returned any data from the underlying queries
-
-    """
+def generate_chart_as_file(*, chart_request_params: ChartRequestParams) -> bytes:
     charts_interface = ChartsInterface(chart_request_params=chart_request_params)
     chart_output: ChartOutput = charts_interface.generate_chart_output()
 

--- a/tests/integration/metrics/api/views/test_charts.py
+++ b/tests/integration/metrics/api/views/test_charts.py
@@ -14,7 +14,7 @@ class TestChartsView:
     @staticmethod
     def _build_valid_payload_for_existing_timeseries(core_timeseries: CoreTimeSeries):
         return {
-            "file_format": "svg",
+            "file_format": "png",
             "plots": [
                 {
                     "topic": core_timeseries.metric.metric_group.topic.name,
@@ -85,8 +85,8 @@ class TestChartsView:
         # Then
         assert response.status_code == HTTPStatus.OK != HTTPStatus.UNAUTHORIZED
 
-        # Check that the headers on the response indicate an `svg` image being returned
-        assert response.headers["Content-Type"] == "image/svg+xml"
+        # Check that the headers on the response indicate a `png` image being returned
+        assert response.headers["Content-Type"] == "image/png"
 
     @pytest.mark.django_db
     def test_hitting_endpoint_without_appended_forward_slash_redirects_correctly_for_v3(

--- a/tests/integration/metrics/api/views/test_charts.py
+++ b/tests/integration/metrics/api/views/test_charts.py
@@ -103,6 +103,7 @@ class TestChartsView:
         valid_payload = self._build_valid_payload_for_existing_timeseries(
             core_timeseries=core_timeseries_example[0]
         )
+        valid_payload["file_format"] = "svg"
         path = "/api/charts/v3"
 
         # When


### PR DESCRIPTION
# Description

This PR includes the following:

- Writes charts in charts/v2 to memory instead of to disk. Which breaks the dependency on writing to the filesystem. Meaning we can safely prevent those actions

Fixes #CDD-2379

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
