### PR TITLE
Update crawler for both deprecated v2 and live `geographies/v3` APIs

### DIFF
--- a/caching/internal_api_client.py
+++ b/caching/internal_api_client.py
@@ -10,7 +10,8 @@ TRENDS_ENDPOINT_PATH = f"{API_PREFIX}trends/v3/"
 CHARTS_ENDPOINT_PATH = f"{API_PREFIX}charts/v3/"
 TABLES_ENDPOINT_PATH = f"{API_PREFIX}tables/v4/"
 DOWNLOADS_ENDPOINT_PATH = f"{API_PREFIX}downloads/v2/"
-GEOGRAPHIES_ENDPOINT_PATH = f"{API_PREFIX}geographies/v2/"
+GEOGRAPHIES_ENDPOINT_PATH_DEPRECATED = f"{API_PREFIX}geographies/v2/"
+GEOGRAPHIES_ENDPOINT_PATH = f"{API_PREFIX}geographies/v3/"
 GLOBAL_BANNERS_ENDPOINT_PATH = f"{API_PREFIX}global-banners/v1"
 MENUS_ENDPOINT_PATH = f"{API_PREFIX}menus/v1"
 
@@ -51,6 +52,7 @@ class InternalAPIClient:
         self.charts_endpoint_path = CHARTS_ENDPOINT_PATH
         self.tables_endpoint_path = TABLES_ENDPOINT_PATH
         self.downloads_endpoint_path = DOWNLOADS_ENDPOINT_PATH
+        self.geographies_endpoint_path_deprecated = GEOGRAPHIES_ENDPOINT_PATH_DEPRECATED
         self.geographies_endpoint_path = GEOGRAPHIES_ENDPOINT_PATH
         self.global_banners_endpoint_path = GLOBAL_BANNERS_ENDPOINT_PATH
         self.menus_endpoint_path = MENUS_ENDPOINT_PATH
@@ -161,16 +163,33 @@ class InternalAPIClient:
         headers = self.build_headers()
         return self._client.post(path=path, data=data, headers=headers, format="json")
 
-    def hit_geographies_list_endpoint(self, *, topic: str) -> Response:
-        """Sends a `GET` request to the list `geographies/` endpoint
+    def hit_geographies_list_endpoint_deprecated(self, *, topic: str) -> Response:
+        """Sends a `GET` request to the list `geographies/v2` endpoint
 
         Returns:
             `Response` from the `geographies/` endpoint
 
         """
-        path: str = urljoin(base=self.geographies_endpoint_path, url=topic)
+        path: str = urljoin(base=self.geographies_endpoint_path_deprecated, url=topic)
         headers: dict[str, bool] = self.build_headers()
         return self._client.get(path=path, headers=headers, format="json")
+
+    def hit_geographies_list_endpoint(self, *, topic: str) -> Response:
+        """Sends a `GET` request to the `geographies/v3` endpoint
+
+        Returns:
+            `Response` from the `geographies/` endpoint
+
+        """
+        self.hit_geographies_list_endpoint_deprecated(topic=topic)
+        headers: dict[str, bool] = self.build_headers()
+        query_params = {"topic": topic}
+        return self._client.get(
+            path=self.geographies_endpoint_path,
+            headers=headers,
+            format="json",
+            query_params=query_params,
+        )
 
     def hit_pages_list_endpoint(self) -> Response:
         """Sends a `GET` request to the list `pages/` endpoint.

--- a/tests/unit/caching/test_internal_api_client.py
+++ b/tests/unit/caching/test_internal_api_client.py
@@ -23,7 +23,8 @@ class TestInternalAPIClient:
                 ("charts_endpoint_path", "/api/charts/v3/"),
                 ("tables_endpoint_path", "/api/tables/v4/"),
                 ("downloads_endpoint_path", "/api/downloads/v2/"),
-                ("geographies_endpoint_path", "/api/geographies/v2/"),
+                ("geographies_endpoint_path_deprecated", "/api/geographies/v2/"),
+                ("geographies_endpoint_path", "/api/geographies/v3/"),
                 ("global_banners_endpoint_path", "/api/global-banners/v1"),
                 ("menus_endpoint_path", "/api/menus/v1"),
             ]

--- a/tests/unit/caching/test_internal_api_client.py
+++ b/tests/unit/caching/test_internal_api_client.py
@@ -327,12 +327,22 @@ class TestInternalAPIClient:
 
         # Then
         assert response == internal_api_client._client.get.return_value
-        expected_path = f"{internal_api_client.geographies_endpoint_path}{topic}"
-
-        mocked_client.get.assert_called_once_with(
-            path=expected_path,
-            headers=internal_api_client.build_headers(),
+        expected_path = internal_api_client.geographies_endpoint_path
+        headers = internal_api_client.build_headers()
+        deprecated_api_call = mock.call(
+            path=f"{internal_api_client.geographies_endpoint_path_deprecated}{topic}",
+            headers=headers,
             format="json",
+        )
+        live_api_call = mock.call(
+            path=expected_path,
+            query_params={"topic": topic},
+            headers=headers,
+            format="json",
+        )
+
+        mocked_client.get.assert_has_calls(
+            calls=[deprecated_api_call, live_api_call], any_order=False
         )
 
     def test_hit_pages_list_endpoint_delegates_call_correctly(self):


### PR DESCRIPTION
# Description

This PR includes the following:

- Updates the crawler so that it processes both geographies v2 and geographies v3 for `topic` combinations used for the area selector

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
