### PR TITLE
Extract latest associated date for maps output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,8 +139,6 @@ omit = [
     "metrics/api/wsgi.py",              # Boilerplate Django server entrypoint
     "metrics/api/asgi.py",              # Boilerplate Django server entrypoint
     "metrics/api/settings/*",           # Configuration paackage
-    "metrics/api/views/maps.py",        # Temporary bypass whilst API is being built
-    "metrics/api/serializers/maps.py",  # Temporary bypass whilst API is being built
     "config.py",                        # Configuration file
     "manage.py",                        # Application server entrypoint
     "*/migrations/*"                    # Database migrations

--- a/tests/integration/metrics/api/views/test_maps.py
+++ b/tests/integration/metrics/api/views/test_maps.py
@@ -1,3 +1,4 @@
+import datetime
 from decimal import Decimal
 
 from rest_framework.response import Response
@@ -34,6 +35,8 @@ class TestMapsView:
         """
         # Given
         client = APIClient()
+        earlier_date = datetime.date(year=2025, month=1, day=1)
+        latest_date = datetime.date(year=2025, month=12, day=31)
 
         bexley = CoreTimeSeriesFactory.create_record(
             metric_name=self.covid_19_cases_metric,
@@ -42,6 +45,7 @@ class TestMapsView:
             geography_name="Bexley",
             geography_code="E09000004",
             metric_value=1,
+            date=latest_date,
         )
         arun = CoreTimeSeriesFactory.create_record(
             metric_name=self.covid_19_cases_metric,
@@ -50,6 +54,7 @@ class TestMapsView:
             geography_name="Arun",
             geography_code="E07000224",
             metric_value=2,
+            date=earlier_date,
         )
         hackney = CoreTimeSeriesFactory.create_record(
             metric_name=self.covid_19_cases_metric,
@@ -58,6 +63,7 @@ class TestMapsView:
             geography_name="Hackney",
             geography_code="E09000012",
             metric_value=3,
+            date=earlier_date,
         )
         CoreTimeSeriesFactory.create_record(
             metric_name=self.covid_19_cases_metric,
@@ -66,6 +72,7 @@ class TestMapsView:
             geography_name="England",
             geography_code="E92000001",
             metric_value=4,
+            date=datetime.date(year=2025, month=1, day=1),
         )
         # An unrelated record which should not be returned
         CoreTimeSeriesFactory.create_record(
@@ -157,7 +164,7 @@ class TestMapsView:
 
         assert response.data == {
             "data": expected_data,
-            "latest_date": "2025-01-01",
+            "latest_date": latest_date,
         }
 
     @pytest.mark.django_db
@@ -171,6 +178,7 @@ class TestMapsView:
         """
         # Given
         client = APIClient()
+        date_stamp = datetime.date(year=2020, month=1, day=1)
 
         CoreTimeSeriesFactory.create_record(
             metric_name=self.covid_19_cases_metric,
@@ -179,6 +187,7 @@ class TestMapsView:
             geography_name="Bexley",
             geography_code="E09000004",
             metric_value=1,
+            date=date_stamp,
         )
         CoreTimeSeriesFactory.create_record(
             metric_name=self.covid_19_cases_metric,
@@ -187,6 +196,7 @@ class TestMapsView:
             geography_name="Arun",
             geography_code="E07000224",
             metric_value=2,
+            date=date_stamp,
         )
         hackney = CoreTimeSeriesFactory.create_record(
             metric_name=self.covid_19_cases_metric,
@@ -195,6 +205,7 @@ class TestMapsView:
             geography_name="Hackney",
             geography_code="E09000012",
             metric_value=3,
+            date=date_stamp,
         )
         CoreTimeSeriesFactory.create_record(
             metric_name=self.covid_19_cases_metric,
@@ -203,6 +214,7 @@ class TestMapsView:
             geography_name="England",
             geography_code="E92000001",
             metric_value=4,
+            date=date_stamp,
         )
         CoreTimeSeriesFactory.create_record(
             metric_name="influenza_healthcare_ICUHDUadmissionRateByWeek",
@@ -266,5 +278,5 @@ class TestMapsView:
 
         assert response.data == {
             "data": expected_data,
-            "latest_date": "2025-01-01",
+            "latest_date": date_stamp,
         }

--- a/tests/integration/metrics/api/views/test_maps.py
+++ b/tests/integration/metrics/api/views/test_maps.py
@@ -79,8 +79,8 @@ class TestMapsView:
             metric_name="influenza_healthcare_ICUHDUadmissionRateByWeek",
             topic_name="Influenza",
             geography_type_name=self.ltla,
-            geography_name="Leeds",
-            geography_code="E08000035",
+            geography_name="Bexley",
+            geography_code="E09000004",
             metric_value=5,
         )
 
@@ -96,11 +96,10 @@ class TestMapsView:
                 "age": "all",
                 "sex": "all",
                 "geography_type": self.ltla,
-                "geographies": [
-                    bexley.geography.name,
-                    arun.geography.name,
-                    hackney.geography.name,
-                ],
+                "geographies": [],
+                # When no `geographies` are specified,
+                # Then all geographies under the given `geography_type`
+                # should be returned
             },
             "accompanying_points": [
                 {
@@ -122,10 +121,10 @@ class TestMapsView:
         assert response.status_code == 200
         expected_data = [
             {
-                "geography_code": bexley.geography.geography_code,
+                "geography_code": arun.geography.geography_code,
                 "geography_type": self.ltla,
-                "geography": bexley.geography.name,
-                "metric_value": Decimal("1.0000"),
+                "geography": arun.geography.name,
+                "metric_value": Decimal("2.0000"),
                 "accompanying_points": [
                     {
                         "label_prefix": "Rate of cases in England:",
@@ -135,10 +134,10 @@ class TestMapsView:
                 ],
             },
             {
-                "geography_code": arun.geography.geography_code,
+                "geography_code": bexley.geography.geography_code,
                 "geography_type": self.ltla,
-                "geography": arun.geography.name,
-                "metric_value": Decimal("2.0000"),
+                "geography": bexley.geography.name,
+                "metric_value": Decimal("1.0000"),
                 "accompanying_points": [
                     {
                         "label_prefix": "Rate of cases in England:",


### PR DESCRIPTION
# Description

This PR includes the following:

- Extracts the latest `date` associated with the maps output and returns this in the maps API response

Fixes #CDD-2671

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
