### PR TITLE
Copy processed files to ingest archive bucket upon completion

### DIFF
--- a/config.py
+++ b/config.py
@@ -50,6 +50,8 @@ if not REDIS_HOST:
 
 # The name of the s3 bucket used for ingestion
 INGESTION_BUCKET_NAME = os.environ.get("INGESTION_BUCKET_NAME")
+# The name of the s3 bucket used for archiving files which have been successfully ingested
+INGESTION_ARCHIVE_BUCKET_NAME = os.environ.get("INGESTION_ARCHIVE_BUCKET_NAME")
 # The name of the AWS profile to use for the AWS client used for ingestion
 AWS_PROFILE_NAME = os.environ.get("AWS_PROFILE_NAME")
 

--- a/ingestion/aws_client.py
+++ b/ingestion/aws_client.py
@@ -20,7 +20,8 @@ class AWSClient:
 
     Notes:
         Primarily used to list files in the designated inbound folder in the bucket.
-        As well as to download them and move them to the designated outbound folder
+        As well as to download them and move them to the designated outbound folder.
+        Proccessed files are also copied to the archive bucket.
 
     """
 
@@ -30,12 +31,14 @@ class AWSClient:
         client: botocore.client.BaseClient | None = None,
         profile_name: str = config.AWS_PROFILE_NAME,
         bucket_name: str = config.INGESTION_BUCKET_NAME,
+        archive_bucket_name: str = config.INGESTION_ARCHIVE_BUCKET_NAME,
         inbound_folder: str = DEFAULT_INBOUND_INGESTION_FOLDER,
         processed_folder: str = DEFAULT_PROCESSED_INGESTION_FOLDER,
         failed_folder: str = DEFAULT_FAILED_INGESTION_FOLDER,
     ):
         self._client = client or self.create_client(profile_name=profile_name)
         self._bucket_name = bucket_name
+        self._archive_bucket_name = archive_bucket_name
         self._inbound_folder = inbound_folder
         self._processed_folder = processed_folder
         self._failed_folder = failed_folder
@@ -55,6 +58,10 @@ class AWSClient:
     def move_file_to_processed_folder(self, *, key: str) -> None:
         """Moves the file matching the given `key` into the `processed/` folder within the s3 bucket
 
+        Notes:
+            This will also copy the file
+            to the proccessed folder in the archive s3 bucket.
+
         Args:
             key: The key of the item to be moved
 
@@ -70,6 +77,7 @@ class AWSClient:
             self._processed_folder,
         )
         self._copy_file_to_processed(key=key)
+        self._copy_file_to_processed_archive(key=key)
         self._delete_file_from_inbound(key=key)
 
     def move_file_to_failed_folder(self, *, key: str) -> None:
@@ -119,6 +127,32 @@ class AWSClient:
         except botocore.client.ClientError:
             logger.warning(
                 "Failed to move `%s` to `%s` folder", key, self._processed_folder
+            )
+
+    def _copy_file_to_processed_archive(self, *, key: str) -> None:
+        """Copies the file matching the given `key` into the ingest archive s3 bucket
+
+        Args:
+            key: The key of the item to be moved
+
+        Returns:
+            None
+
+        """
+        processed_archive_key: str = self._build_processed_archive_key(key=key)
+        try:
+            self._client.copy(
+                CopySource={"Bucket": self._bucket_name, "Key": key},
+                Bucket=self._archive_bucket_name,
+                Key=processed_archive_key,
+                ExtraArgs={
+                    "StorageClass": "GLACIER_IR",
+                    "MetadataDirective": "COPY",
+                },
+            )
+        except botocore.client.ClientError:
+            logger.warning(
+                "Failed to move `%s` to `%s` bucket", key, self._archive_bucket_name
             )
 
     def _copy_file_to_failed(self, *, key: str) -> None:
@@ -226,3 +260,24 @@ class AWSClient:
 
         """
         return self._build_destination_key(key=key, folder=self._failed_folder)
+
+    def _build_processed_archive_key(self, key: str) -> str:
+        """Constructs the full archive proccesed `key` of the item
+
+        Examples:
+            If the inbound `key` of
+            "in/adenovirus_testing_positivityByWeek_CTRY_E92000001_all_all_default.json" is provided,
+            then "2025-05-29/adenovirus/adenovirus_testing_positivityByWeek_CTRY_E92000001_all_all_default.json"
+            will be returned where the current date is "2025-05-29".
+
+        Args:
+            key: The inbound key of the item in the bucket
+
+        Returns:
+            The archive key of the item
+
+        """
+        filename: str = self._get_filename_from_key(key=key)
+        topic = filename.split("_")[0]
+        current_date: str = datetime.datetime.now().strftime("%Y-%m-%d")
+        return f"processed/{current_date}/{topic}/{filename}"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ coverage==7.8.2
 cyclonedx-python-lib==8.9.0
 django-factory-boy==1.0.0
 factory-boy==3.3.3
+freezegun==1.5.2
 Faker==37.3.0
 gitdb==4.0.12
 GitPython==3.1.44

--- a/tests/unit/ingestion/test_aws_client.py
+++ b/tests/unit/ingestion/test_aws_client.py
@@ -1,6 +1,7 @@
 from unittest import mock
 
 import botocore.client
+import freezegun
 import pytest
 from _pytest.logging import LogCaptureFixture
 
@@ -152,28 +153,46 @@ class TestAWSClient:
         """
         # Given
         fake_key: str = FAKE_KEY
+        fake_bucket_name = "fake-bucket"
+        fake_archive_bucket_name = "fake-archive-bucket"
         spy_client = aws_client_with_mocked_boto_client._client
+        aws_client_with_mocked_boto_client._bucket_name = fake_bucket_name
+        aws_client_with_mocked_boto_client._archive_bucket_name = (
+            fake_archive_bucket_name
+        )
 
         # When
         aws_client_with_mocked_boto_client.move_file_to_processed_folder(key=fake_key)
 
         # Then
-        bucket_name: str = aws_client_with_mocked_boto_client._bucket_name
         processed_key: str = aws_client_with_mocked_boto_client._build_processed_key(
             key=fake_key
         )
         # Check that the call to copy the file is made correctly
         expected_copy_file_to_processed_call = mock.call.copy(
-            CopySource={"Bucket": bucket_name, "Key": fake_key},
-            Bucket=bucket_name,
+            CopySource={"Bucket": fake_bucket_name, "Key": fake_key},
+            Bucket=fake_bucket_name,
             Key=processed_key,
+        )
+        # Check that the call to archive the file is made correctly
+        expected_copy_file_to_processed_archive_call = mock.call.copy(
+            CopySource={"Bucket": fake_bucket_name, "Key": fake_key},
+            Bucket=fake_archive_bucket_name,
+            Key=aws_client_with_mocked_boto_client._build_processed_archive_key(
+                key=fake_key
+            ),
+            ExtraArgs={
+                "StorageClass": "GLACIER_IR",
+                "MetadataDirective": "COPY",
+            },
         )
         # Check that the call to delete the origin file is made correctly
         expected_delete_file_from_origin_call = mock.call.delete_object(
-            Bucket=bucket_name, Key=fake_key
+            Bucket=fake_bucket_name, Key=fake_key
         )
         expected_calls = [
             expected_copy_file_to_processed_call,
+            expected_copy_file_to_processed_archive_call,
             expected_delete_file_from_origin_call,
         ]
         # The ordering of the call is important, we expect to copy the file
@@ -418,6 +437,46 @@ class TestAWSClient:
         expected_log = f"Failed to move `{key}` to `{failed_folder}` folder"
         assert expected_log in caplog.text
 
+    @mock.patch.object(AWSClient, "_build_processed_archive_key")
+    def test_copy_file_to_processed_archive(
+        self,
+        spy_build_processed_archive_key: mock.MagicMock,
+        aws_client_with_mocked_boto_client: AWSClient,
+    ):
+        """
+        Given a bucket name and a key for a file
+        When `_copy_file_to_processed_archive()` is called
+            from an instance of `AWSClient`
+        Then the call is delegated to the `copy` method
+            on the underlying client with the correct args
+
+        Patches:
+            `spy_build_processed_archive_key`: To check the
+                correct method is called out to create
+                the processed archive key for the file
+
+        """
+        # Given
+        bucket_name = "fake-bucket"
+        archive_bucket_name = "fake-archive-bucket"
+        key = FAKE_KEY
+        aws_client_with_mocked_boto_client._bucket_name = bucket_name
+        aws_client_with_mocked_boto_client._archive_bucket_name = archive_bucket_name
+        spy_client: mock.Mock = aws_client_with_mocked_boto_client._client
+
+        # When
+        aws_client_with_mocked_boto_client._copy_file_to_processed_archive(key=key)
+
+        # Then
+        spy_build_processed_archive_key.assert_called_once_with(key=key)
+
+        spy_client.copy.assert_called_once_with(
+            CopySource={"Bucket": bucket_name, "Key": key},
+            Bucket=archive_bucket_name,
+            Key=spy_build_processed_archive_key.return_value,
+            ExtraArgs={"StorageClass": "GLACIER_IR", "MetadataDirective": "COPY"},
+        )
+
     # Tests for `_delete_file_from_inbound`
 
     def test_delete_file_from_inbound_records_log_when_client_error_occurs(
@@ -504,3 +563,27 @@ class TestAWSClient:
 
         # Then
         assert failed_key == f"failed/{FAKE_FILE_NAME}"
+
+    @freezegun.freeze_time("2025-01-01")
+    def test_build_processed_archive_key(
+        self, aws_client_with_mocked_boto_client: AWSClient
+    ):
+        """
+        Given a key from the s3 bucket for an item
+        When `_build_processed_archive_key()` is called
+            from an instance of `AWSClient`
+        Then the correct processed archive key is returned
+        """
+        # Given
+        fake_key = FAKE_KEY
+
+        # When
+        processed_archive_key: str = (
+            aws_client_with_mocked_boto_client._build_processed_archive_key(
+                key=fake_key
+            )
+        )
+
+        # Then
+        expected_key = f"processed/2025-01-01/COVID-19/{FAKE_FILE_NAME}"
+        assert processed_archive_key == expected_key

--- a/tests/unit/ingestion/test_aws_client.py
+++ b/tests/unit/ingestion/test_aws_client.py
@@ -500,7 +500,9 @@ class TestAWSClient:
         aws_client_with_mocked_boto_client._copy_file_to_processed_archive(key=key)
 
         # Then
-        _archive_bucket_name: str = aws_client_with_mocked_boto_client._archive_bucket_name
+        _archive_bucket_name: str = (
+            aws_client_with_mocked_boto_client._archive_bucket_name
+        )
         expected_log = f"Failed to move `{key}` to `{_archive_bucket_name}` bucket"
         assert expected_log in caplog.text
 


### PR DESCRIPTION
# Description

This PR includes the following:

- Updates the ingestion lambda so that when it successfully completes an ingestion, it also copies said file to the new ingest archive bucket for long term storage

Fixes #CDD-2598

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
