### PR TITLE
Task/add force cache refresh for reserved namespace handler/cdd 2729

### DIFF
--- a/caching/private_api/crawler/private_api_crawler.py
+++ b/caching/private_api/crawler/private_api_crawler.py
@@ -78,7 +78,7 @@ class PrivateAPICrawler:
         return cls(internal_api_client=internal_api_client)
 
     @classmethod
-    def create_crawler_to_force_write_in_reserved_namespace(cls) -> Self:
+    def create_crawler_to_force_write_in_reserved_staging_namespace(cls) -> Self:
         internal_api_client = InternalAPIClient(
             force_refresh=True, reserved_namespace=True
         )

--- a/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
+++ b/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
@@ -20,16 +20,16 @@ class TestPrivateAPICrawlerCreate:
         assert crawler._internal_api_client.force_refresh
         assert not crawler._internal_api_client.reserved_namespace
 
-    def test_create_crawler_to_force_write_in_reserved_namespace(self):
+    def test_create_crawler_to_force_write_in_reserved_staging_namespace(self):
         """
         Given no pre-existing `InternalAPIClient`
-        When the `create_crawler_to_force_write_in_reserved_namespace`
+        When the `create_crawler_to_force_write_in_reserved_staging_namespace`
             class method is called from the `PrivateAPICrawler` class
         Then the correct object is returned
         """
         # Given / When
         crawler = (
-            PrivateAPICrawler.create_crawler_to_force_write_in_reserved_namespace()
+            PrivateAPICrawler.create_crawler_to_force_write_in_reserved_staging_namespace()
         )
 
         # Then


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds the `force_cache_refresh_for_reserved_namespace()` handler which will be used the django management command to initiate the blue-green cache refresh of the reserved namespace

Fixes #CDD-2729

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
