### PR TITLE
Add `charts/v3` API to CMS admin

### DIFF
--- a/metrics/api/urls_construction.py
+++ b/metrics/api/urls_construction.py
@@ -176,6 +176,7 @@ audit_api_urlpatterns = [
         name="audit-core-headline",
     ),
     re_path(f"^{API_PREFIX}charts/v2", ChartsView.as_view()),
+    re_path(f"^{API_PREFIX}charts/v3", EncodedChartsView.as_view()),
     re_path(f"^{API_PREFIX}charts/dual-category/v1", DualCategoryChartsView.as_view()),
 ]
 

--- a/tests/unit/metrics/api/test_urls_construction.py
+++ b/tests/unit/metrics/api/test_urls_construction.py
@@ -17,7 +17,6 @@ MODULE_PATH = "metrics.api.urls_construction"
 HEADLESS_CMS_API_ENDPOINT_PATHS = ["drafts", "pages"]
 
 PRIVATE_API_ENDPOINT_PATHS = [
-    "api/charts/v3",
     "api/downloads/v2",
     "api/headlines/v3",
     "api/bulkdownloads/v1",


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds the `charts/v3` API to CMS admin so that we can debug without having to hit the private API

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
