### PR TITLE
Task/improve interopability between api and data layers part three/cdd 2616

### DIFF
--- a/metrics/data/managers/core_models/headline.py
+++ b/metrics/data/managers/core_models/headline.py
@@ -644,12 +644,12 @@ class CoreHeadlineManager(models.Manager):
         """
         return {
             geography_code: self.get_latest_headline(
-                topic_name=topic_name,
-                metric_name=metric_name,
-                geography_name=geography_name,
-                geography_type_name=geography_type_name,
+                topic_name=topic,
+                metric_name=metric,
+                geography_name=geography,
+                geography_type_name=geography_type,
                 geography_code=geography_code,
-                stratum_name=stratum_name,
+                stratum_name=stratum,
                 sex=sex,
                 age=age,
             )

--- a/metrics/data/managers/core_models/headline.py
+++ b/metrics/data/managers/core_models/headline.py
@@ -603,30 +603,30 @@ class CoreHeadlineManager(models.Manager):
     def get_latest_headlines_for_geography_codes(
         self,
         *,
-        topic_name: str,
-        metric_name: str,
+        topic: str,
+        metric: str,
         geography_codes: list[str],
-        geography_name: str = "",
-        geography_type_name: str = "",
-        stratum_name: str = "",
+        geography: str = "",
+        geography_type: str = "",
+        stratum: str = "",
         sex: str = "",
         age: str = "",
     ) -> dict[str, Optional["CoreHeadline"]]:
-        """Grabs by the latest records by the given `topic_name` and `metric_name` with a current `period_end`
+        """Grabs by the latest records by the given `topic` and `metric` with a current `period_end`
 
         Args:
-            topic_name: The name of the disease being queried.
+            topic: The name of the disease being queried.
                 E.g. `COVID-19`
-            metric_name: The name of the metric being queried.
+            metric: The name of the metric being queried.
                 E.g. `COVID-19_deaths_ONSByDay`
-            geography_name: The name of the geography being queried.
+            geography: The name of the geography being queried.
                 E.g. `England`
-            geography_type_name: The name of the geography
+            geography_type: The name of the geography
                 type being queried.
                 E.g. `Nation`
             geography_codes: Codes associated with the geographies being queried.
                 E.g. ["E45000010", "E45000020"]
-            stratum_name: The value of the stratum to apply additional filtering to.
+            stratum: The value of the stratum to apply additional filtering to.
                 E.g. `default`, which would be used to capture all strata.
             sex: The gender to apply additional filtering to.
                 E.g. `F`, would be used to capture Females.

--- a/metrics/interfaces/weather_health_alerts/access.py
+++ b/metrics/interfaces/weather_health_alerts/access.py
@@ -38,8 +38,8 @@ class WeatherHealthAlertsInterface:
         """
         headlines_mapping = (
             self._core_headline_manager.get_latest_headlines_for_geography_codes(
-                topic_name=topic_name,
-                metric_name=metric_name,
+                topic=topic_name,
+                metric=metric_name,
                 geography_codes=[
                     geography_code for geography_code, geography_name in geography_data
                 ],

--- a/tests/integration/metrics/data/managers/core_models/test_headline.py
+++ b/tests/integration/metrics/data/managers/core_models/test_headline.py
@@ -367,8 +367,8 @@ class TestCoreHeadlineManager:
 
         # When
         result = CoreHeadline.objects.get_latest_headlines_for_geography_codes(
-            topic_name=topic_name,
-            metric_name=metric_name,
+            topic=topic_name,
+            metric=metric_name,
             geography_codes=[first_geography_code, second_geography_code],
         )
 


### PR DESCRIPTION
# Description

This PR includes the following:

- Refactoring part 3 to improve the interopability between the metrics api and data layers. Long story short we have lots of fields like topic_name, topic. This series of PRs reworks all of this so that we just have say topic, which would lean on the corresponding type hint to tell us if it's just a string or a Topic model etc.
This will help the main work here (dual category charts) in how we unpack queries from the api layer down into the data layer

Fixes #CDD-2616

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
