### PR TITLE
Task/reimplement clearing non reserved keys/cdd 2729

### DIFF
--- a/caching/private_api/client.py
+++ b/caching/private_api/client.py
@@ -45,32 +45,32 @@ class CacheClient:
         """
         self._cache.set(key=cache_entry_key, value=value, timeout=timeout)
 
-    def clear_non_reserved_keys(self, reserved_namespace_key_prefix: str) -> None:
-        """Deletes all keys in the cache which are not within the reserved namespace
-
-        Args:
-            reserved_namespace_key_prefix: The prefix associated
-                with reserved namespace entries in the cache.
-                Any keys prefixed with this will not be cleared.
-                All others will be cleared by this method invocation.
+    def list_keys(self) -> list[bytes]:
+        """Lists all the application-level keys in the cache
 
         Notes:
-            This allows us to keep hold of
-            expensive, infrequently changing data in the cache
-            like maps data, whilst still allowing the
-            cheaper more frequently changing data types like
-            tables and charts to be cleared.
+            This is the Django cache <-> Redis implementation
+            for listing all the keys in the cache.
+
+        Returns:
+            List of bytes where each byte represents a single key
+
+        """
+        low_level_client = self._cache._cache.get_client()
+        return low_level_client.keys("*ukhsa*")
+
+    def delete_many(self, keys: list) -> None:
+        """Deletes all the provided keys in the cache
+
+        Args:
+            keys: The cache keys to delete
+                within a bulk delete operation
 
         Returns:
             None
 
         """
-        non_reserved_keys = [
-            key
-            for key in self._cache.scan_iter()
-            if reserved_namespace_key_prefix not in key
-        ]
-        self._cache.delete_many(keys=non_reserved_keys)
+        self._cache.delete_many(keys=keys)
 
     def clear(self) -> None:
         """Deletes all keys in the cache

--- a/caching/private_api/client.py
+++ b/caching/private_api/client.py
@@ -136,28 +136,16 @@ class InMemoryCacheClient(CacheClient):
         """
         self._cache.clear()
 
-    def clear_non_reserved_keys(self, *, reserved_namespace_key_prefix: str) -> None:
+    def delete_many(self, *, keys: list) -> None:
         """Deletes all keys in the cache which are not within the reserved namespace
 
         Args:
-            reserved_namespace_key_prefix: The prefix associated
-                with reserved namespace entries in the cache.
-                Any keys prefixed with this will not be cleared.
-                All others will be cleared by this method invocation.
-
-        Notes:
-            This allows us to keep hold of
-            expensive, infrequently changing data in the cache
-            like maps data, whilst still allowing the
-            cheaper more frequently changing data types like
-            tables and charts to be cleared.
+            keys: The cache keys to delete
+                within a bulk delete operation
 
         Returns:
             None
 
         """
-        non_reserved_keys = [
-            key for key in self._cache if reserved_namespace_key_prefix not in key
-        ]
-        for key in non_reserved_keys:
+        for key in keys:
             self._cache.pop(key)

--- a/caching/private_api/management.py
+++ b/caching/private_api/management.py
@@ -151,7 +151,11 @@ class CacheManagement:
 
     def _get_non_reserved_keys(self) -> list[CacheKey]:
         all_keys = self._get_keys()
-        return [str(cache_key) for cache_key in all_keys if not cache_key.is_reserved_namespace]
+        return [
+            str(cache_key)
+            for cache_key in all_keys
+            if not cache_key.is_reserved_namespace
+        ]
 
     def _get_keys(self) -> list[CacheKey]:
         all_raw_keys: list[bytes] = self._client.list_keys()

--- a/caching/private_api/management.py
+++ b/caching/private_api/management.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+from typing import Self
 
 from rest_framework.renderers import JSONRenderer
 from rest_framework.request import Request
@@ -12,6 +13,30 @@ class CacheMissError(Exception): ...
 
 
 RESERVED_NAMESPACE_KEY_PREFIX = "ns2"
+
+
+class CacheKey:
+    def __init__(self, prefix: str, version: int, key: str):
+        self._key = key
+        self._prefix = prefix
+        self._version = version
+
+    def __repr__(self) -> str:
+        return f"{self._prefix}:{self._version}:{self._key}"
+
+    def __str__(self) -> str:
+        return self._key
+
+    @classmethod
+    def create(cls, raw_key: bytes | str) -> Self:
+        raw_key = str(raw_key)
+        raw_key = raw_key.strip("b'\"")
+        prefix, version, key = raw_key.split(":")
+        return cls(prefix=prefix, version=version, key=key)
+
+    @property
+    def is_reserved_namespace(self) -> bool:
+        return self._key.startswith(RESERVED_NAMESPACE_KEY_PREFIX)
 
 
 class CacheManagement:
@@ -121,9 +146,16 @@ class CacheManagement:
             None
 
         """
-        self._client.clear_non_reserved_keys(
-            reserved_namespace_key_prefix=self._reserved_namespace_key_prefix
-        )
+        non_reserved_keys: list[CacheKey] = self._get_non_reserved_keys()
+        self._client.delete_many(keys=non_reserved_keys)
+
+    def _get_non_reserved_keys(self) -> list[CacheKey]:
+        all_keys = self._get_keys()
+        return [str(cache_key) for cache_key in all_keys if not cache_key.is_reserved_namespace]
+
+    def _get_keys(self) -> list[CacheKey]:
+        all_raw_keys: list[bytes] = self._client.list_keys()
+        return [CacheKey.create(raw_key=raw_key) for raw_key in all_raw_keys]
 
     def _render_response(self, *, response: Response) -> Response:
         if response.headers["Content-Type"] == "text/csv":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,8 @@ target-version = "py312"
 "public_api/views/root_view.py"                               = ["A002"]           # Ignore built-in `format` used in arg to extended
 "public_api/version_02/views/root_view.py"                    = ["A002"]           # Ignore built-in `format` used in arg to extended
                                                                                         # rest framework API view method
+"caching/private_api/client.py"                               = ["SLF001"]         # Ignore access to private member
+                                                                                        # due to low level Redis client being used
 "caching/public_api/crawler.py"                               = ["PERF401"]        # Ignore list comprehension which would reduce readibility
 "caching/common/geographies_crawler.py"                       = ["PLW1641"]        # Ignore requirement of `__hash__` implementation
 "metrics/domain/weather_health_alerts/text_lookups/*"         = ["W291"]           # Ignore trailing whitespace for weather alert text lookups

--- a/tests/unit/caching/private_api/test_client.py
+++ b/tests/unit/caching/private_api/test_client.py
@@ -80,28 +80,21 @@ class TestCacheClient:
         spy_cache.clear.assert_called_once()
 
     @mock.patch(f"{MODULE_PATH}.cache")
-    def test_clear_non_reserved_keys_delegates_call(self, spy_cache: mock.MagicMock):
+    def test_delete_many_delegates_call(self, spy_cache: mock.MagicMock):
         """
         Given an instance of the `CacheClient`
-        When `clear_non_reserved_keys()` is called from the client
+        When `delete_many()` is called from the client
         Then the call is delegated to the underlying cache
         """
         # Given
-        reserved_namespace_key_prefix = "reserved-ns"
         cache_client = CacheClient()
+        mocked_keys = [mock.Mock()] * 3
 
         # When
-        cache_client.clear_non_reserved_keys(
-            reserved_namespace_key_prefix=reserved_namespace_key_prefix
-        )
+        cache_client.delete_many(keys=mocked_keys)
 
         # Then
-        all_cache_keys = spy_cache.scan_iter.return_value
-        filtered_non_reserved_keys = [
-            key for key in all_cache_keys if reserved_namespace_key_prefix not in key
-        ]
-
-        spy_cache.delete_many.assert_called_once_with(keys=filtered_non_reserved_keys)
+        spy_cache.delete_many.assert_called_once_with(keys=mocked_keys)
 
 
 class TestInMemoryCacheClient:
@@ -186,12 +179,12 @@ class TestInMemoryCacheClient:
         # Then
         assert fake_cache_entry_key not in in_memory_cache_client._cache
 
-    def test_clear_non_reserved_keys_flushes_all_items(self):
+    def test_delete_many_clears_select_keys_only(self):
         """
         Given a number of cache keys
-        When `clear_non_reserved_keys()` is called
+        When `delete_many()` is called
             from an instance of the `InMemoryCacheClient`
-        Then only the non-reserved keys are deleted
+        Then only the given keys are deleted
         """
         # Given
         reserved_namespace_key_prefix = "reserved-ns"
@@ -205,8 +198,8 @@ class TestInMemoryCacheClient:
         }
 
         # When
-        in_memory_cache_client.clear_non_reserved_keys(
-            reserved_namespace_key_prefix=reserved_namespace_key_prefix
+        in_memory_cache_client.delete_many(
+            keys=[non_reserved_cache_key],
         )
 
         # Then

--- a/tests/unit/caching/private_api/test_management.py
+++ b/tests/unit/caching/private_api/test_management.py
@@ -667,13 +667,18 @@ class TestCacheManagement:
         # Then
         spy_client.clear.assert_called_once()
 
-    def test_clear_non_reserved_keys(self):
+    @mock.patch.object(CacheManagement, "_get_non_reserved_keys")
+    def test_clear_non_reserved_keys(
+        self, mocked_get_non_reserved_keys: mock.MagicMock
+    ):
         """
         Given an instance of `CacheManagement`
         When `clear_non_reserved_keys()` is called from the object
         Then the call is delegated to the underlying client
         """
         # Given
+        non_reserved_keys = [mock.Mock(), mock.Mock()]
+        mocked_get_non_reserved_keys.return_value = non_reserved_keys
         reserved_namespace_key_prefix = "abc-123456-"
         spy_client = mock.Mock()
         cache_management = CacheManagement(
@@ -686,6 +691,4 @@ class TestCacheManagement:
         cache_management.clear_non_reserved_keys()
 
         # Then
-        spy_client.clear_non_reserved_keys.assert_called_once_with(
-            reserved_namespace_key_prefix=reserved_namespace_key_prefix
-        )
+        spy_client.delete_many.assert_called_once_with(keys=non_reserved_keys)


### PR DESCRIPTION
# Description

This PR includes the following:

- Reimplements how we clear non reserved keys to work with the django <-> redis client system

Fixes #CDD-2729

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
