### PR TITLE
Replace hardcoded cache key prefix with value from django app settings

### DIFF
--- a/caching/private_api/client.py
+++ b/caching/private_api/client.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from django.core.cache import cache
 
+from metrics.api import settings
+
 
 class CacheClient:
     """The client abstraction used to interact with the cache as set by the main Django application

--- a/tests/unit/caching/private_api/test_client.py
+++ b/tests/unit/caching/private_api/test_client.py
@@ -96,6 +96,15 @@ class TestCacheClient:
         # Then
         spy_cache.delete_many.assert_called_once_with(keys=mocked_keys)
 
+    @mock.patch.dict(
+        in_dict="django.conf.settings.CACHES",
+        values={
+            "default": {
+                "KEY_PREFIX": "some-other-prefix",
+                "BACKEND": "django.core.cache.backends.redis.RedisCache",
+            }
+        },
+    )
     @mock.patch(f"{MODULE_PATH}.cache")
     def test_list_keys(self, spy_cache: mock.MagicMock):
         """
@@ -106,7 +115,7 @@ class TestCacheClient:
         """
         # Given
         cache_client = CacheClient()
-        prefix = "ukhsa"
+        prefix = "some-other-prefix"
 
         # When
         all_keys = cache_client.list_keys()

--- a/tests/unit/caching/private_api/test_management.py
+++ b/tests/unit/caching/private_api/test_management.py
@@ -668,6 +668,15 @@ class TestCacheManagement:
         # Then
         spy_client.clear.assert_called_once()
 
+    @mock.patch.dict(
+        in_dict="django.conf.settings.CACHES",
+        values={
+            "default": {
+                "KEY_PREFIX": "app",
+                "BACKEND": "django.core.cache.backends.redis.RedisCache",
+            }
+        },
+    )
     def test_clear_non_reserved_keys(self):
         """
         Given an instance of `CacheManagement`
@@ -675,15 +684,16 @@ class TestCacheManagement:
         Then the call is delegated to the underlying client
         """
         # Given
+        cache_prefix = "app"
         reserved_namespace_key_prefix = "ns2"
         non_reserved_complete_keys = [
-            "ukhsa:1:abc123",
-            "ukhsa:1:def456",
-            "ukhsa:1:abc123456",
+            f"{cache_prefix}:1:abc123",
+            f"{cache_prefix}:1:def456",
+            f"{cache_prefix}:1:abc123456",
         ]
         reserved_complete_keys = [
-            f"ukhsa:1:{reserved_namespace_key_prefix}-abc123",
-            f"ukhsa:1:{reserved_namespace_key_prefix}-qwerty",
+            f"{cache_prefix}:1:{reserved_namespace_key_prefix}-abc123",
+            f"{cache_prefix}:1:{reserved_namespace_key_prefix}-qwerty",
         ]
         all_keys = non_reserved_complete_keys + reserved_complete_keys
         spy_client = mock.Mock()


### PR DESCRIPTION
# Description

This PR includes the following:

- Takes the `CACHES["default"]["KEY_PREFIX"]` value from the django app settings as the cache prefix to be used in our cache handling logic instead of hardcoding as `ukhsa`

Fixes #CDD-2729

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
