### PR TITLE
Extend data ingestion validation to allow for `Region` geography type

### DIFF
--- a/ingestion/data_transfer_models/validation/geography_code.py
+++ b/ingestion/data_transfer_models/validation/geography_code.py
@@ -12,7 +12,7 @@ LOWER_TIER_LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIXES = ("E06", "E07", "E08", "E09"
 UPPER_TIER_LOCAL_AUTHORITY_GEOGRAPHY_CODE_PREFIXES = ("E06", "E07", "E08", "E09", "E10")
 NHS_REGION_GEOGRAPHY_CODE_PREFIX = "E40"
 UKHSA_REGION_GEOGRAPHY_CODE_PREFIX = "E45"
-GOVERNMENT_OFFICE_REGION_GEOGRAPHY_CODE_PREFIX = "E12"
+REGION_GEOGRAPHY_CODE_PREFIX = "E12"
 UKHSA_SUPER_REGION_PREFIX = "X2500"
 
 
@@ -54,9 +54,9 @@ def validate_geography_code(
         case enums.GeographyType.NHS_REGION.value:
             return _validate_nhs_region_geography_code(geography_code=geography_code)
         case enums.GeographyType.GOVERNMENT_OFFICE_REGION.value:
-            return _validate_government_office_region_geography_code(
-                geography_code=geography_code
-            )
+            return _validate_region_geography_code(geography_code=geography_code)
+        case enums.GeographyType.REGION.value:
+            return _validate_region_geography_code(geography_code=geography_code)
         case enums.GeographyType.NHS_TRUST.value:
             return _validate_nhs_trust_geography_code(geography_code=geography_code)
         case enums.GeographyType.INTEGRATED_CARE_BOARD.value:
@@ -123,8 +123,8 @@ def _validate_nhs_region_geography_code(*, geography_code: str) -> str:
     raise ValueError
 
 
-def _validate_government_office_region_geography_code(*, geography_code: str) -> str:
-    if geography_code.startswith(GOVERNMENT_OFFICE_REGION_GEOGRAPHY_CODE_PREFIX):
+def _validate_region_geography_code(*, geography_code: str) -> str:
+    if geography_code.startswith(REGION_GEOGRAPHY_CODE_PREFIX):
         return geography_code
     raise ValueError
 

--- a/ingestion/utils/enums/geographies_enums.py
+++ b/ingestion/utils/enums/geographies_enums.py
@@ -13,3 +13,4 @@ class GeographyType(Enum):
     GOVERNMENT_OFFICE_REGION = "Government Office Region"
     INTEGRATED_CARE_BOARD = "Integrated Care Board"
     SUB_INTEGRATED_CARE_BOARD = "Sub-Integrated Care Board"
+    REGION = "Region"

--- a/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_code.py
+++ b/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_code.py
@@ -6,6 +6,9 @@ from ingestion.data_transfer_models.validation.geography_code import (
     UNITED_KINGDOM_GEOGRAPHY_CODE,
 )
 from ingestion.utils import enums
+from tests.unit.ingestion.data_transfer_models.base.test_validate_geography_type import (
+    VALID_REGION_CODE,
+)
 
 VALID_ENGLAND_NATION_CODE = "E92000001"
 VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE = "E06000059"
@@ -568,6 +571,60 @@ class TestIncomingBaseValidationForGovernmentOfficeRegionGeographyCode:
         # Given
         payload = valid_payload_for_base_model
         payload["geography_type"] = enums.GeographyType.GOVERNMENT_OFFICE_REGION.value
+        payload["geography_code"] = geography_code
+
+        # When / Then
+        with pytest.raises(ValidationError):
+            IncomingBaseDataModel(**payload)
+
+
+class TestIncomingBaseValidationForRegionGeographyCode:
+    def test_valid_geography_code_validates_successfully(
+        self, valid_payload_for_base_model: dict[str, str]
+    ):
+        """
+        Given a payload containing a valid `geography_code` value
+            for a `geography_type` of "Region"
+        When the `IncomingBaseDataModel` model is initialized
+        Then model is deemed valid
+        """
+        # Given
+        payload = valid_payload_for_base_model
+        payload["geography_type"] = enums.GeographyType.REGION.value
+        payload["geography_code"] = VALID_REGION_CODE
+
+        # When
+        incoming_base_validation = IncomingBaseDataModel(**payload)
+
+        # Then
+        incoming_base_validation.model_validate(
+            incoming_base_validation,
+            strict=True,
+        )
+
+    @pytest.mark.parametrize(
+        "geography_code",
+        (
+            VALID_NHS_REGION_CODE,
+            VALID_NHS_TRUST_CODE,
+            VALID_LOWER_TIER_LOCAL_AUTHORITY_CODE,
+            VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE,
+            VALID_UKHSA_REGION_CODE,
+            VALID_ENGLAND_NATION_CODE,
+        ),
+    )
+    def test_invalid_geography_code_throws_error(
+        self, geography_code: str, valid_payload_for_base_model: dict[str, str]
+    ):
+        """
+        Given a payload containing a `geography_code`
+            which is not valid for the "Region" `geography_type`
+        When the `IncomingBaseDataModel` model is initialized
+        Then a `ValidationError` is raised
+        """
+        # Given
+        payload = valid_payload_for_base_model
+        payload["geography_type"] = enums.GeographyType.REGION.value
         payload["geography_code"] = geography_code
 
         # When / Then

--- a/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_type.py
+++ b/tests/unit/ingestion/data_transfer_models/base/test_validate_geography_type.py
@@ -13,6 +13,7 @@ VALID_NHS_TRUST_CODE = "RY6"
 VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE = "E10000024"
 VALID_UKHSA_REGION_CODE = "E45000017"
 VALID_GOVERNMENT_OFFICE_REGION_CODE = "E12000003"
+VALID_REGION_CODE = "E12000007"
 
 
 class TestIncomingBaseValidationForGeographyType:
@@ -26,6 +27,7 @@ class TestIncomingBaseValidationForGeographyType:
             ("Upper Tier Local Authority", VALID_UPPER_TIER_LOCAL_AUTHORITY_CODE),
             ("UKHSA Region", VALID_UKHSA_REGION_CODE),
             ("Government Office Region", VALID_GOVERNMENT_OFFICE_REGION_CODE),
+            ("Region", VALID_REGION_CODE),
         ),
     )
     def test_valid_geography_type_value_is_deemed_valid(
@@ -77,6 +79,9 @@ class TestIncomingBaseValidationForGeographyType:
             ("UKHSA Regions", VALID_UKHSA_REGION_CODE),
             ("government office region", VALID_GOVERNMENT_OFFICE_REGION_CODE),
             ("Government Office Regions", VALID_GOVERNMENT_OFFICE_REGION_CODE),
+            ("region", VALID_REGION_CODE),
+            ("regions", VALID_REGION_CODE),
+            ("Regions", VALID_REGION_CODE),
         ),
     )
     def test_invalid_geography_type_value_throws_error(


### PR DESCRIPTION
# Description

This PR includes the following:

- Extends data ingestion validation to include the `Region` geography type as a replacement for the `Government Office Region` geography type

Fixes #CDD-2758

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
