### PR TITLE
Task/subplots charts svg generation part five/cdd 2755

### DIFF
--- a/caching/private_api/decorators.py
+++ b/caching/private_api/decorators.py
@@ -35,7 +35,10 @@ def cache_response(timeout: int | None = None):
 
     Args:
         timeout: The number of seconds after which the response is expired
-            and evicted from the cache
+            and evicted from the cache.
+            If set to `0` the response will not be cached at all.
+            If set to `None`, the response will be indefinitely cached,
+            until the cache is flushed intentionally.
 
     Returns:
         The response containing the results of the request.
@@ -120,6 +123,9 @@ def _calculate_response_and_save_in_cache(
     view_function, timeout, cache_management, cache_entry_key, *args, **kwargs
 ) -> Response:
     response: Response = _calculate_response_from_view(view_function, *args, **kwargs)
+    if timeout == 0:
+        return response
+
     cache_management.save_item_in_cache(
         cache_entry_key=cache_entry_key, item=response, timeout=timeout
     )

--- a/caching/private_api/management.py
+++ b/caching/private_api/management.py
@@ -98,7 +98,8 @@ class CacheManagement:
         self._client.clear()
 
     def _render_response(self, *, response: Response) -> Response:
-        if response.headers["Content-Type"] == "text/csv":
+        non_json_content_types = ("text/csv", "image/png")
+        if response.headers["Content-Type"] in non_json_content_types:
             return response
 
         return self._render_json_response(response=response)


### PR DESCRIPTION
# Description

This PR includes the following:

- Reconfigures the subplots charts API so that if `preview=true` we do not cache the response. If `preview=false` then we do cache the response 

Fixes #CDD-2755

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
