### PR TITLE
Ensure keys are deleted from the cache reserved namespace 

### DIFF
--- a/caching/private_api/client.py
+++ b/caching/private_api/client.py
@@ -1,11 +1,8 @@
-import logging
 from typing import Any
 
 from django.core.cache import cache
 
 from metrics.api import settings
-
-logger = logging.getLogger(__name__)
 
 
 class CacheClient:

--- a/caching/private_api/client.py
+++ b/caching/private_api/client.py
@@ -93,13 +93,7 @@ class CacheClient:
         """
         low_level_client = self._get_low_level_client()
         for key in keys:
-            is_deleted: bool = bool(self._cache.delete(key))
-            logger.info(
-                "Deleted key using normal client abs `%s` -- %s", key, is_deleted
-            )
-
-            is_deleted: bool = bool(low_level_client.delete(key))
-            logger.info("Deleted key using low level `%s` -- %s", key, is_deleted)
+            low_level_client.delete(key)
 
     def copy(self, *, source: str, destination: str) -> None:
         """Copies the value stored at the `source_key` to the `destination_key`
@@ -118,10 +112,7 @@ class CacheClient:
 
         """
         low_level_client = self._get_low_level_client()
-        is_copied: bool = bool(
-            low_level_client.copy(source=source, destination=destination, replace=True)
-        )
-        logger.info("Copied key (%s) from %s to %s", is_copied, source, destination)
+        low_level_client.copy(source=source, destination=destination, replace=True)
 
 
 class InMemoryCacheClient(CacheClient):

--- a/caching/private_api/client.py
+++ b/caching/private_api/client.py
@@ -1,8 +1,11 @@
+import logging
 from typing import Any
 
 from django.core.cache import cache
 
 from metrics.api import settings
+
+logger = logging.getLogger(__name__)
 
 
 class CacheClient:
@@ -90,7 +93,8 @@ class CacheClient:
         """
         low_level_client = self._get_low_level_client()
         for key in keys:
-            low_level_client.delete(key)
+            is_deleted = bool(low_level_client.delete(key))
+            logger.info("Deleted key `%s` in cache. Status: `%s`", key, is_deleted)
 
     def copy(self, *, source: str, destination: str) -> None:
         """Copies the value stored at the `source_key` to the `destination_key`
@@ -109,7 +113,14 @@ class CacheClient:
 
         """
         low_level_client = self._get_low_level_client()
-        low_level_client.copy(source=source, destination=destination, replace=True)
+        is_copied = bool(
+            low_level_client.copy(source=source, destination=destination, replace=True)
+        )
+        logger.info(
+            "Copied key `%s` in cache to reserved namespace. Status: `%s`",
+            destination,
+            is_copied,
+        )
 
 
 class InMemoryCacheClient(CacheClient):

--- a/caching/private_api/handlers.py
+++ b/caching/private_api/handlers.py
@@ -87,7 +87,6 @@ def force_cache_refresh_for_all_pages(
     cache_management = cache_management or CacheManagement(in_memory=False)
     logger.info("Clearing all non reserved keys")
     cache_management.clear_non_reserved_keys()
-    logger.info("Deleted all non reserved keys")
 
     private_api_crawler = (
         private_api_crawler

--- a/caching/private_api/handlers.py
+++ b/caching/private_api/handlers.py
@@ -85,7 +85,9 @@ def force_cache_refresh_for_all_pages(
 
     """
     cache_management = cache_management or CacheManagement(in_memory=False)
+    logger.info("Clearing all non reserved keys")
     cache_management.clear_non_reserved_keys()
+    logger.info("Deleted all non reserved keys")
 
     private_api_crawler = (
         private_api_crawler

--- a/caching/private_api/management.py
+++ b/caching/private_api/management.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import logging
 from typing import Self
 
 from rest_framework.renderers import JSONRenderer
@@ -11,6 +12,8 @@ from caching.private_api.client import CacheClient, InMemoryCacheClient
 
 class CacheMissError(Exception): ...
 
+
+logger = logging.getLogger(__name__)
 
 RESERVED_NAMESPACE_KEY_PREFIX = "ns2"
 RESERVED_NAMESPACE_STAGING_KEY_PREFIX = "ns3"
@@ -217,18 +220,20 @@ class CacheManagement:
         """
         all_cache_keys: list[CacheKey] = self._get_all_cache_keys()
         return [
-            cache_key.standalone_key
+            cache_key.full_key
             for cache_key in all_cache_keys
             if cache_key.is_reserved_namespace
         ]
 
     def _get_non_reserved_keys(self) -> list[str]:
         all_cache_keys: list[CacheKey] = self._get_all_cache_keys()
-        return [
-            cache_key.standalone_key
+        all_keys = [
+            cache_key.full_key
             for cache_key in all_cache_keys
             if not cache_key.is_reserved_namespace
         ]
+        logger.info("all non reserved keys: %s", all_keys)
+        return all_keys
 
     def _get_all_cache_keys(self) -> list[CacheKey]:
         all_raw_keys: list[bytes] = self._client.list_keys()

--- a/caching/private_api/management.py
+++ b/caching/private_api/management.py
@@ -204,7 +204,7 @@ class CacheManagement:
                 source=source_key.full_key, destination=destination_key.full_key
             )
 
-        obsolete_keys = [key.standalone_key for key in reserved_staging_keys]
+        obsolete_keys = [key.full_key for key in reserved_staging_keys]
         self._client.delete_many(keys=obsolete_keys)
 
     def get_reserved_keys(self) -> list[str]:
@@ -227,13 +227,11 @@ class CacheManagement:
 
     def _get_non_reserved_keys(self) -> list[str]:
         all_cache_keys: list[CacheKey] = self._get_all_cache_keys()
-        logger.info(f"got all non reserved keys: {all_cache_keys}")
         all_keys = [
             cache_key.full_key
             for cache_key in all_cache_keys
             if not cache_key.is_reserved_namespace
         ]
-        logger.info("all non reserved keys: %s", all_keys)
         return all_keys
 
     def _get_all_cache_keys(self) -> list[CacheKey]:

--- a/caching/private_api/management.py
+++ b/caching/private_api/management.py
@@ -1,6 +1,5 @@
 import hashlib
 import json
-import logging
 from typing import Self
 
 from rest_framework.renderers import JSONRenderer
@@ -12,8 +11,6 @@ from caching.private_api.client import CacheClient, InMemoryCacheClient
 
 class CacheMissError(Exception): ...
 
-
-logger = logging.getLogger(__name__)
 
 RESERVED_NAMESPACE_KEY_PREFIX = "ns2"
 RESERVED_NAMESPACE_STAGING_KEY_PREFIX = "ns3"
@@ -235,7 +232,6 @@ class CacheManagement:
 
     def _get_all_cache_keys(self) -> list[CacheKey]:
         all_raw_keys: list[bytes] = self._client.list_keys()
-        logger.info("listing all raw keys")
         return [CacheKey.create(raw_key=raw_key) for raw_key in all_raw_keys]
 
     def _render_response(self, *, response: Response) -> Response:

--- a/caching/private_api/management.py
+++ b/caching/private_api/management.py
@@ -227,6 +227,7 @@ class CacheManagement:
 
     def _get_non_reserved_keys(self) -> list[str]:
         all_cache_keys: list[CacheKey] = self._get_all_cache_keys()
+        logger.info(f"got all non reserved keys: {all_cache_keys}")
         all_keys = [
             cache_key.full_key
             for cache_key in all_cache_keys
@@ -237,6 +238,7 @@ class CacheManagement:
 
     def _get_all_cache_keys(self) -> list[CacheKey]:
         all_raw_keys: list[bytes] = self._client.list_keys()
+        logger.info("listing all raw keys")
         return [CacheKey.create(raw_key=raw_key) for raw_key in all_raw_keys]
 
     def _render_response(self, *, response: Response) -> Response:

--- a/caching/private_api/management.py
+++ b/caching/private_api/management.py
@@ -227,12 +227,11 @@ class CacheManagement:
 
     def _get_non_reserved_keys(self) -> list[str]:
         all_cache_keys: list[CacheKey] = self._get_all_cache_keys()
-        all_keys = [
+        return [
             cache_key.full_key
             for cache_key in all_cache_keys
             if not cache_key.is_reserved_namespace
         ]
-        return all_keys
 
     def _get_all_cache_keys(self) -> list[CacheKey]:
         all_raw_keys: list[bytes] = self._client.list_keys()

--- a/tests/unit/caching/private_api/management/test_crud_operations.py
+++ b/tests/unit/caching/private_api/management/test_crud_operations.py
@@ -452,5 +452,5 @@ class TestCacheManagementCRUDOperations:
             destination=f"ukhsa:1:{RESERVED_NAMESPACE_KEY_PREFIX}-test-key",
         )
         spy_cache_client.delete_many.assert_called_once_with(
-            keys=[reserved_staging_standalone_key]
+            keys=[reserved_staging_raw_key]
         )

--- a/tests/unit/caching/private_api/management/test_crud_operations.py
+++ b/tests/unit/caching/private_api/management/test_crud_operations.py
@@ -274,8 +274,7 @@ class TestCacheManagementCRUDOperations:
         cache_management.clear_non_reserved_keys()
 
         # Then
-        non_reserved_keys = [key.split(":")[-1] for key in non_reserved_complete_keys]
-        spy_client.delete_many.assert_called_once_with(keys=non_reserved_keys)
+        spy_client.delete_many.assert_called_once_with(keys=non_reserved_complete_keys)
 
     def test_delete_many(self):
         """
@@ -349,9 +348,9 @@ class TestCacheManagementCRUDOperations:
         reserved_keys: list[str] = cache_management.get_reserved_keys()
 
         # Then
-        assert "abc" not in reserved_keys
-        assert "def456" not in reserved_keys
-        assert "ns2-test-key" in reserved_keys
+        assert "ukhsa:1:abc" not in reserved_keys
+        assert "ukhsa:1:def456" not in reserved_keys
+        assert "ukhsa:1:ns2-test-key" in reserved_keys
 
     def test_get_non_reserved_keys(self):
         """
@@ -377,9 +376,9 @@ class TestCacheManagementCRUDOperations:
         non_reserved_keys: list[str] = cache_management._get_non_reserved_keys()
 
         # Then
-        assert "abc" in non_reserved_keys
-        assert "def456" in non_reserved_keys
-        assert "ns2-test-key" not in non_reserved_keys
+        assert "ukhsa:1:abc" in non_reserved_keys
+        assert "ukhsa:1:def456" in non_reserved_keys
+        assert "ukhsa:1:ns2-test-key" not in non_reserved_keys
 
     def test_get_reserved_staging_keys(self):
         """

--- a/tests/unit/caching/private_api/test_client.py
+++ b/tests/unit/caching/private_api/test_client.py
@@ -63,8 +63,8 @@ class TestCacheClient:
             key=fake_cache_entry_key, value=mocked_value, timeout=timeout
         )
 
-    @mock.patch(f"{MODULE_PATH}.cache")
-    def test_delete_many_delegates_call(self, spy_cache: mock.MagicMock):
+    @mock.patch.object(CacheClient, "_get_low_level_client")
+    def test_delete_many_delegates_call(self, spy_get_low_level_client: mock.MagicMock):
         """
         Given an instance of the `CacheClient`
         When `delete_many()` is called from the client
@@ -78,8 +78,9 @@ class TestCacheClient:
         cache_client.delete_many(keys=mocked_keys)
 
         # Then
-        expected_calls = [mock.call(key=key) for key in mocked_keys]
-        spy_cache.delete.assert_has_calls(calls=expected_calls)
+        low_level_cache_client = spy_get_low_level_client.return_value
+        expected_calls = [mock.call(key) for key in mocked_keys]
+        low_level_cache_client.delete.assert_has_calls(calls=expected_calls)
 
     @mock.patch.dict(
         in_dict="django.conf.settings.CACHES",

--- a/tests/unit/caching/private_api/test_client.py
+++ b/tests/unit/caching/private_api/test_client.py
@@ -80,7 +80,9 @@ class TestCacheClient:
         # Then
         low_level_cache_client = spy_get_low_level_client.return_value
         expected_calls = [mock.call(key) for key in mocked_keys]
-        low_level_cache_client.delete.assert_has_calls(calls=expected_calls)
+        low_level_cache_client.delete.assert_has_calls(
+            calls=expected_calls, any_order=True
+        )
 
     @mock.patch.dict(
         in_dict="django.conf.settings.CACHES",


### PR DESCRIPTION
# Description

This PR includes the following:

- Switches to using the low level Redis client instead of the Django Redis abstraction when performing CRUD operations against the Redis cache

---

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
