### PR TITLE
Task/add cache flush handler for keys in reserved namespace part two/cdd 2729

### DIFF
--- a/caching/private_api/client.py
+++ b/caching/private_api/client.py
@@ -79,7 +79,7 @@ class CacheClient:
         """
         self._cache.delete_many(keys=keys)
 
-    def copy(self, source: str, destination: str) -> None:
+    def copy(self, *, source: str, destination: str) -> None:
         """Copies the value stored at the `source_key` to the `destination_key`
 
         Args:
@@ -162,6 +162,6 @@ class InMemoryCacheClient(CacheClient):
         """Lists all the keys in the cache as bytes"""
         return [bytes(key, encoding="utf-8") for key in self._cache]
 
-    def copy(self, source: str, destination: str) -> None:
+    def copy(self, *, source: str, destination: str) -> None:
         source_value = self.get(cache_entry_key=source)
         self._cache[destination] = source_value

--- a/caching/private_api/management.py
+++ b/caching/private_api/management.py
@@ -171,6 +171,20 @@ class CacheManagement:
         """
         self._client.delete_many(keys=keys)
 
+    def get_reserved_staging_keys(self) -> list[CacheKey]:
+        """Fetches all the keys in the reserved staging namespace of the cache
+
+        Returns:
+            List of reserved staging keys objects
+
+        """
+        all_cache_keys: list[CacheKey] = self._get_all_cache_keys()
+        return [
+            cache_key
+            for cache_key in all_cache_keys
+            if cache_key.is_reserved_staging_namespace
+        ]
+
     def get_reserved_keys(self) -> list[str]:
         """Fetches all the keys in the reserved namespace of the cache
 

--- a/caching/private_api/management.py
+++ b/caching/private_api/management.py
@@ -185,6 +185,25 @@ class CacheManagement:
             if cache_key.is_reserved_staging_namespace
         ]
 
+    def move_all_reserved_staging_keys_into_reserved_namespace(self) -> None:
+        """Moves any keys in the reserved staging area into the reserved namespace of the cache
+
+        Notes:
+            This will overwrite the existing key if a clash is detected
+            in the destination reserved namespace
+            This will also clear out the reserved staging namespace upon completion
+
+        """
+        reserved_staging_keys: list[CacheKey] = self.get_reserved_staging_keys()
+        for source_key in reserved_staging_keys:
+            destination_key = source_key.output_to_reserved_namespace()
+            self._client.copy(
+                source=source_key.full_key, destination=destination_key.full_key
+            )
+
+        obsolete_keys = [key.standalone_key for key in reserved_staging_keys]
+        self._client.delete_many(keys=obsolete_keys)
+
     def get_reserved_keys(self) -> list[str]:
         """Fetches all the keys in the reserved namespace of the cache
 

--- a/tests/unit/caching/private_api/management/test_crud_operations.py
+++ b/tests/unit/caching/private_api/management/test_crud_operations.py
@@ -1,4 +1,3 @@
-from http import HTTPMethod
 from unittest import mock
 
 import pytest

--- a/tests/unit/caching/private_api/management/test_crud_operations.py
+++ b/tests/unit/caching/private_api/management/test_crud_operations.py
@@ -391,7 +391,7 @@ class TestCacheManagementCRUDOperations:
         """
         # Given
         in_memory_cache_client = InMemoryCacheClient()
-        reserved_staging_key = f"ukhsa:1:{RESERVED_NAMESPACE_STAGING_KEY_PREFIX}"
+        reserved_staging_key = f"ukhsa:1:{RESERVED_NAMESPACE_STAGING_KEY_PREFIX}-789"
         in_memory_cache_client._cache = {
             "ukhsa:1:abc": mock.Mock(),
             "ukhsa:1:def456": mock.Mock(),


### PR DESCRIPTION
# Description

This PR includes the following:

- Implements `get_reserved_staging_keys()` and `move_all_reserved_staging_keys_into_reserved_namespace()`, which allows us to orchestrate the migration of keys from the reserved staging namespace into the accessible reserved namespace of the cache 

Fixes #CDD-2729

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
