### PR TITLE
Task/add flush redis reserved namespace script/cdd 2729

### DIFF
--- a/metrics/interfaces/management/commands/hydrate_private_api_cache_reserved_namespace.py
+++ b/metrics/interfaces/management/commands/hydrate_private_api_cache_reserved_namespace.py
@@ -1,0 +1,9 @@
+from django.core.management.base import BaseCommand
+
+from caching.private_api.handlers import force_cache_refresh_for_reserved_namespace
+
+
+class Command(BaseCommand):
+    @classmethod
+    def handle(cls, *args, **options) -> None:
+        force_cache_refresh_for_reserved_namespace()

--- a/scripts/_cache.sh
+++ b/scripts/_cache.sh
@@ -5,9 +5,10 @@ function _cache_help() {
     echo "uhd cache <command>"
     echo
     echo "commands:"
-    echo "  help                      - this help screen"
+    echo "  help                            - this help screen"
     echo
-    echo "  flush-redis               - flush and re-fill the redis (private api) cache"
+    echo "  flush-redis                     - flush and re-fill the redis (private api) cache"
+    echo "  flush-redis-reserved-namespace  - blue-green update the reserved namespace in the redis (private api) cache"
 
     return 0
 }
@@ -18,6 +19,7 @@ function _cache() {
 
     case $verb in
         "flush-redis") _cache_flush_redis $args ;;
+        "flush-redis-reserved-namespace") _cache_flush_redis_reserved_namespace $args ;;
 
         *) _cache_help ;;
     esac
@@ -28,3 +30,7 @@ function _cache_flush_redis() {
     python manage.py hydrate_private_api_cache
 }
 
+function _cache_flush_redis_reserved_namespace() {
+    uhd venv activate
+    python manage.py hydrate_private_api_cache_reserved_namespace
+}

--- a/scripts/hydrate_private_api_cache_reserved_namespace.sh
+++ b/scripts/hydrate_private_api_cache_reserved_namespace.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+function run_script() {
+    echo "Running script to fill reserved namespace in private API cache"
+
+    source uhd.sh
+    # This script is intended to be ran within a job
+    # Which means the entrypoint of the container is overridden with a call to this script
+    # As such, the static files need to be collected within the job process
+    # Before the main action can be executed
+    uhd server setup-static-files
+    uhd cache flush-redis-reserved-namespace
+    echo "Completed filling reserved namespace in private API cache"
+}
+
+run_script

--- a/tests/unit/metrics/interfaces/management/test_hydrate_frontend_cache.py
+++ b/tests/unit/metrics/interfaces/management/test_hydrate_frontend_cache.py
@@ -5,7 +5,7 @@ from django.core.management import call_command
 MODULE_PATH = "metrics.interfaces.management.commands.hydrate_frontend_cache"
 
 
-class TestGenerateAPITimeSeries:
+class TestHydrateFrontendCache:
     @mock.patch(f"{MODULE_PATH}.crawl_front_end")
     def test_delegates_call_successfully(self, spy_crawl_front_end: mock.MagicMock):
         """

--- a/tests/unit/metrics/interfaces/management/test_hydrate_private_api_cache.py
+++ b/tests/unit/metrics/interfaces/management/test_hydrate_private_api_cache.py
@@ -5,7 +5,7 @@ from django.core.management import call_command
 MODULE_PATH = "metrics.interfaces.management.commands.hydrate_private_api_cache"
 
 
-class TestGenerateAPITimeSeries:
+class TestHydratePrivateAPICommand:
     @mock.patch(f"{MODULE_PATH}.force_cache_refresh_for_all_pages")
     def test_delegates_call_successfully(
         self, spy_force_cache_refresh_for_all_pages: mock.MagicMock

--- a/tests/unit/metrics/interfaces/management/test_hydrate_private_api_cache_reserved_namespace.py
+++ b/tests/unit/metrics/interfaces/management/test_hydrate_private_api_cache_reserved_namespace.py
@@ -1,0 +1,25 @@
+from unittest import mock
+
+from django.core.management import call_command
+
+MODULE_PATH = "metrics.interfaces.management.commands.hydrate_private_api_cache_reserved_namespace"
+
+
+class TestHydratePrivateAPIReservedNamespaceCommand:
+    @mock.patch(f"{MODULE_PATH}.force_cache_refresh_for_reserved_namespace")
+    def test_delegates_call_successfully(
+        self, spy_force_cache_refresh_for_reserved_namespace: mock.MagicMock
+    ):
+        """
+        Given an instance of the app
+        When a call is made to the custom management command `hydrate_private_api_cache`
+        Then the call is delegated to the `force_cache_refresh_for_reserved_namespace()` function
+
+        Patches:
+            `spy_force_cache_refresh_for_reserved_namespace`: For the main assertion
+        """
+        # Given / When
+        call_command("hydrate_private_api_cache_reserved_namespace")
+
+        # Then
+        spy_force_cache_refresh_for_reserved_namespace.assert_called_once()

--- a/tests/unit/metrics/interfaces/management/test_hydrate_public_api_cache.py
+++ b/tests/unit/metrics/interfaces/management/test_hydrate_public_api_cache.py
@@ -5,7 +5,7 @@ from django.core.management import call_command
 MODULE_PATH = "metrics.interfaces.management.commands.hydrate_public_api_cache"
 
 
-class TestGenerateAPITimeSeries:
+class TestHydratePublicApiCacheCommand:
     @mock.patch(f"{MODULE_PATH}.crawl_public_api")
     def test_delegates_call_successfully(self, spy_crawl_public_api: mock.MagicMock):
         """

--- a/tests/unit/metrics/interfaces/management/test_upload_truncated_test_data.py
+++ b/tests/unit/metrics/interfaces/management/test_upload_truncated_test_data.py
@@ -5,7 +5,7 @@ from django.core.management import call_command
 MODULE_PATH = "metrics.interfaces.management.commands.upload_truncated_test_data"
 
 
-class TestUploadTruncatedTestData:
+class TestUploadTruncatedTestDataCommand:
     @mock.patch(f"{MODULE_PATH}.upload_truncated_test_data")
     def test_delegates_call(self, spy_upload_truncated_test_data: mock.MagicMock):
         """


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds the `uhd cache redis-flush-reserved-namespace` CLI command
- Adds the `hydrate_private_api_cache_reserved_namespace` wrapper script which can be used by the corresponding ECS job
- Adds the `hydrate_private_api_cache_reserved_namespace` django management command

Fixes #CDD-2729

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
