### PR TITLE
Task/add cache flush workflow for reserved namespace/cdd 2729

### DIFF
--- a/caching/internal_api_client.py
+++ b/caching/internal_api_client.py
@@ -16,6 +16,8 @@ MENUS_ENDPOINT_PATH = f"{API_PREFIX}menus/v1"
 
 
 CACHE_FORCE_REFRESH_HEADER_KEY = "Cache-Force-Refresh"
+CACHE_RESERVED_NAMESPACE_HEADER_KEY = "Cache-Reserved-Namespace"
+
 
 PAGE_TYPES_WITH_NO_ADDITIONAL_QUERY_PARAMS = (
     "common.CommonPage",
@@ -38,6 +40,7 @@ class InternalAPIClient:
         *,
         client: APIClient | None = None,
         force_refresh: bool = False,
+        reserved_namespace: bool = False,
     ):
         self._client = client or self.create_api_client()
 
@@ -54,6 +57,7 @@ class InternalAPIClient:
 
         # Header configurations
         self.force_refresh = force_refresh
+        self.reserved_namespace = reserved_namespace
 
     # API client
 
@@ -72,6 +76,7 @@ class InternalAPIClient:
     def build_headers(self) -> dict[str, bool]:
         return {
             CACHE_FORCE_REFRESH_HEADER_KEY: self.force_refresh,
+            CACHE_RESERVED_NAMESPACE_HEADER_KEY: self.reserved_namespace,
         }
 
     # Query parameters

--- a/caching/private_api/crawler/area_selector/orchestration.py
+++ b/caching/private_api/crawler/area_selector/orchestration.py
@@ -106,7 +106,9 @@ class AreaSelectorOrchestrator:
             None
 
         """
-        private_api_crawler = PrivateAPICrawler.create_crawler_to_force_write_in_non_reserved_namespace()
+        private_api_crawler = (
+            PrivateAPICrawler.create_crawler_to_force_write_in_non_reserved_namespace()
+        )
 
         # Since the payload to this method is intended to be serializable
         # via pickle -> multiprocessing or a message broker of some sort

--- a/caching/private_api/crawler/area_selector/orchestration.py
+++ b/caching/private_api/crawler/area_selector/orchestration.py
@@ -106,7 +106,7 @@ class AreaSelectorOrchestrator:
             None
 
         """
-        private_api_crawler = PrivateAPICrawler.create_crawler_for_force_cache_refresh()
+        private_api_crawler = PrivateAPICrawler.create_crawler_to_force_write_in_non_reserved_namespace()
 
         # Since the payload to this method is intended to be serializable
         # via pickle -> multiprocessing or a message broker of some sort

--- a/caching/private_api/crawler/private_api_crawler.py
+++ b/caching/private_api/crawler/private_api_crawler.py
@@ -72,12 +72,16 @@ class PrivateAPICrawler:
 
     @classmethod
     def create_crawler_to_force_write_in_non_reserved_namespace(cls) -> Self:
-        internal_api_client = InternalAPIClient(force_refresh=True, reserved_namespace=False)
+        internal_api_client = InternalAPIClient(
+            force_refresh=True, reserved_namespace=False
+        )
         return cls(internal_api_client=internal_api_client)
 
     @classmethod
     def create_crawler_to_force_write_in_reserved_namespace(cls) -> Self:
-        internal_api_client = InternalAPIClient(force_refresh=True, reserved_namespace=True)
+        internal_api_client = InternalAPIClient(
+            force_refresh=True, reserved_namespace=True
+        )
         return cls(internal_api_client=internal_api_client)
 
     @classmethod

--- a/caching/private_api/crawler/private_api_crawler.py
+++ b/caching/private_api/crawler/private_api_crawler.py
@@ -71,8 +71,8 @@ class PrivateAPICrawler:
     # Class constructors
 
     @classmethod
-    def create_crawler_for_force_cache_refresh(cls) -> Self:
-        internal_api_client = InternalAPIClient(force_refresh=True)
+    def create_crawler_to_force_write_in_non_reserved_namespace(cls) -> Self:
+        internal_api_client = InternalAPIClient(force_refresh=True, reserved_namespace=False)
         return cls(internal_api_client=internal_api_client)
 
     @classmethod

--- a/caching/private_api/crawler/private_api_crawler.py
+++ b/caching/private_api/crawler/private_api_crawler.py
@@ -76,6 +76,11 @@ class PrivateAPICrawler:
         return cls(internal_api_client=internal_api_client)
 
     @classmethod
+    def create_crawler_to_force_write_in_reserved_namespace(cls) -> Self:
+        internal_api_client = InternalAPIClient(force_refresh=True, reserved_namespace=True)
+        return cls(internal_api_client=internal_api_client)
+
+    @classmethod
     def create_crawler_for_lazy_loading(cls) -> Self:
         internal_api_client = InternalAPIClient(force_refresh=False)
         return cls(internal_api_client=internal_api_client)

--- a/caching/private_api/handlers.py
+++ b/caching/private_api/handlers.py
@@ -89,7 +89,7 @@ def force_cache_refresh_for_all_pages(
 
     private_api_crawler = (
         private_api_crawler
-        or PrivateAPICrawler.create_crawler_for_force_cache_refresh()
+        or PrivateAPICrawler.create_crawler_to_force_write_in_non_reserved_namespace()
     )
     area_selector_orchestrator = AreaSelectorOrchestrator(
         geographies_api_crawler=private_api_crawler.geography_api_crawler

--- a/tests/unit/caching/private_api/crawler/area_selector/test_orchestration.py
+++ b/tests/unit/caching/private_api/crawler/area_selector/test_orchestration.py
@@ -103,10 +103,12 @@ class TestAreaSelectorOrchestrator:
         )
 
     @mock.patch.object(TopicPage, "objects")
-    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_force_cache_refresh")
+    @mock.patch.object(
+        PrivateAPICrawler, "create_crawler_to_force_write_in_non_reserved_namespace"
+    )
     def test_process_geography_page_combination(
         self,
-        mocked_create_crawler_for_force_cache_refresh: mock.MagicMock,
+        mocked_create_crawler_to_force_write_in_non_reserved_namespace: mock.MagicMock,
         spy_topic_page_manager: mock.MagicMock,
     ):
         """
@@ -121,7 +123,7 @@ class TestAreaSelectorOrchestrator:
         Patches:
             `spy_topic_page_manager`: To check the page ID
                 is used to retrieve the `TopicPage` model
-            `mocked_create_crawler_for_force_cache_refresh`: To
+            `mocked_create_crawler_to_force_write_in_non_reserved_namespace`: To
                 isolate the `PrivateAPICrawler` so that the
                 returned mock object can be spied on further
                 i.e. to check the main `process_all_sections_in_page()` call
@@ -143,7 +145,7 @@ class TestAreaSelectorOrchestrator:
         page_model = spy_topic_page_manager.get.return_value
 
         spy_private_api_crawler = (
-            mocked_create_crawler_for_force_cache_refresh.return_value
+            mocked_create_crawler_to_force_write_in_non_reserved_namespace.return_value
         )
         spy_private_api_crawler.process_all_sections_in_page(
             page=page_model, geography_data=geography_data

--- a/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
+++ b/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
@@ -12,7 +12,9 @@ class TestPrivateAPICrawlerCreate:
         Then the correct object is returned
         """
         # Given / When
-        crawler = PrivateAPICrawler.create_crawler_to_force_write_in_non_reserved_namespace()
+        crawler = (
+            PrivateAPICrawler.create_crawler_to_force_write_in_non_reserved_namespace()
+        )
 
         # Then
         assert crawler._internal_api_client.force_refresh
@@ -26,7 +28,9 @@ class TestPrivateAPICrawlerCreate:
         Then the correct object is returned
         """
         # Given / When
-        crawler = PrivateAPICrawler.create_crawler_to_force_write_in_reserved_namespace()
+        crawler = (
+            PrivateAPICrawler.create_crawler_to_force_write_in_reserved_namespace()
+        )
 
         # Then
         assert crawler._internal_api_client.force_refresh

--- a/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
+++ b/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
@@ -4,15 +4,15 @@ from caching.private_api.crawler import PrivateAPICrawler
 class TestPrivateAPICrawlerCreate:
     # Tests for the create class methods
 
-    def test_create_crawler_for_force_cache_refresh(self):
+    def test_create_crawler_to_force_write_in_non_reserved_namespace(self):
         """
         Given no pre-existing `InternalAPIClient`
-        When the `create_crawler_for_force_cache_refresh` class method
-            is called from the `PrivateAPICrawler` class
+        When the `create_crawler_to_force_write_in_non_reserved_namespace`
+            class method is called from the `PrivateAPICrawler` class
         Then the correct object is returned
         """
         # Given / When
-        crawler = PrivateAPICrawler.create_crawler_for_force_cache_refresh()
+        crawler = PrivateAPICrawler.create_crawler_to_force_write_in_non_reserved_namespace()
 
         # Then
         assert crawler._internal_api_client.force_refresh

--- a/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
+++ b/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
@@ -16,6 +16,21 @@ class TestPrivateAPICrawlerCreate:
 
         # Then
         assert crawler._internal_api_client.force_refresh
+        assert not crawler._internal_api_client.reserved_namespace
+
+    def test_create_crawler_to_force_write_in_reserved_namespace(self):
+        """
+        Given no pre-existing `InternalAPIClient`
+        When the `create_crawler_to_force_write_in_reserved_namespace`
+            class method is called from the `PrivateAPICrawler` class
+        Then the correct object is returned
+        """
+        # Given / When
+        crawler = PrivateAPICrawler.create_crawler_to_force_write_in_reserved_namespace()
+
+        # Then
+        assert crawler._internal_api_client.force_refresh
+        assert crawler._internal_api_client.reserved_namespace
 
     def test_create_crawler_for_lazy_loading(self):
         """
@@ -29,3 +44,4 @@ class TestPrivateAPICrawlerCreate:
 
         # Then
         assert not crawler._internal_api_client.force_refresh
+        assert not crawler._internal_api_client.reserved_namespace

--- a/tests/unit/caching/private_api/test_handlers.py
+++ b/tests/unit/caching/private_api/test_handlers.py
@@ -124,10 +124,12 @@ class TestCrawlAllPages:
 class TestForceCacheRefreshForAllPages:
     @mock.patch(f"{MODULE_PATH}.AreaSelectorOrchestrator")
     @mock.patch(f"{MODULE_PATH}.crawl_all_pages")
-    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_force_cache_refresh")
+    @mock.patch.object(
+        PrivateAPICrawler, "create_crawler_to_force_write_in_non_reserved_namespace"
+    )
     def test_delegates_calls_successfully(
         self,
-        spy_create_crawler_for_force_cache_refresh: mock.MagicMock,
+        spy_create_crawler_to_force_write_in_non_reserved_namespace: mock.MagicMock,
         spy_crawl_all_pages: mock.MagicMock,
         spy_area_selector_orchestrator_class: mock.MagicMock,
     ):
@@ -137,8 +139,8 @@ class TestForceCacheRefreshForAllPages:
         Then the correct crawler is passed to `crawl_all_pages()`
 
         Patches:
-            `spy_create_crawler_for_force_cache_refresh`: To assert that
-                the correct crawler is initialized i.e. the one
+            `spy_create_crawler_to_force_write_in_non_reserved_namespace`: To assert
+                that the correct crawler is initialized i.e. the one
                 which can be used to forcibly refresh the cache
             `spy_crawl_all_pages`: For the main assertion
             `spy_area_selector_orchestrator_class`: To check the
@@ -152,14 +154,18 @@ class TestForceCacheRefreshForAllPages:
         force_cache_refresh_for_all_pages(cache_management=mocked_cache_management)
 
         # Then
-        spy_create_crawler_for_force_cache_refresh.assert_called_once()
-        expected_crawler = spy_create_crawler_for_force_cache_refresh.return_value
+        spy_create_crawler_to_force_write_in_non_reserved_namespace.assert_called_once()
+        expected_crawler = (
+            spy_create_crawler_to_force_write_in_non_reserved_namespace.return_value
+        )
         spy_crawl_all_pages.assert_called_once_with(
             private_api_crawler=expected_crawler,
             area_selector_orchestrator=spy_area_selector_orchestrator_class.return_value,
         )
 
-    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_force_cache_refresh")
+    @mock.patch.object(
+        PrivateAPICrawler, "create_crawler_to_force_write_in_non_reserved_namespace"
+    )
     @mock.patch(f"{MODULE_PATH}.crawl_all_pages")
     @mock.patch(f"{MODULE_PATH}.AreaSelectorOrchestrator")
     @mock.patch.object(CacheManagement, "clear_non_reserved_keys")
@@ -168,7 +174,7 @@ class TestForceCacheRefreshForAllPages:
         spy_cache_management_clear_non_reserved_keys: mock.MagicMock,
         spy_area_selector_orchestrator_class: mock.MagicMock,
         spy_crawl_all_pages: mock.MagicMock,
-        mocked_created_private_api_crawler: mock.MagicMock,
+        mocked_create_crawler_to_force_write_in_non_reserved_namespace: mock.MagicMock,
     ):
         """
         Given no input
@@ -195,7 +201,7 @@ class TestForceCacheRefreshForAllPages:
         expected_calls = [
             mock.call.cache_management_clear_non_reserved_keys(),
             mock.call.crawl_all_pages(
-                private_api_crawler=mocked_created_private_api_crawler.return_value,
+                private_api_crawler=mocked_create_crawler_to_force_write_in_non_reserved_namespace.return_value,
                 area_selector_orchestrator=spy_area_selector_orchestrator_class.return_value,
             ),
         ]

--- a/tests/unit/caching/test_internal_api_client.py
+++ b/tests/unit/caching/test_internal_api_client.py
@@ -7,6 +7,7 @@ from caching.internal_api_client import (
     CACHE_FORCE_REFRESH_HEADER_KEY,
     PAGE_TYPES_WITH_NO_ADDITIONAL_QUERY_PARAMS,
     InternalAPIClient,
+    CACHE_RESERVED_NAMESPACE_HEADER_KEY,
 )
 
 
@@ -114,17 +115,17 @@ class TestInternalAPIClient:
     # Header construction tests
 
     @pytest.mark.parametrize(
-        "force_refresh",
+        "force_refresh, reserved_namespace",
         (
-            True,
-            True,
-            False,
-            False,
+            [True, True],
+            [True, True],
+            [False, True],
+            [False, True],
         ),
     )
-    def test_build_headers(self, force_refresh: bool):
+    def test_build_headers(self, force_refresh: bool, reserved_namespace: bool):
         """
-        Given provided `force_refresh` values
+        Given provided `force_refresh` & `reserved_namespace` values
         When `build_headers()` is called
             from an instance of `InternalAPIClient`
         Then the correct dict representing the headers is returned
@@ -134,6 +135,7 @@ class TestInternalAPIClient:
         internal_api_client = InternalAPIClient(
             client=mocked_client,
             force_refresh=force_refresh,
+            reserved_namespace=reserved_namespace,
         )
 
         # When
@@ -142,6 +144,7 @@ class TestInternalAPIClient:
         # Then
         expected_headers = {
             CACHE_FORCE_REFRESH_HEADER_KEY: force_refresh,
+            CACHE_RESERVED_NAMESPACE_HEADER_KEY: reserved_namespace,
         }
         assert headers == expected_headers
 


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds a new construtor to build a crawler + internal API client which targets the reserved namespace only

Fixes #CDD-2729

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
