### PR TITLE
Task/implement dual redis cache strategy/cdd 2839

### DIFF
--- a/caching/internal_api_client.py
+++ b/caching/internal_api_client.py
@@ -41,7 +41,6 @@ class InternalAPIClient:
         self,
         *,
         client: APIClient | None = None,
-        force_refresh: bool = False,
         reserved_namespace: bool = False,
     ):
         self._client = client or self.create_api_client()
@@ -60,7 +59,6 @@ class InternalAPIClient:
         self.menus_endpoint_path = MENUS_ENDPOINT_PATH
 
         # Header configurations
-        self.force_refresh = force_refresh
         self.reserved_namespace = reserved_namespace
 
     # API client
@@ -79,7 +77,6 @@ class InternalAPIClient:
 
     def build_headers(self) -> dict[str, bool]:
         return {
-            CACHE_FORCE_REFRESH_HEADER_KEY: self.force_refresh,
             CACHE_RESERVED_NAMESPACE_HEADER_KEY: self.reserved_namespace,
         }
 

--- a/caching/private_api/crawler/private_api_crawler.py
+++ b/caching/private_api/crawler/private_api_crawler.py
@@ -86,7 +86,7 @@ class PrivateAPICrawler:
 
     @classmethod
     def create_crawler_for_lazy_loading(cls) -> Self:
-        internal_api_client = InternalAPIClient(force_refresh=False)
+        internal_api_client = InternalAPIClient()
         return cls(internal_api_client=internal_api_client)
 
     # Process pages for content

--- a/caching/private_api/crawler/private_api_crawler.py
+++ b/caching/private_api/crawler/private_api_crawler.py
@@ -72,16 +72,12 @@ class PrivateAPICrawler:
 
     @classmethod
     def create_crawler_to_force_write_in_non_reserved_namespace(cls) -> Self:
-        internal_api_client = InternalAPIClient(
-            force_refresh=True, reserved_namespace=False
-        )
+        internal_api_client = InternalAPIClient(reserved_namespace=False)
         return cls(internal_api_client=internal_api_client)
 
     @classmethod
     def create_crawler_to_force_write_in_reserved_staging_namespace(cls) -> Self:
-        internal_api_client = InternalAPIClient(
-            force_refresh=True, reserved_namespace=True
-        )
+        internal_api_client = InternalAPIClient(reserved_namespace=True)
         return cls(internal_api_client=internal_api_client)
 
     @classmethod

--- a/config.py
+++ b/config.py
@@ -48,6 +48,12 @@ if not REDIS_HOST:
     logger.info("No REDIS_HOST given, falling back to localhost")
     REDIS_HOST = "redis://127.0.0.1:6379"
 
+# The endpoint of the reserved Redis cache
+REDIS_RESERVED_HOST = os.environ.get("REDIS_RESERVED_HOST", "")
+if not REDIS_RESERVED_HOST:
+    logger.info("No REDIS_RESERVED_HOST given, falling back to localhost")
+    REDIS_RESERVED_HOST = "redis://127.0.0.1:6379"
+
 # The name of the s3 bucket used for ingestion
 INGESTION_BUCKET_NAME = os.environ.get("INGESTION_BUCKET_NAME")
 # The name of the s3 bucket used for archiving files which have been successfully ingested

--- a/metrics/api/settings/backend_utility_worker.py
+++ b/metrics/api/settings/backend_utility_worker.py
@@ -6,5 +6,11 @@ CACHES = {
         "BACKEND": "django.core.cache.backends.redis.RedisCache",
         "LOCATION": config.REDIS_HOST,
         "KEY_PREFIX": "ukhsa",
-    }
+    },
+    "reserved": {
+        "TIME_ZONE": "Europe/London",
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": config.REDIS_RESERVED_HOST,
+        "KEY_PREFIX": "reserved",
+    },
 }

--- a/metrics/api/settings/default.py
+++ b/metrics/api/settings/default.py
@@ -136,7 +136,12 @@ CACHE_TTL = None
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-    }
+        "KEY_PREFIX": "ukhsa",
+    },
+    "reserved": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "KEY_PREFIX": "reserved",
+    },
 }
 
 

--- a/metrics/api/settings/private_api.py
+++ b/metrics/api/settings/private_api.py
@@ -13,5 +13,10 @@ else:
             "BACKEND": "django.core.cache.backends.redis.RedisCache",
             "LOCATION": config.REDIS_HOST,
             "KEY_PREFIX": "ukhsa",
-        }
+        },
+        "reserved": {
+            "BACKEND": "django.core.cache.backends.redis.RedisCache",
+            "LOCATION": config.REDIS_RESERVED_HOST,
+            "KEY_PREFIX": "reserved",
+        },
     }

--- a/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
+++ b/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
@@ -45,5 +45,4 @@ class TestPrivateAPICrawlerCreate:
         crawler = PrivateAPICrawler.create_crawler_for_lazy_loading()
 
         # Then
-        assert not crawler._internal_api_client.force_refresh
         assert not crawler._internal_api_client.reserved_namespace

--- a/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
+++ b/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
@@ -17,7 +17,6 @@ class TestPrivateAPICrawlerCreate:
         )
 
         # Then
-        assert crawler._internal_api_client.force_refresh
         assert not crawler._internal_api_client.reserved_namespace
 
     def test_create_crawler_to_force_write_in_reserved_staging_namespace(self):
@@ -33,7 +32,6 @@ class TestPrivateAPICrawlerCreate:
         )
 
         # Then
-        assert crawler._internal_api_client.force_refresh
         assert crawler._internal_api_client.reserved_namespace
 
     def test_create_crawler_for_lazy_loading(self):

--- a/tests/unit/caching/private_api/test_decorators.py
+++ b/tests/unit/caching/private_api/test_decorators.py
@@ -23,9 +23,7 @@ class TestRetrieveResponseFromCacheOrCalculate:
         Then the expected response is returned
         """
         # Given
-        mocked_request = mock.MagicMock(
-            method="POST", headers={CACHE_FORCE_REFRESH_HEADER_KEY: False}
-        )
+        mocked_request = mock.MagicMock(method="POST")
         mocked_cache_management = mock.Mock()
 
         # When
@@ -57,9 +55,7 @@ class TestRetrieveResponseFromCacheOrCalculate:
         Patches:
             `spy_calculate_response_and_save_in_cache`: For the main assertion
         """
-        mocked_request = mock.MagicMock(
-            method="POST", headers={CACHE_FORCE_REFRESH_HEADER_KEY: False}
-        )
+        mocked_request = mock.MagicMock(method="POST")
         mocked_cache_management = mock.Mock()
 
         # When
@@ -91,9 +87,7 @@ class TestRetrieveResponseFromCacheOrCalculate:
             `spy_calculate_response_and_save_in_cache`: For the main assertion
         """
         # Given
-        mocked_request = mock.MagicMock(
-            method="POST", headers={CACHE_FORCE_REFRESH_HEADER_KEY: False}
-        )
+        mocked_request = mock.MagicMock(method="POST")
         mocked_view_function = mock.Mock()
         mocked_cache_management = mock.Mock()
         mocked_args = [mock.Mock(), mocked_request, mock.Mock()]
@@ -165,243 +159,6 @@ class TestRetrieveResponseFromCacheOrCalculate:
         spy_calculate_response_and_save_in_cache.assert_not_called()
         spy_calculate_response_from_view.assert_called_once()
         assert retrieved_response == spy_calculate_response_from_view.return_value
-
-
-class TestForceCacheRefreshHeader:
-    @mock.patch(f"{MODULE_PATH}._calculate_response_and_save_in_cache")
-    def test_response_is_recalculated_for_reserved_namespace_with_reserved_header(
-        self, spy_calculate_response_and_save_in_cache: mock.MagicMock
-    ):
-        """
-        Given a mocked request for a key in the reserved namespace
-            and a `CacheManagement` object
-        And the `Cache-Force-Refresh` & `Cache-Reserved-Namespace` headers are included
-        When `_retrieve_response_from_cache_or_calculate()` is called
-        Then the response is recalculated and saved regardless
-
-        Patches:
-            `spy_calculate_response_and_save_in_cache`: For the main assertion
-        """
-        # Given
-        mocked_request = mock.MagicMock(
-            method="POST",
-            headers={
-                CACHE_FORCE_REFRESH_HEADER_KEY: True,
-                CACHE_RESERVED_NAMESPACE_HEADER_KEY: True,
-            },
-        )
-        spy_cache_management = mock.Mock()
-        is_reserved_namespace = True
-
-        # When
-        retrieved_response = _retrieve_response_from_cache_or_calculate(
-            mock.Mock(),  # view_function
-            None,  # timeout
-            is_reserved_namespace,  # is_reserved_namespace
-            mock.Mock(),
-            mocked_request,
-            cache_management=spy_cache_management,
-        )
-
-        # Then
-        assert (
-            retrieved_response
-            == spy_calculate_response_and_save_in_cache.return_value
-            != spy_cache_management.retrieve_item_from_cache.return_value
-        )
-
-    @mock.patch(f"{MODULE_PATH}._calculate_response_and_save_in_cache")
-    def test_response_is_recalculated_for_non_reserved_namespace_without_reserved_header(
-        self, spy_calculate_response_and_save_in_cache: mock.MagicMock
-    ):
-        """
-        Given a mocked request for a key in the reserved namespace
-            and a `CacheManagement` object
-        And only the `Cache-Force-Refresh` header is included
-        When `_retrieve_response_from_cache_or_calculate()` is called
-        Then the response is recalculated and saved regardless
-
-        Patches:
-            `spy_calculate_response_and_save_in_cache`: For the main assertion
-        """
-        # Given
-        mocked_request = mock.MagicMock(
-            method="POST",
-            headers={CACHE_FORCE_REFRESH_HEADER_KEY: True},
-        )
-        spy_cache_management = mock.Mock()
-        is_reserved_namespace = False
-
-        # When
-        retrieved_response = _retrieve_response_from_cache_or_calculate(
-            mock.Mock(),  # view_function
-            None,  # timeout
-            is_reserved_namespace,  # is_reserved_namespace
-            mock.Mock(),
-            mocked_request,
-            cache_management=spy_cache_management,
-        )
-
-        # Then
-        assert (
-            retrieved_response
-            == spy_calculate_response_and_save_in_cache.return_value
-            != spy_cache_management.retrieve_item_from_cache.return_value
-        )
-
-    @mock.patch(f"{MODULE_PATH}._calculate_response_and_save_in_cache")
-    def test_response_is_not_recalculated_for_reserved_namespace_without_reserved_header(
-        self, spy_calculate_response_and_save_in_cache: mock.MagicMock
-    ):
-        """
-        Given a mocked request for a key in the reserved namespace
-            and a `CacheManagement` object
-        And only the `Cache-Force-Refresh` header is included
-        When `_retrieve_response_from_cache_or_calculate()` is called
-        Then the response is fetched from the cache, not recalculated
-
-        Patches:
-            `spy_calculate_response_and_save_in_cache`: For the main assertion
-        """
-        # Given
-        mocked_request = mock.MagicMock(
-            method="POST", headers={CACHE_FORCE_REFRESH_HEADER_KEY: True}
-        )
-        spy_cache_management = mock.Mock()
-        is_reserved_namespace = True
-
-        # When
-        retrieved_response = _retrieve_response_from_cache_or_calculate(
-            mock.Mock(),  # view_function
-            None,  # timeout
-            is_reserved_namespace,  # is_reserved_namespace
-            mock.Mock(),
-            mocked_request,
-            cache_management=spy_cache_management,
-        )
-
-        # Then
-        assert (
-            retrieved_response
-            == spy_cache_management.retrieve_item_from_cache.return_value
-            != spy_calculate_response_and_save_in_cache.return_value
-        )
-
-    @mock.patch(f"{MODULE_PATH}._calculate_response_and_save_in_cache")
-    def test__response_is_not_recalculated_for_non_reserved_namespace_with_reserved_header(
-        self, spy_calculate_response_and_save_in_cache: mock.MagicMock
-    ):
-        """
-        Given a mocked request for a key in the non-reserved namespace
-            and a `CacheManagement` object
-        And the `Cache-Force-Refresh` & `Cache-Reserved-Namespace` headers are included
-        When `_retrieve_response_from_cache_or_calculate()` is called
-        Then the response is fetched from the cache, not recalculated
-
-        Patches:
-            `spy_calculate_response_and_save_in_cache`: For the main assertion
-        """
-        # Given
-        mocked_request = mock.MagicMock(
-            method="POST",
-            headers={
-                CACHE_FORCE_REFRESH_HEADER_KEY: True,
-                CACHE_RESERVED_NAMESPACE_HEADER_KEY: True,
-            },
-        )
-        spy_cache_management = mock.Mock()
-        is_reserved_namespace = False
-
-        # When
-        retrieved_response = _retrieve_response_from_cache_or_calculate(
-            mock.Mock(),  # view_function
-            None,  # timeout
-            is_reserved_namespace,  # is_reserved_namespace
-            mock.Mock(),
-            mocked_request,
-            cache_management=spy_cache_management,
-        )
-
-        # Then
-        assert (
-            retrieved_response
-            == spy_cache_management.retrieve_item_from_cache.return_value
-            != spy_calculate_response_and_save_in_cache.return_value
-        )
-
-    @mock.patch(f"{MODULE_PATH}._calculate_response_and_save_in_cache")
-    def test_means_response_is_recalculated_and_saved_if_already_available(
-        self, spy_calculate_response_and_save_in_cache: mock.MagicMock
-    ):
-        """
-        Given a mocked request and a `CacheManagement` object
-            which will return a valid pre-calculated response
-        And only the `Cache-Force-Refresh` header is included
-        When `_retrieve_response_from_cache_or_calculate()` is called
-        Then the response is recalculated and saved regardless
-
-        Patches:
-            `spy_calculate_response_and_save_in_cache`: For the main assertion
-        """
-        # Given
-        mocked_request = mock.MagicMock(
-            method="POST", headers={CACHE_FORCE_REFRESH_HEADER_KEY: True}
-        )
-        mocked_cache_management = mock.Mock()
-        mocked_cache_management.retrieve_item_from_cache = mock.Mock()
-
-        # When
-        retrieved_response = _retrieve_response_from_cache_or_calculate(
-            mock.Mock(),  # view_function
-            None,  # timeout
-            False,  # is_reserved_namespace
-            mock.Mock(),
-            mocked_request,
-            cache_management=mocked_cache_management,
-        )
-
-        # Then
-        assert (
-            retrieved_response
-            == spy_calculate_response_and_save_in_cache.return_value
-            != mocked_cache_management.retrieve_item_from_cache.return_value
-        )
-
-    @mock.patch(f"{MODULE_PATH}._calculate_response_and_save_in_cache")
-    def test_means_response_is_recalculated_and_saved_if_not_available(
-        self, spy_calculate_response_and_save_in_cache: mock.MagicMock
-    ):
-        """
-        Given a mocked request and a `CacheManagement` object
-            which will not return a valid pre-calculated response
-        When `_retrieve_response_from_cache_or_calculate()` is called
-        Then the response is recalculated and saved
-
-        Patches:
-            `spy_calculate_response_and_save_in_cache`: For the main assertion
-        """
-        # Given
-        mocked_request = mock.MagicMock(
-            method="POST", headers={CACHE_FORCE_REFRESH_HEADER_KEY: True}
-        )
-        mocked_cache_management = mock.Mock()
-        mocked_cache_management.retrieve_item_from_cache.side_effect = [CacheMissError]
-
-        # When
-        retrieved_response = _retrieve_response_from_cache_or_calculate(
-            mock.Mock(),  # view_function
-            None,  # timeout
-            False,  # is_reserved_namespace
-            mock.Mock(),
-            mocked_request,
-            cache_management=mocked_cache_management,
-        )
-
-        # Then
-        spy_calculate_response_and_save_in_cache.assert_called_once()
-        assert (
-            retrieved_response == spy_calculate_response_and_save_in_cache.return_value
-        )
 
 
 class TestCalculateResponseAndSaveInCache:

--- a/tests/unit/caching/test_internal_api_client.py
+++ b/tests/unit/caching/test_internal_api_client.py
@@ -80,21 +80,6 @@ class TestInternalAPIClient:
         spy_create_api_client.assert_called_once()
         assert internal_api_client._client == spy_create_api_client.return_value
 
-    def test_force_refresh_attribute_defaults_to_false(self):
-        """
-        Given no provided argument for `force_refresh`
-        When the `InternalAPIClient` class is initialized
-        Then the `force_refresh` attribute is set to False
-        """
-        # Given
-        mocked_client = mock.Mock()
-
-        # When
-        internal_api_client = InternalAPIClient(client=mocked_client)
-
-        # Then
-        assert not internal_api_client.force_refresh
-
     # API key manager & API client tests
 
     def test_create_api_client_returns_api_client(self):
@@ -135,16 +120,14 @@ class TestInternalAPIClient:
         mocked_client = mock.Mock()
         internal_api_client = InternalAPIClient(
             client=mocked_client,
-            force_refresh=force_refresh,
             reserved_namespace=reserved_namespace,
         )
 
         # When
-        headers = internal_api_client.build_headers()
+        headers: dict = internal_api_client.build_headers()
 
         # Then
         expected_headers = {
-            CACHE_FORCE_REFRESH_HEADER_KEY: force_refresh,
             CACHE_RESERVED_NAMESPACE_HEADER_KEY: reserved_namespace,
         }
         assert headers == expected_headers


### PR DESCRIPTION
# Description

This is the 1st PR to implement the dual cache strategy.
With this new approach we will be:
- Seperating ephemeral data (charts, tables, downloads etc) from long lived / reserved data (maps) into physically seperate caches - they are currently in 2 namespaces within the same cache.
- Simplifying how we flush caches to be naive:
    - Empty the selected cache completely with the `clear()` which wraps around the `FLUSHDB` command
    - Crawl the app and lazy load the responses into the cache
    - Reconfigure the `CacheManagement` and underlying `CacheClient` so that when they are getting or putting items in the cache, they select the cache based on the key. If it begins with `ns2-` it goes in the reserved cache otherwise the default cache
    - Simplify the `cache_response()` decorator so that it is a simple lazy-load of the request into the cache. Its the responsibility of the previous clear cache command to ensure the cache has been cleared so the next version of data can be persisted.

This PR includes the following:

- Adds the connection for the django app to the `reserved` cache
- Removes reference to `force_refresh`, previously when we were crawling the app, we'd set the cache crawler to always punch through the cache and write. But we don't really need this if we empty the selected cache ahead of time.

Fixes #CDD-2839

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
