### PR TITLE
Clear cache entirely as part of normal cache flush process

### DIFF
--- a/caching/private_api/handlers.py
+++ b/caching/private_api/handlers.py
@@ -86,7 +86,7 @@ def force_cache_refresh_for_all_pages(
     """
     cache_management = cache_management or CacheManagement(in_memory=False)
     logger.info("Clearing all non reserved keys")
-    cache_management.clear_non_reserved_keys()
+    cache_management.clear()
 
     private_api_crawler = (
         private_api_crawler

--- a/caching/private_api/management.py
+++ b/caching/private_api/management.py
@@ -145,22 +145,14 @@ class CacheManagement:
         self._client.put(cache_entry_key=cache_entry_key, value=item, timeout=timeout)
         return item
 
-    def clear_non_reserved_keys(self):
-        """Deletes all keys in the cache which are not within the reserved namespace
-
-        Notes:
-            This allows us to keep hold of
-            expensive, infrequently changing data in the cache
-            like maps data, whilst still allowing the
-            cheaper more frequently changing data types like
-            tables and charts to be cleared.
+    def clear(self):
+        """Deletes all keys in the current cache
 
         Returns:
             None
 
         """
-        non_reserved_keys: list[str] = self._get_non_reserved_keys()
-        self._client.delete_many(keys=non_reserved_keys)
+        self._client.clear()
 
     def delete_many(self, keys: list[str]) -> None:
         """Deletes the given `keys` from the cache within 1 trip to the cache

--- a/tests/unit/caching/private_api/management/test_crud_operations.py
+++ b/tests/unit/caching/private_api/management/test_crud_operations.py
@@ -233,48 +233,26 @@ class TestCacheManagementCRUDOperations:
         )
         assert retrieved_response == mocked_item
 
-    @mock.patch.dict(
-        in_dict="django.conf.settings.CACHES",
-        values={
-            "default": {
-                "KEY_PREFIX": "app",
-                "BACKEND": "django.core.cache.backends.redis.RedisCache",
-            }
-        },
-    )
-    def test_clear_non_reserved_keys(self):
+    def test_clear(self):
         """
         Given an instance of `CacheManagement`
-        When `clear_non_reserved_keys()` is called from the object
+        When `clear()` is called from the object
         Then the call is delegated to the underlying client
         """
         # Given
-        cache_prefix = "app"
-        reserved_namespace_key_prefix = "ns2"
-        non_reserved_complete_keys = [
-            f"{cache_prefix}:1:abc123",
-            f"{cache_prefix}:1:def456",
-            f"{cache_prefix}:1:abc123456",
-        ]
-        reserved_complete_keys = [
-            f"{cache_prefix}:1:{reserved_namespace_key_prefix}-abc123",
-            f"{cache_prefix}:1:{reserved_namespace_key_prefix}-qwerty",
-        ]
-        all_keys = non_reserved_complete_keys + reserved_complete_keys
         spy_client = mock.Mock()
-        spy_client.list_keys.return_value = all_keys
 
         cache_management = CacheManagement(
             in_memory=True,
             client=spy_client,
-            reserved_namespace_key_prefix=reserved_namespace_key_prefix,
+            reserved_namespace_key_prefix="ns2",
         )
 
         # When
-        cache_management.clear_non_reserved_keys()
+        cache_management.clear()
 
         # Then
-        spy_client.delete_many.assert_called_once_with(keys=non_reserved_complete_keys)
+        spy_client.clear.assert_called_once()
 
     def test_delete_many(self):
         """

--- a/tests/unit/caching/private_api/test_client.py
+++ b/tests/unit/caching/private_api/test_client.py
@@ -137,6 +137,23 @@ class TestCacheClient:
             replace=True,
         )
 
+    @mock.patch(f"{MODULE_PATH}.cache")
+    def test_clear(self, spy_cache: mock.MagicMock):
+        """
+        Given a `CacheClient`
+        When `clear()` is called from the client
+        Then the call is delegated
+            to the underlying client
+        """
+        # Given
+        cache_client = CacheClient()
+
+        # When
+        cache_client.clear()
+
+        # Then
+        spy_cache.clear.assert_called_once()
+
 
 class TestInMemoryCacheClient:
     def test_put_stores_given_value(self):


### PR DESCRIPTION
# Description

This PR includes the following:

- Re-implement `clear()` which wraps around `FLUSHDB` redis command at start of **normal** cache flush process.
- Note that this will also empty the cache for maps data for the time being

Fixes #CDD-2839

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
