### PR TITLE
Set threshold boundaries to 4dp in COVER template CMS page

### DIFF
--- a/cms/dashboard/templates/cms_starting_pages/childhood_vaccinations.json
+++ b/cms/dashboard/templates/cms_starting_pages/childhood_vaccinations.json
@@ -604,7 +604,7 @@
                                                                 "label": "Under 80%",
                                                                 "colour": "COLOUR_1_DARK_BLUE",
                                                                 "boundary_minimum_value": 0,
-                                                                "boundary_maximum_value": 80
+                                                                "boundary_maximum_value": 80.9999
                                                             },
                                                             "id": "9019a648-901c-4801-9d3e-d3b95242a58e"
                                                         },
@@ -614,7 +614,7 @@
                                                                 "label": "80-85%",
                                                                 "colour": "COLOUR_2_TURQUOISE",
                                                                 "boundary_minimum_value": 81,
-                                                                "boundary_maximum_value": 85
+                                                                "boundary_maximum_value": 85.9999
                                                             },
                                                             "id": "9137b412-ef3a-4d39-8662-1096ba1c3b99"
                                                         },
@@ -624,7 +624,7 @@
                                                                 "label": "85-90%",
                                                                 "colour": "COLOUR_3_DARK_PINK",
                                                                 "boundary_minimum_value": 86,
-                                                                "boundary_maximum_value": 90
+                                                                "boundary_maximum_value": 90.9999
                                                             },
                                                             "id": "38cd3f76-46ed-41d9-a7a2-9a41510c0b2d"
                                                         },
@@ -634,7 +634,7 @@
                                                                 "label": "90-95%",
                                                                 "colour": "COLOUR_4_ORANGE",
                                                                 "boundary_minimum_value": 91,
-                                                                "boundary_maximum_value": 95
+                                                                "boundary_maximum_value": 95.9999
                                                             },
                                                             "id": "3584882d-ce37-4d57-abcb-ac0d71133dc5"
                                                         },

--- a/cms/dashboard/templates/cms_starting_pages/childhood_vaccinations.json
+++ b/cms/dashboard/templates/cms_starting_pages/childhood_vaccinations.json
@@ -604,7 +604,7 @@
                                                                 "label": "Under 80%",
                                                                 "colour": "COLOUR_1_DARK_BLUE",
                                                                 "boundary_minimum_value": 0,
-                                                                "boundary_maximum_value": 80.9999
+                                                                "boundary_maximum_value": 80
                                                             },
                                                             "id": "9019a648-901c-4801-9d3e-d3b95242a58e"
                                                         },
@@ -613,8 +613,8 @@
                                                             "value": {
                                                                 "label": "80-85%",
                                                                 "colour": "COLOUR_2_TURQUOISE",
-                                                                "boundary_minimum_value": 81,
-                                                                "boundary_maximum_value": 85.9999
+                                                                "boundary_minimum_value": 80.0001,
+                                                                "boundary_maximum_value": 85
                                                             },
                                                             "id": "9137b412-ef3a-4d39-8662-1096ba1c3b99"
                                                         },
@@ -623,8 +623,8 @@
                                                             "value": {
                                                                 "label": "85-90%",
                                                                 "colour": "COLOUR_3_DARK_PINK",
-                                                                "boundary_minimum_value": 86,
-                                                                "boundary_maximum_value": 90.9999
+                                                                "boundary_minimum_value": 85.0001,
+                                                                "boundary_maximum_value": 90
                                                             },
                                                             "id": "38cd3f76-46ed-41d9-a7a2-9a41510c0b2d"
                                                         },
@@ -633,8 +633,8 @@
                                                             "value": {
                                                                 "label": "90-95%",
                                                                 "colour": "COLOUR_4_ORANGE",
-                                                                "boundary_minimum_value": 91,
-                                                                "boundary_maximum_value": 95.9999
+                                                                "boundary_minimum_value": 90.0001,
+                                                                "boundary_maximum_value": 95
                                                             },
                                                             "id": "3584882d-ce37-4d57-abcb-ac0d71133dc5"
                                                         },
@@ -643,7 +643,7 @@
                                                             "value": {
                                                                 "label": "Over 95%",
                                                                 "colour": "COLOUR_5_DARK_GREY",
-                                                                "boundary_minimum_value": 96,
+                                                                "boundary_minimum_value": 95.0001,
                                                                 "boundary_maximum_value": 100
                                                             },
                                                             "id": "d8583ba3-259f-49f0-be86-eaa670198c25"


### PR DESCRIPTION
# Description

This PR includes the following:

- Sets the threshold boundaries to 4dp in COVER template CMS page so that there are no gaps between threshold boundaries

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
