### PR TITLE
Add `target_threshold_label` field to CMS & consume from subplots API

### DIFF
--- a/cms/dashboard/templates/cms_starting_pages/childhood_vaccinations.json
+++ b/cms/dashboard/templates/cms_starting_pages/childhood_vaccinations.json
@@ -690,7 +690,8 @@
                         "value": {
                             "title_prefix": "Vaccination coverage statistics",
                             "legend_title": "Coverage (%)",
-                            "target_threshold": 0.95
+                            "target_threshold": 0.95,
+                            "target_threshold_label": "95% target"
                         },
                         "id": "ef3a544a-f335-44a8-9259-ee323b60e0fa"
                     }

--- a/cms/dynamic_content/global_filter/components/sub_plot_chart.py
+++ b/cms/dynamic_content/global_filter/components/sub_plot_chart.py
@@ -14,6 +14,10 @@ class FilterLinkedSubPlotChartTemplate(FilterLinkedComponent):
         required=False,
         help_text=help_texts.FILTER_LINKED_SUB_PLOT_CHART_TARGET_THRESHOLD,
     )
+    target_threshold_label = blocks.CharBlock(
+        required=False,
+        help_text=help_texts.FILTER_LINKED_SUB_PLOT_CHART_TARGET_THRESHOLD_LABEL,
+    )
 
     class Meta:
         icon = "standalone_chart"

--- a/cms/dynamic_content/help_texts.py
+++ b/cms/dynamic_content/help_texts.py
@@ -530,3 +530,7 @@ The full title will be structured as follows:
 FILTER_LINKED_SUB_PLOT_CHART_TARGET_THRESHOLD: str = """
 An optional value to draw a target threshold for.
 """
+
+FILTER_LINKED_SUB_PLOT_CHART_TARGET_THRESHOLD_LABEL: str = """
+An optional label to add as for the target threshold indicator on the charts.
+"""

--- a/metrics/api/serializers/charts/subplot_charts.py
+++ b/metrics/api/serializers/charts/subplot_charts.py
@@ -116,6 +116,11 @@ class SubplotChartRequestSerializer(serializers.Serializer):
         max_digits=10,
         decimal_places=2,
     )
+    target_threshold_label = serializers.CharField(
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
 
     chart_parameters = ChartParametersSerializer()
     subplots = SubplotsSerializer()
@@ -159,6 +164,7 @@ class SubplotChartRequestSerializer(serializers.Serializer):
             or DEFAULT_Y_AXIS_MINIMUM_VAlUE,
             y_axis_maximum_value=self.validated_data["y_axis_maximum_value"],
             target_threshold=self.validated_data["target_threshold"],
+            target_threshold_label=self.validated_data["target_threshold_label"],
             subplots=self.validated_data["subplots"],
             request=request,
         )

--- a/metrics/domain/charts/subplots/generation.py
+++ b/metrics/domain/charts/subplots/generation.py
@@ -36,16 +36,20 @@ def generate_chart_figure(
                 figure.update_yaxes(showticklabels=False, row=1, col=plot_index)
 
     if chart_generation_payload.target_threshold:
-        add_threshold_bar(figure, y_bottom=chart_generation_payload.target_threshold)
+        add_target_threshold(
+            figure=figure,
+            y_bottom=chart_generation_payload.target_threshold,
+            target_threshold_label=chart_generation_payload.target_threshold_label,
+        )
 
     return figure
 
 
-def add_threshold_bar(
+def add_target_threshold(
     figure: plotly.graph_objs.Figure,
     y_bottom: float,
+    target_threshold_label: str | None,
     fill_colour: str = "rgba(135, 206, 235, 0.3)",
-    label: str = "95% target",
 ):
     """Add a blue bar with solid top line and dashed bottom line to a Plotly figure.
 
@@ -58,7 +62,8 @@ def add_threshold_bar(
         y_bottom: Y-coordinate for the bottom of the bar
             i.e. the threshold value
         fill_colour: Colour for the filled bar area (with transparency)
-        label : Label for the threshold indicator (appears in legend)
+        target_threshold_label: Label for the threshold indicator
+            (appears in legend)
 
     Returns:
         The modified plotly figure object
@@ -101,7 +106,7 @@ def add_threshold_bar(
             y=[None],
             mode="lines",
             line={"color": fill_colour, "width": 8},
-            name=label,
+            name=target_threshold_label,
             showlegend=True,
         )
     )

--- a/metrics/domain/models/charts/subplot_charts.py
+++ b/metrics/domain/models/charts/subplot_charts.py
@@ -39,6 +39,7 @@ class SubplotChartRequestParameters(BaseModel):
     y_axis_minimum_value: Decimal | int | None = 0
     y_axis_maximum_value: Decimal | int | None = None
     target_threshold: float | None = None
+    target_threshold_label: str | None = ""
     request: Request | None = None
 
     subplots: list[Subplots]

--- a/metrics/domain/models/subplot_plots.py
+++ b/metrics/domain/models/subplot_plots.py
@@ -21,3 +21,4 @@ class SubplotChartGenerationPayload(BaseModel):
     y_axis_minimum_value: Decimal = 0
     y_axis_maximum_value: Decimal | None = None
     target_threshold: Decimal | None = None
+    target_threshold_label: str | None = ""

--- a/metrics/interfaces/charts/subplot_charts/access.py
+++ b/metrics/interfaces/charts/subplot_charts/access.py
@@ -80,6 +80,7 @@ class SubplotChartsInterface:
             y_axis_minimum_value=self.chart_request_params.y_axis_minimum_value,
             y_axis_maximum_value=self.chart_request_params.y_axis_maximum_value,
             target_threshold=self.chart_request_params.target_threshold,
+            target_threshold_label=self.chart_request_params.target_threshold_label,
         )
 
     @staticmethod

--- a/tests/integration/metrics/domain/charts/subplots/test_generation.py
+++ b/tests/integration/metrics/domain/charts/subplots/test_generation.py
@@ -25,6 +25,7 @@ class TestSubplotGeneration:
             y_axis_maximum_value=None,
             y_axis_minimum_value=0,
             target_threshold=95,
+            target_threshold_label="95% target",
         )
 
     def test_chart_figure_returns_correctly_with_threshold(


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds a new optional field `target_threshold_label` to the CMS for sub plot template charts
- Passes this new field down into the domain layer from the API

Fixes #CDD-2771

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
