### PR TITLE
CDD-2621: Dual category chart card cms component

### DIFF
--- a/cms/dashboard/static/js/dual_category_chart_form.js
+++ b/cms/dashboard/static/js/dual_category_chart_form.js
@@ -1,0 +1,420 @@
+/**
+ * FormStateManager - Handles all form state operations
+ */
+class FormStateManger {
+    constructor() {
+        this.primary_field_values_state = [];
+        this.secondary_field_value_state = [];
+    }
+
+    /**
+     * @name initialise
+     * @description Initialise state from Wagtail's initialState object
+     * @param initialState {object} the initial form state from wagtail
+     */
+    initialise(initialState) {
+        if (!initialState) {
+            return;
+        }
+
+        this.primary_field_values_state = initialState?.primary_field_values || [];
+        this.secondary_field_value_state = initialState?.segments?.map(segment => (
+            segment.value?.secondary_field_value || []
+        )) || [];
+    }
+
+    /**
+     * @name clearPrimaryFieldState
+     * @description clears primary field state
+     */
+    clearPrimaryFieldState() {
+        this.primary_field_values_state = [];
+    }
+
+    /**
+     * @name clearSecondaryFieldState
+     * @description clears secondary field state
+     */
+    clearSecondaryFieldState() {
+        this.secondary_field_value_state = [];
+    }
+
+    /**
+     * @name storeCurrentSelections
+     * @description Store the current selection state from secondary field inputs before DOM update
+     * @param inputs {NodeList} NodeList of secondary field values
+     */
+    storeCurrentSelections(inputs) {
+        if (!inputs) {
+            return;
+        }
+
+        this.secondary_field_value_state = Array.from(inputs).map(input => {
+            const selectedValues = [];
+
+            for (let i = 0; i < input.options.length; i++) {
+                const option = input.options[i];
+                if (option.selected && option.value !== "") {
+                    selectedValues.push(option.value);
+                }
+            }
+
+            return selectedValues;
+        })
+    }
+
+    /**
+     * @name isSecondaryFieldOptionValueSelected
+     * @description check in the secondary field value is selected
+     * @param value {string} a value from secondary field select options
+     * @param segmentIndex {int} the index of the current value being checked
+     * @return {boolean} whether the value should be selected
+     */
+    isSecondaryFieldOptionValueSelected(value, segmentIndex) {
+        return this.secondary_field_value_state &&
+            this.secondary_field_value_state[segmentIndex] &&
+            this.secondary_field_value_state[segmentIndex].includes(value);
+    }
+
+    /**
+     * @name isPrimaryValueSelected
+     * @description check the primary field value is selected
+     * @param value {string} the value to check
+     * @return {boolean} whether the value should be selected
+     */
+    isPrimaryValueSelected(value) {
+        return this.primary_field_values_state &&
+            this.primary_field_values_state.includes(value)
+    }
+}
+
+
+class DualCategoryChartCardBlockDefinition extends window.wagtailStreamField.blocks.StructBlockDefinition {
+
+   static SELECTORS = {
+        SEGMENTS_CONTAINER: '[class="dual-category-chart-card"] [data-streamfield-list-container]',
+        SEGMENT_ITEM: 'dual-category-chart-card__segments',
+        SECONDARY_FIELD_VALUE: '[id$="secondary_field_value"]'
+    };
+
+    static FIELD_SUFFIXES = {
+        X_AXIS: 'x_axis',
+        GEOGRAPHY: 'static_fields-geography_type',
+        SECONDARY_CATEGORY: 'second_category',
+        PRIMARY_VALUES: 'primary_field_values',
+        SECONDARY_VALUES: 'secondary_field_values',
+        DATA_SCRIPT: 'subcategory-data',
+        SEGMENTS: 'segments',
+        GEOGRAPHY_SUBCATEGORY_KEY: 'geography'
+    };
+
+    static DEFAULT_OPTION = {
+        VALUE: '',
+        TEXT: '-----'
+    };
+
+    stateManager = new FormStateManger()
+
+    // Category and subcategory choices
+    data_script = null;
+    secondary_category_choices = null;
+
+    // Category fields (fields that drive subcategory choice options)
+    x_axis_field = null;
+    geography_type_field = null;
+    secondary_category_field = null;
+
+    // Subcategory fields
+    primary_field_values_inputs = null;
+    secondary_field_value_inputs = null;
+
+    /**
+     * @name setupDataScript
+     * @description Retrieve JSON data from script tag containing all category data
+     * this JSON data is parsed into an object used to populate `secondary field options`.
+     * @param prefix - {string} html form prefix for element IDs
+     */
+    setupDataScript(prefix) {
+        const script_id = `${prefix}-${DualCategoryChartCardBlockDefinition.FIELD_SUFFIXES.DATA_SCRIPT}`;
+        this.data_script = document.getElementById(script_id);
+
+        if (!this.data_script) {
+            console.error(`Subcategory data script not found with ID: ${script_id}`);
+            this.secondary_category_choices = {};
+        }
+
+        try {
+            this.secondary_category_choices = JSON.parse(this.data_script.textContent);
+        } catch (error) {
+            console.error('Error parsing subcategory data JSON:', error, {
+                textContent: this.data_script.textContent
+            });
+            this.secondary_category_choices = {};
+        }
+
+    }
+
+    /**
+     * @name setupCategoryFormFields
+     * @description Gets all DOM elements from the dual category form that provide top level categories
+     * for elements that display sub-category details. Eg: an `x_axis_field` of age will populate
+     * `primary_field_values` options with age related options.
+     * @param prefix - {string} html form prefix for element IDs
+     */
+    setupCategoryFormFields(prefix) {
+        const { FIELD_SUFFIXES } = DualCategoryChartCardBlockDefinition;
+
+        this.x_axis_field = document.getElementById(`${prefix}-${FIELD_SUFFIXES.X_AXIS}`);
+        this.geography_type_field = document.getElementById(`${prefix}-${FIELD_SUFFIXES.GEOGRAPHY}`);
+        this.secondary_category_field = document.getElementById(`${prefix}-${FIELD_SUFFIXES.SECONDARY_CATEGORY}`);
+
+        const missingFields = [];
+        if (!this.x_axis_field) missingFields.push(FIELD_SUFFIXES.X_AXIS);
+        if (!this.geography_type_field) missingFields.push(FIELD_SUFFIXES.GEOGRAPHY);
+        if (!this.secondary_category_field) missingFields.push(FIELD_SUFFIXES.SECONDARY_CATEGORY);
+
+        if(missingFields.length > 0) {
+            console.error(`Category form fields not found: ${missingFields.join(', ')}`, {
+                prefix,
+                x_axis_field: this.x_axis_field,
+                geography_type_field: this.geography_type_field,
+                secondary_category_field: this.secondary_category_field
+            });
+        }
+    }
+
+    /**
+     * @name setupSubCategoryFormFields
+     * @description Gets all DOM elements from dual category segments form that provide subcategory
+     * options for a charts segments. Eg: the segments `primary_field_values` will display options related
+     * to the category selected in `x_axis` field from our `primary form fields`
+     * @param prefix
+     */
+    setupSubCategoryFormFields(prefix) {
+        const { FIELD_SUFFIXES, SELECTORS } = DualCategoryChartCardBlockDefinition;
+
+        this.primary_field_values_inputs = document.getElementById(
+            `${prefix}-${FIELD_SUFFIXES.PRIMARY_VALUES}`
+        );
+        this.secondary_field_value_inputs = document.querySelectorAll(
+            `[id^="${prefix}-${FIELD_SUFFIXES.SEGMENTS}-"]${SELECTORS.SECONDARY_FIELD_VALUE}`
+        );
+
+        const missingFields = [];
+        if (!this.primary_field_values_inputs) missingFields.push(FIELD_SUFFIXES.PRIMARY_VALUES);
+        if (!this.secondary_field_value_inputs) missingFields.push(FIELD_SUFFIXES.SECONDARY_VALUES);
+
+        if (missingFields.length > 0) {
+            console.error(`Sub-category form fields not found: ${missingFields.join(', ')}`, {
+                prefix,
+                primary_field_values: this.primary_field_values_inputs,
+                secondary_field_value: this.primary_field_values_inputs?.length || 0
+            });
+        }
+    }
+
+    /**
+     * @name initialiseFieldOptions
+     * @description Populate field options on initial load based on current primary field
+     * and restore saved state for existing content
+     */
+    initialiseFieldOptions() {
+        if(!this.x_axis_field || !this.secondary_category_field || !this.secondary_category_choices) {
+            return;
+        }
+
+        const { DEFAULT_OPTION } = DualCategoryChartCardBlockDefinition;
+
+        if(this.x_axis_field && this.primary_field_values_inputs) {
+            this.updatePrimaryFieldValueOptions(this.x_axis_field.value);
+        }
+
+        if(this.secondary_category_field && this.secondary_field_value_inputs) {
+            this.updateSecondaryFieldValueOptions(this.secondary_category_field.value);
+        }
+
+        if(!this.x_axis_field.value && this.primary_field_values_inputs) {
+            this.primary_field_values_inputs.innerHTML = `<option value="${DEFAULT_OPTION.VALUE}">${DEFAULT_OPTION.TEXT}</option>`;
+        }
+
+        if(!this.secondary_category_field.value && this.secondary_field_value_inputs.length > 0) {
+            this.secondary_field_value_inputs.forEach(input => {
+                input.innerHTML = `<option value="${DEFAULT_OPTION.VALUE}">${DEFAULT_OPTION.TEXT}</option>`;
+            });
+        }
+    }
+
+    /**
+     * @name getFieldOptions
+     * @description This function return an array of array's containing value and label pairs for the forms
+     * selection options. These options are based on `primary` field choices. Eg: if a primary field (such as x_axis)
+     * has a value of `age` then the options in our list should be of `age groups`.
+     * @param subcategory_key {string} representing the sub category key (primary category)
+     */
+    getFieldOptions(subcategory_key) {
+        const { GEOGRAPHY_SUBCATEGORY_KEY } = DualCategoryChartCardBlockDefinition.FIELD_SUFFIXES
+
+        if (subcategory_key && subcategory_key !== GEOGRAPHY_SUBCATEGORY_KEY) {
+            return this.secondary_category_choices[subcategory_key] || [];
+        }
+
+        if (subcategory_key === GEOGRAPHY_SUBCATEGORY_KEY && this.geography_type_field.value) {
+            return this.secondary_category_choices[subcategory_key][this.geography_type_field.value] || [];
+        }
+
+        return [];
+    }
+
+    /**
+     * @name updatePrimaryFieldValueOptions
+     * @description This function rebuilds the options for instance of the `primary field values` node
+     * @param subcategory_key - {string} the subcategory key used to retrieve the primary field value options.
+     */
+    updatePrimaryFieldValueOptions(subcategory_key) {
+        const { DEFAULT_OPTION } = DualCategoryChartCardBlockDefinition;
+
+        this.primary_field_values_inputs.innerHTML = `<option value="${DEFAULT_OPTION.VALUE}">${DEFAULT_OPTION.TEXT}</option>`;
+
+        const options = this.getFieldOptions(subcategory_key)
+
+        options.forEach(([value, label]) => {
+            const option = document.createElement('option');
+            option.value = value;
+            option.textContent = label;
+
+            if (this.stateManager.isPrimaryValueSelected(value)) {
+                option.selected = true;
+            }
+
+            this.primary_field_values_inputs.appendChild(option);
+        })
+    }
+
+    /**
+     * @name updateSecondaryFieldValueOptions
+     * @description This function rebuilds the options for instance of the `secondary field value` node
+     * @param subcategory_key - {string} the subcategory key used to retrieve the primary field value options.
+     */
+    updateSecondaryFieldValueOptions(subcategory_key) {
+        const { DEFAULT_OPTION } = DualCategoryChartCardBlockDefinition;
+
+        this.secondary_field_value_inputs.forEach((secondary_field_value, index) => {
+            secondary_field_value.innerHTML = `<option value="${DEFAULT_OPTION.VALUE}">${DEFAULT_OPTION.TEXT}</option>`;
+
+            const options = this.getFieldOptions(subcategory_key)
+
+            options.forEach(([value, label]) => {
+                const option = document.createElement('option');
+                option.value = value;
+                option.textContent = label;
+
+                if (this.stateManager.isSecondaryFieldOptionValueSelected(value, index)) {
+                    option.selected = true;
+                }
+
+                secondary_field_value.appendChild(option);
+            });
+        });
+    }
+
+    /**
+     * @name observeSegmentsBlocks
+     * @description This makes use of the `MutationObserver` API to watch for new `segment` `ListBlock` items
+     * added to the DOM, when this is `observed` a number of functions are called that update the list of
+     * `SecondaryFormFields` and then update the options of these lists to ensure they align with the primary fields.
+     * @param prefix
+     */
+    observeSegmentBlocks(prefix) {
+        const { SELECTORS } =  DualCategoryChartCardBlockDefinition;
+        const segments_container = document.querySelector(SELECTORS.SEGMENTS_CONTAINER)
+
+        if(!segments_container) {
+            console.warn("Segments container not found - observer disabled");
+            return;
+        }
+
+        const observer = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                if (mutation.type === "childList") {
+                    mutation.addedNodes.forEach(node => {
+                        if (node.nodeType === 1 && node.classList.contains(SELECTORS.SEGMENT_ITEM)) {
+
+                            this.stateManager.storeCurrentSelections(this.secondary_field_value_inputs);
+
+                            this.setupSubCategoryFormFields(prefix);
+                            if (this.secondary_category_field.value) {
+                                this.updateSecondaryFieldValueOptions(this.secondary_category_field.value);
+                            }
+
+                        }
+                    })
+                }
+            })
+        })
+
+        observer.observe(segments_container, {
+            childList: true,
+            attributes: true,
+            subtree: true
+        })
+    }
+
+    /**
+     * @name setupEvents
+     * @description Setup event handlers for dynamic choice fields `secondary_category` and `x_axis_field`.
+     */
+    setupEvents() {
+        const { FIELD_SUFFIXES } = DualCategoryChartCardBlockDefinition;
+
+        this.x_axis_field.addEventListener("change", (evt) => {
+            this.stateManager.clearPrimaryFieldState();
+            this.updatePrimaryFieldValueOptions(evt.target.value)
+        });
+
+        this.secondary_category_field.addEventListener("change", (evt) => {
+            this.stateManager.clearSecondaryFieldState();
+            this.updateSecondaryFieldValueOptions(evt.target.value);
+        });
+
+        this.geography_type_field.addEventListener("change", (evt) => {
+            if(this.x_axis_field.value === FIELD_SUFFIXES.GEOGRAPHY_SUBCATEGORY_KEY) {
+                this.stateManager.clearPrimaryFieldState();
+                this.updatePrimaryFieldValueOptions(this.x_axis_field.value);
+            }
+
+            if(this.secondary_category_field.value === FIELD_SUFFIXES.GEOGRAPHY_SUBCATEGORY_KEY) {
+                this.stateManager.clearSecondaryFieldState();
+                this.updateSecondaryFieldValueOptions(this.secondary_category_field.value);
+            }
+        });
+    }
+
+    render(placeholder, prefix, initialState, initialError) {
+        const block = super.render(placeholder, prefix, initialState, initialError);
+
+        // initialise form state
+        this.stateManager.initialise(initialState);
+
+        // setup form data
+        this.setupDataScript(prefix);
+
+        // setup primary and secondary form fields
+        this.setupCategoryFormFields(prefix);
+        this.setupSubCategoryFormFields(prefix);
+
+        // Initial population of field options based on current/initial values
+        this.initialiseFieldOptions();
+
+        // Setup observer for watching segments list and event handlers on
+        this.observeSegmentBlocks(prefix);
+        this.setupEvents();
+
+        return block;
+    }
+
+}
+
+window.telepath.register(
+    'cms.dynamic_content.cards.DualCategoryChartCard',
+    DualCategoryChartCardBlockDefinition,
+);

--- a/cms/dashboard/templates/blocks/dual_category_chart_form.html
+++ b/cms/dashboard/templates/blocks/dual_category_chart_form.html
@@ -1,0 +1,27 @@
+{% load wagtailadmin_tags  %}
+
+{{ block.super }}
+
+<script type="application/json" id="{{ prefix }}-subcategory-data">
+    {{ subcategory_data|safe }}
+</script>
+
+<script type="application/json" id={{ prefix }}-current-values">
+    {{ current_values|safe }}
+</script>
+
+<div class="dual-category-chart-card">
+    {% if help_text %}
+        <div class="help">
+            {% icon name="help" classname="default" %}
+            {{ help_text }}
+        </div>
+    {% endif %}
+
+    {% for child in children.values %}
+        {% if child.block.label %}
+            <label class="w-field__label" {% if child.id_for_label %}for="{{ child.id_for_label }}"{% endif %}>{{ child.block.label }}{% if child.block.required %}<span class="w-required-mark">*</span>{% endif %}</label>
+        {% endif %}
+        {{ child.render_form }}
+    {% endfor %}
+</div>

--- a/cms/dashboard/templates/blocks/dual_category_segments_form.html
+++ b/cms/dashboard/templates/blocks/dual_category_segments_form.html
@@ -1,0 +1,28 @@
+{% load wagtailadmin_tags %}
+
+{{ block.super }}
+
+<div class="dual-category-chart-card__segments">
+    {% if help_text %}
+        <div class="helps">
+            {% icon name="help" classname="default" %}
+            {{ help_text }}
+        </div>
+    {% endif %}
+
+    {% for child in children.values %}
+        {% if child.block.label %}
+            <label class="w-field__label"
+                   {% if child.id_for_label %}
+                       for="{{ child.id_for_label }}"
+                   {% endif %}
+            >
+                {{ child.block.label }}
+                {% if child.block.required %}
+                    <span class="w-required-mark">*</span>
+                {% endif %}
+            </label>
+        {% endif %}
+        {{ child.render_form }}
+    {% endfor %}
+</div>

--- a/cms/dynamic_content/components.py
+++ b/cms/dynamic_content/components.py
@@ -2,8 +2,10 @@ from wagtail import blocks
 
 from cms.dynamic_content import elements, help_texts
 from cms.metrics_interface.field_choices_callables import (
+    get_all_subcategory_choices,
     get_all_unique_change_type_metric_names,
     get_all_unique_percent_change_type_names,
+    get_colours,
 )
 
 
@@ -26,6 +28,42 @@ class SimplifiedChartComponent(blocks.StreamBlock):
 
     class Meta:
         icon = "standalone_chart"
+
+
+class DualCategoryChartStaticFieldComponent(elements.BaseMetricsElement):
+    date_from = blocks.DateBlock(
+        required=False,
+        help_text=help_texts.DATE_FROM_FIELD,
+    )
+    date_to = blocks.DateBlock(
+        required=False,
+        help_text=help_texts.DATE_TO_FIELD,
+    )
+
+    class Meta:
+        icon = "standalone_chart"
+
+
+class DualCategoryChartSegmentComponent(blocks.StructBlock):
+    secondary_field_value = blocks.ChoiceBlock(
+        choices=get_all_subcategory_choices,
+        help_text=help_texts.SECONDARY_FIELD_VALUES,
+    )
+    colour = blocks.ChoiceBlock(
+        required=True,
+        choices=get_colours,
+        default=get_colours()[0],
+        help_text=help_texts.LINE_COLOUR_FIELD,
+    )
+    label = blocks.TextBlock(
+        required=False,
+        help_text=help_texts.LABEL_FIELD,
+    )
+
+    class Meta:
+        form_classname = "dual-category-chart-segments-form"
+        form_template = "blocks/dual_category_segments_form.html"
+        label = "Dual charts segments"
 
 
 class HeadlineNumberComponent(elements.BaseMetricsElement):

--- a/cms/dynamic_content/help_texts.py
+++ b/cms/dynamic_content/help_texts.py
@@ -363,3 +363,23 @@ Note that multiple page banners can be active on one page. Consider
 carefully if you need multiple announcements to be active at once as
 this can have an impact on user experience of the dashboard page.
 """
+
+SECONDARY_CATEGORY: str = """
+This is for selecting the Second categorical variable type for Dual category charts.
+For example when building a `Stacked bar chart` where the x-axis may be of type `Sex` and
+display `Male` and `Female` along the x-axis. If our stacked bar chart then breaks each bar up into
+age groups, then our `Secondary Category` type is `Age`.
+"""
+
+PRIMARY_FIELD_VALUES: str = """
+Select a list of primary field values for the chart, these will be you're x-axis.
+For example if we're creating a stacked bar chart that has a metric value in y and geographies along
+the x-axis. The `primary field values` should be the list of geographies to include in the chart.
+"""
+
+SECONDARY_FIELD_VALUES: str = """
+Select the secondary field for a `Segments` this is the second categorical variable used to create segments
+of a `stacked bar` chart. For example if we're creating a stacked bar chart that has a metric in the y-axis
+and geographies along the x-axis. If each bar is broken into segments by `age group` this field
+should be the age group for this segment.
+"""

--- a/cms/metrics_interface/interface.py
+++ b/cms/metrics_interface/interface.py
@@ -103,7 +103,7 @@ class MetricsAPIInterface:
     @staticmethod
     def get_simplified_chart_types() -> tuple[tuple[str, str], ...]:
         """Gets all available chart type choices for headline charts as a nested tuple of 2-item tuples.
-        Note this is achived by delegating the call to the `ChartTypes` enum from the metrics API
+        Note this is achieved by delegating the call to the `ChartTypes` enum from the metrics API
 
         Returns:
             Nested tuples of 2 item tuples as expected by the form blocks.
@@ -111,6 +111,18 @@ class MetricsAPIInterface:
                 (("line_single_simplified", "line_single_simplified"), ...)
         """
         return ChartTypes.selectable_simplified_chart_choices()
+
+    @staticmethod
+    def get_dual_category_chart_types() -> tuple[tuple[str, str], ...]:
+        """Gets all available chart type choices for dual category charts as a nested tuple of 2-item tuples.
+        Note this is achieved by delegating the calle to the `ChartTypes` enum from the Metrics API
+
+        Returns:
+            Nested tuples of 2 item tuples as expected by the form blocks.
+            Examples:
+                (("stacked_bar", "stacked_bar"), ...)
+        """
+        return ChartTypes.dual_category_chart_options()
 
     @staticmethod
     def get_chart_axis_choices() -> list[tuple[str, str]]:
@@ -267,6 +279,24 @@ class MetricsAPIInterface:
         """
         return self.geography_manager.get_geography_codes_and_names_by_geography_type(
             geography_type_name=geography_type,
+        )
+
+    def get_all_geography_names_by_geography_type(
+        self,
+        geography_type_name: str,
+    ):
+        """Gets all geography names for a particular geography type, for example `Nation` or
+            `Government Office Region`.
+
+        Note: this is achieved by delegating the call to the `GeographyManager` from Metrics API
+
+        Returns:
+            QuerySet: A queryset of the geography_names fields as a list of tuples.
+                Example:
+                    `<GeographyQuerySet ['North East', 'North West']>`
+        """
+        return self.geography_manager.get_all_geography_names_by_geography_type(
+            geography_type_name=geography_type_name,
         )
 
     def get_all_geography_type_names(self) -> QuerySet:

--- a/metrics/data/managers/core_models/geography.py
+++ b/metrics/data/managers/core_models/geography.py
@@ -41,6 +41,23 @@ class GeographyQuerySet(models.QuerySet):
             .order_by("geography_code")
         )
 
+    def get_all_geography_names_by_geography_type(
+        self,
+        geography_type_name: str,
+    ) -> Self:
+        """Gets all available geography names for the given `geography_type_name`.
+        Returns:
+            QuerySet: A queryset of the individual geography names
+            which are related to the given geography_type:
+            Examples:
+                `<GeographyQuerySet ['England', 'London']>`
+        """
+        return (
+            self.filter(geography_type__name=geography_type_name)
+            .values_list("name", flat=True)
+            .order_by("name")
+        )
+
     def get_geography_codes_and_names_by_geography_type(
         self,
         geography_type_name: str,
@@ -96,6 +113,22 @@ class GeographyManager(models.Manager):
 
         """
         return self.get_queryset().get_all_geography_codes_by_geography_type(
+            geography_type_name=geography_type_name
+        )
+
+    def get_all_geography_names_by_geography_type(self, geography_type_name: str):
+        """Gets all available geography names for the given `geography_type_name`.
+
+        Args:
+            geography_type_name: string representation of `geography_type_name`
+
+        Returns:
+            QuerySet: A queryset of the individual geography names
+            which are related to the given geography_type:
+            Examples:
+                `<GeographyQuerySet ['England', 'London']>`
+        """
+        return self.get_queryset().get_all_geography_names_by_geography_type(
             geography_type_name=geography_type_name
         )
 

--- a/metrics/domain/common/utils.py
+++ b/metrics/domain/common/utils.py
@@ -106,6 +106,21 @@ class ChartTypes(Enum):
         return [chart_type.value for chart_type in selectable]
 
     @classmethod
+    def dual_category_chart_options(cls) -> list[str]:
+        """Returns a list of `dual` chart types as strings
+        Note:
+            Dual category chart types include charts like `stacked-bar` and `pyramid` chart,
+            which are charts that include two categorical variables.
+
+        Returns:
+            A list of `dual` chart types as strings.
+            Examples:
+                ["stacked-bar", "pyramid"]
+        """
+        selectable = (cls.stacked_bar, cls.pyramid)
+        return tuple((chart_type.value, chart_type.value) for chart_type in selectable)
+
+    @classmethod
     def values(cls) -> list[str]:
         return [chart_type.value for chart_type in cls]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ target-version = "py312"
                                                                  "S101",           # Ignore use of `assert` statement in tests
                                                                  "SLF001"          # Ignore access of private methods/attributes in tests
                                                                 ]
+"cms/dynamic_content/cards.py"                                = ["SLF001"]         # Ignore access to protected member
 "metrics/api/views/*"                                         = ["E501"]           # Ignore line length in API views.
                                                                                         # This infringement is due to
                                                                                         # swagger-facing docstrings/documentation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,19 @@ DATA_PAYLOAD_HINT = dict[str, str | datetime.date]
 
 
 @pytest.fixture
+def fake_subcategory_choices_grouped_by_categories() -> dict[str, list[str]]:
+    return {
+        "age": ["00-04", "05-11"],
+        "sex": ["m", "f"],
+        "stratum": ["default", "unknown"],
+        "geography": {
+            "Nation": ["England", "England"],
+            "Region": ["RegionOne", "RegionOne"],
+        },
+    }
+
+
+@pytest.fixture
 def fake_chart_plot_parameters() -> PlotParameters:
     return PlotParameters(
         chart_type="line_multi_coloured",

--- a/tests/factories/metrics/geography_type.py
+++ b/tests/factories/metrics/geography_type.py
@@ -14,7 +14,7 @@ class GeographyTypeFactory(factory.django.DjangoModelFactory):
     @factory.post_generation
     def with_geographies(self, create, extracted, **kwargs):
         if create:
-            geography_names: list[str] = kwargs.get("geography_names", [])
+            geography_names: list[str] = extracted
 
             geographies = [
                 Geography.objects.create(name=geography_name)

--- a/tests/integration/metrics/data/managers/core_models/test_geography.py
+++ b/tests/integration/metrics/data/managers/core_models/test_geography.py
@@ -1,0 +1,43 @@
+import pytest
+
+from metrics.data.models.core_models.supporting import Geography
+from tests.factories.metrics.geography_type import GeographyTypeFactory
+
+
+class TestGeographyManager:
+    @pytest.mark.django_db
+    def test_query_for_all_geography_names_by_geography_type(
+        self,
+    ):
+        """
+        Given a number of existing `Geography` records
+        When `get_all_geography_names_by_geography_type` is called
+        Then the geographies have bee filtered correctly
+        """
+        # Given
+        fake_geography_type_name_one = "Nation"
+        fake_geography_type_name_two = "Region"
+        fake_geography_name_one = "England"
+        fake_geography_name_two = "North west"
+
+        GeographyTypeFactory(
+            name=fake_geography_type_name_one,
+            with_geographies=[fake_geography_name_one],
+        )
+        GeographyTypeFactory(
+            name=fake_geography_type_name_two,
+            with_geographies=[fake_geography_name_two],
+        )
+
+        # When
+        all_geography_names = Geography.objects.all()
+        all_geography_names_by_type = (
+            Geography.objects.get_all_geography_names_by_geography_type(
+                geography_type_name=fake_geography_type_name_one
+            )
+        )
+
+        # Then
+        assert all_geography_names.count() == 2
+        assert all_geography_names_by_type.count() == 1
+        assert all_geography_names_by_type.first() == fake_geography_name_one

--- a/tests/unit/cms/dynamic_content/test_dual_category_chart_card.py
+++ b/tests/unit/cms/dynamic_content/test_dual_category_chart_card.py
@@ -1,0 +1,132 @@
+import json
+from django import forms
+import unittest
+from unittest import mock
+from wagtail.blocks.struct_block import StructBlockAdapter
+
+import pytest
+
+from cms.dynamic_content.cards import (
+    DualCategoryChartCard,
+    DualCategoryChartCardAdapter,
+)
+from cms.metrics_interface import interface, field_choices_callables
+from cms.metrics_interface.field_choices_callables import (
+    get_all_geography_choices_grouped_by_type,
+)
+
+
+class TestDualCategoryChartCard:
+    @mock.patch.object(
+        field_choices_callables, "get_all_geography_choices_grouped_by_type"
+    )
+    @pytest.mark.parametrize(
+        "expected_dual_chart_card_field_name",
+        (
+            "title",
+            "body",
+            "about",
+            "tag_manager_event_id",
+            "x_axis",
+            "x_axis_title",
+            "primary_field_values",
+            "y_axis",
+            "y_axis_title",
+            "y_axis_minimum_value",
+            "y_axis_maximum_value",
+            "chart_type",
+            "second_category",
+        ),
+    )
+    def test_dual_chart_card_has_expected_fields(
+        self,
+        mocked_get_all_geography_choices_grouped_by_type: mock.MagicMock,
+        expected_dual_chart_card_field_name: str,
+        fake_subcategory_choices_grouped_by_categories: dict[str, list[str]],
+    ):
+        """
+        Given an instance of `DualCategoryChartCard`
+        When inspecting child blocks
+        Then The expected field(s) are available
+        """
+        # Given
+        mocked_get_all_geography_choices_grouped_by_type.return_value = (
+            fake_subcategory_choices_grouped_by_categories["geography"]
+        )
+        dual_category_chart_card = DualCategoryChartCard()
+
+        # When
+        selected_field = dual_category_chart_card.child_blocks.get(
+            expected_dual_chart_card_field_name
+        )
+
+        # Then
+        assert selected_field is not None
+
+    @mock.patch(
+        "cms.dynamic_content.cards.get_all_subcategory_choices_grouped_by_categories"
+    )
+    def test_get_form_context_with_default_parameters(
+        self,
+        mocked_get_subcategory_choices_grouped_by_categories: mock.MagicMock,
+        fake_subcategory_choices_grouped_by_categories: dict[str, list[str]],
+    ):
+        """
+        Given an instance of `DualCategoryChartCard`
+        When `get_form_context()` is called
+        Then the expected `prefix` and `subcategory_data` is available
+        """
+        # Given
+        mock_value = {}
+        mock_prefix = "mock-prefix"
+        fake_subcategory_choices = fake_subcategory_choices_grouped_by_categories
+        mocked_get_subcategory_choices_grouped_by_categories.return_value = (
+            fake_subcategory_choices
+        )
+        dual_category_chart_card = DualCategoryChartCard()
+        expected_context_subcategory_data = json.dumps(fake_subcategory_choices)
+
+        # When
+        context = dual_category_chart_card.get_form_context(
+            mock_value,
+            mock_prefix,
+        )
+
+        # Then
+        assert context["prefix"] == mock_prefix
+        assert context["subcategory_data"] == expected_context_subcategory_data
+
+
+class TestDualCategoryChartCardAdapter:
+    def test_js_constructor_is_set_correctly(self):
+        """
+        Given a DualCategoryChartAdapter instance
+        When accessing the js_constructor property
+        Then it returns the correct javascript constructor name
+        """
+        # Given
+        dual_chart_adapter = DualCategoryChartCardAdapter()
+        expected_js_constructor = "cms.dynamic_content.cards.DualCategoryChartCard"
+
+        # When
+        received_js_constructor = dual_chart_adapter.js_constructor
+
+        # Then
+        assert received_js_constructor == expected_js_constructor
+
+    @mock.patch.object(StructBlockAdapter, "media", forms.Media(js=["mock_parent.js"]))
+    def test_media_preserves_parent_js_unchanged(self):
+        """
+        Given a DualCategoryChartAdapter instance and mocked parent media with existing js
+        When accessing the media property
+        Then it combines parent JS files where `dual_category_chart_form.js`
+        """
+        # Given
+        dual_chart_adapter = DualCategoryChartCardAdapter()
+        expected_media_js = ["mock_parent.js", "js/dual_category_chart_form.js"]
+
+        # When
+        dual_chart_adapter_media = dual_chart_adapter.media
+
+        # Then
+        assert dual_chart_adapter_media._js == expected_media_js

--- a/tests/unit/cms/metrics_interface/test_interface.py
+++ b/tests/unit/cms/metrics_interface/test_interface.py
@@ -44,7 +44,7 @@ class TestMetricsAPIInterface:
             selectable_headline_chart_types == ChartTypes.selectable_headline_choices()
         )
 
-    def test_get_simpliied_chart_type_delegates_calls_correctly(self):
+    def test_get_simplified_chart_type_delegates_calls_correctly(self):
         """
         Given an instance of the `MetricsAPIInterface`
         When `get_simplified_chart_types()` is called from that object
@@ -62,6 +62,26 @@ class TestMetricsAPIInterface:
         assert (
             selectable_simplified_chart_types
             == ChartTypes.selectable_simplified_chart_choices()
+        )
+
+    def test_get_dual_category_chart_types_delegates_call_correctly(self):
+        """
+        Given an instance of `MetricsAPIInterface`
+        When `get_dual_category_chart_types()` is called from that object
+        Then the call is delegated to the correct method on the `ChartTypes` enum
+        """
+        # Given
+        metrics_api_interface = interface.MetricsAPIInterface()
+
+        # When
+        selectable_dual_category_chart_types = (
+            metrics_api_interface.get_dual_category_chart_types()
+        )
+
+        # Then
+        assert (
+            selectable_dual_category_chart_types
+            == ChartTypes.dual_category_chart_options()
         )
 
     def test_get_chart_axis_choices_delegates_call_correctly(self):
@@ -314,6 +334,33 @@ class TestMetricsAPIInterface:
         assert (
             geography_names_and_codes
             == spy_geography_manager.get_geography_codes_and_names_by_geography_type.return_value
+        )
+
+    def test_get_all_geography_names_by_geography_type_delegates_calls_correctly(
+        self,
+    ):
+        """
+        Given a `GeographyManager` from the metrics API app
+        When `get_all_geography_names_by_geography_type()` is called from an instance of the
+        Then the call is delegated to teh correct method on the `GeographyManager`
+        """
+        # Given
+        spy_geography_manager = mock.Mock()
+        metrics_api_interface = interface.MetricsAPIInterface(
+            geography_manager=spy_geography_manager,
+        )
+
+        # When
+        geography_names_by_geography_type = (
+            metrics_api_interface.get_all_geography_names_by_geography_type(
+                geography_type_name="fake_geography_type_name",
+            )
+        )
+
+        # Then
+        assert (
+            geography_names_by_geography_type
+            == spy_geography_manager.get_all_geography_names_by_geography_type.return_value
         )
 
     def test_get_all_geography_type_names_delegates_call_correctly(

--- a/tests/unit/metrics/data/managers/core_models/test_geography.py
+++ b/tests/unit/metrics/data/managers/core_models/test_geography.py
@@ -1,0 +1,32 @@
+from unittest import mock
+
+from metrics.data.managers.core_models.geography import (
+    GeographyManager,
+    GeographyQuerySet,
+)
+
+
+class TestGeographyManager:
+    @mock.patch.object(GeographyQuerySet, "get_all_geography_names_by_geography_type")
+    def test_get_all_geography_names_by_type(
+        self, spy_get_all_geography_names_by_type: mock.MagicMock
+    ):
+        """
+        Given a payload containing the required field
+        When `get_all_geography_names_by_type` is called,
+        Then it delegates call to `GeographyQuerySet`.
+        """
+        # Given
+        fake_geography_type = "fake_geography_type"
+        geography_manager = GeographyManager()
+
+        # When
+        GeographyManager.get_all_geography_names_by_geography_type(
+            geography_manager,
+            geography_type_name=fake_geography_type,
+        )
+
+        # Then
+        spy_get_all_geography_names_by_type.assert_called_with(
+            geography_type_name=fake_geography_type,
+        )


### PR DESCRIPTION
# Description

This PR implements a new CMS component for `DualCategoryChartsCard` for content creators to create charts with two categorical variables such as `stacked_bar` charts.

-

Fixes #CDD-2621

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
