### PR TITLE
Add `about` CMS field to filter linked chart templates

### DIFF
--- a/cms/dashboard/templates/cms_starting_pages/childhood_vaccinations.json
+++ b/cms/dashboard/templates/cms_starting_pages/childhood_vaccinations.json
@@ -691,7 +691,8 @@
                             "title_prefix": "Vaccination coverage statistics",
                             "legend_title": "Coverage (%)",
                             "target_threshold": 95,
-                            "target_threshold_label": "95% target"
+                            "target_threshold_label": "95% target",
+                            "about": ""
                         },
                         "id": "ef3a544a-f335-44a8-9259-ee323b60e0fa"
                     }
@@ -708,7 +709,8 @@
                         "type": "filter_linked_time_series_chart_template",
                         "value": {
                             "title_prefix": "Annual vaccination coverage",
-                            "legend_title": "Level of coverage (%)"
+                            "legend_title": "Level of coverage (%)",
+                            "about": ""
                         },
                         "id": "7bfe0836-6a2c-4596-909f-974426123536"
                     }

--- a/cms/dynamic_content/global_filter/components/sub_plot_chart.py
+++ b/cms/dynamic_content/global_filter/components/sub_plot_chart.py
@@ -1,5 +1,6 @@
 from wagtail import blocks
 
+from cms.dashboard.models import AVAILABLE_RICH_TEXT_FEATURES
 from cms.dynamic_content import help_texts
 
 from .common import FilterLinkedComponent
@@ -17,6 +18,12 @@ class FilterLinkedSubPlotChartTemplate(FilterLinkedComponent):
     target_threshold_label = blocks.CharBlock(
         required=False,
         help_text=help_texts.FILTER_LINKED_SUB_PLOT_CHART_TARGET_THRESHOLD_LABEL,
+    )
+    about = blocks.RichTextBlock(
+        required=False,
+        default="",
+        features=AVAILABLE_RICH_TEXT_FEATURES,
+        help_text=help_texts.OPTIONAL_CHART_ABOUT_FIELD,
     )
 
     class Meta:

--- a/cms/dynamic_content/global_filter/components/time_series_chart.py
+++ b/cms/dynamic_content/global_filter/components/time_series_chart.py
@@ -1,5 +1,6 @@
 from wagtail import blocks
 
+from cms.dashboard.models import AVAILABLE_RICH_TEXT_FEATURES
 from cms.dynamic_content import help_texts
 
 from .common import FilterLinkedComponent
@@ -9,6 +10,12 @@ class FilterLinkedTimeSeriesChartTemplate(FilterLinkedComponent):
     legend_title = blocks.CharBlock(
         required=True,
         help_text=help_texts.FILTER_LINKED_TIME_SERIES_CHART_LEGEND_TITLE,
+    )
+    about = blocks.RichTextBlock(
+        required=False,
+        default="",
+        features=AVAILABLE_RICH_TEXT_FEATURES,
+        help_text=help_texts.OPTIONAL_CHART_ABOUT_FIELD,
     )
 
     class Meta:


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds an optional `about` field to the `filter_linked_sub_plot_chart_template` CMS 
- Adds an optional `about` field to the `filter_linked_time_series_chart_template` CMS 
- Restricts the rich text field features to:
    - h2
    - h3
    - h4
    - bold
    - bullet points
    - links

Fixes #CDD-2813

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
