### PR TITLE
CDD-2839: Implement dual redis cache strategy - Part 2

### DIFF
--- a/caching/private_api/crawler/area_selector/orchestration.py
+++ b/caching/private_api/crawler/area_selector/orchestration.py
@@ -106,9 +106,7 @@ class AreaSelectorOrchestrator:
             None
 
         """
-        private_api_crawler = (
-            PrivateAPICrawler.create_crawler_to_force_write_in_non_reserved_namespace()
-        )
+        private_api_crawler = PrivateAPICrawler.create_crawler_for_default_cache()
 
         # Since the payload to this method is intended to be serializable
         # via pickle -> multiprocessing or a message broker of some sort

--- a/caching/private_api/crawler/private_api_crawler.py
+++ b/caching/private_api/crawler/private_api_crawler.py
@@ -76,7 +76,7 @@ class PrivateAPICrawler:
         return cls(internal_api_client=internal_api_client)
 
     @classmethod
-    def create_crawler_to_force_write_in_reserved_staging_namespace(cls) -> Self:
+    def create_crawler_for_reserved_cache(cls) -> Self:
         internal_api_client = InternalAPIClient(reserved_namespace=True)
         return cls(internal_api_client=internal_api_client)
 

--- a/caching/private_api/crawler/private_api_crawler.py
+++ b/caching/private_api/crawler/private_api_crawler.py
@@ -71,7 +71,7 @@ class PrivateAPICrawler:
     # Class constructors
 
     @classmethod
-    def create_crawler_to_force_write_in_non_reserved_namespace(cls) -> Self:
+    def create_crawler_for_default_cache(cls) -> Self:
         internal_api_client = InternalAPIClient(reserved_namespace=False)
         return cls(internal_api_client=internal_api_client)
 

--- a/caching/private_api/handlers.py
+++ b/caching/private_api/handlers.py
@@ -134,8 +134,7 @@ def force_cache_refresh_for_reserved_namespace(
     """
     cache_management = cache_management or CacheManagement(in_memory=False)
     private_api_crawler = (
-        private_api_crawler
-        or PrivateAPICrawler.create_crawler_to_force_write_in_reserved_staging_namespace()
+        private_api_crawler or PrivateAPICrawler.create_crawler_for_reserved_cache()
     )
     area_selector_orchestrator = AreaSelectorOrchestrator(
         geographies_api_crawler=private_api_crawler.geography_api_crawler

--- a/caching/private_api/handlers.py
+++ b/caching/private_api/handlers.py
@@ -89,8 +89,7 @@ def force_cache_refresh_for_all_pages(
     cache_management.clear_non_reserved_keys()
 
     private_api_crawler = (
-        private_api_crawler
-        or PrivateAPICrawler.create_crawler_to_force_write_in_non_reserved_namespace()
+        private_api_crawler or PrivateAPICrawler.create_crawler_for_default_cache()
     )
     area_selector_orchestrator = AreaSelectorOrchestrator(
         geographies_api_crawler=private_api_crawler.geography_api_crawler

--- a/tests/unit/caching/private_api/crawler/area_selector/test_orchestration.py
+++ b/tests/unit/caching/private_api/crawler/area_selector/test_orchestration.py
@@ -103,12 +103,10 @@ class TestAreaSelectorOrchestrator:
         )
 
     @mock.patch.object(TopicPage, "objects")
-    @mock.patch.object(
-        PrivateAPICrawler, "create_crawler_to_force_write_in_non_reserved_namespace"
-    )
+    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_reserved_cache")
     def test_process_geography_page_combination(
         self,
-        mocked_create_crawler_to_force_write_in_non_reserved_namespace: mock.MagicMock,
+        mocked_create_crawler_for_reserved_cache: mock.MagicMock,
         spy_topic_page_manager: mock.MagicMock,
     ):
         """
@@ -123,7 +121,7 @@ class TestAreaSelectorOrchestrator:
         Patches:
             `spy_topic_page_manager`: To check the page ID
                 is used to retrieve the `TopicPage` model
-            `mocked_create_crawler_to_force_write_in_non_reserved_namespace`: To
+            `mocked_create_crawler_for_reserved_cache`: To
                 isolate the `PrivateAPICrawler` so that the
                 returned mock object can be spied on further
                 i.e. to check the main `process_all_sections_in_page()` call
@@ -144,9 +142,7 @@ class TestAreaSelectorOrchestrator:
         spy_topic_page_manager.get.assert_called_once_with(id=page_id)
         page_model = spy_topic_page_manager.get.return_value
 
-        spy_private_api_crawler = (
-            mocked_create_crawler_to_force_write_in_non_reserved_namespace.return_value
-        )
+        spy_private_api_crawler = mocked_create_crawler_for_reserved_cache.return_value
         spy_private_api_crawler.process_all_sections_in_page(
             page=page_model, geography_data=geography_data
         )

--- a/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
+++ b/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
@@ -17,17 +17,15 @@ class TestPrivateAPICrawlerCreate:
         # Then
         assert not crawler._internal_api_client.reserved_namespace
 
-    def test_create_crawler_to_force_write_in_reserved_staging_namespace(self):
+    def test_create_crawler_for_reserved_cache(self):
         """
         Given no pre-existing `InternalAPIClient`
-        When the `create_crawler_to_force_write_in_reserved_staging_namespace`
+        When the `create_crawler_for_reserved_cache`
             class method is called from the `PrivateAPICrawler` class
         Then the correct object is returned
         """
         # Given / When
-        crawler = (
-            PrivateAPICrawler.create_crawler_to_force_write_in_reserved_staging_namespace()
-        )
+        crawler = PrivateAPICrawler.create_crawler_for_reserved_cache()
 
         # Then
         assert crawler._internal_api_client.reserved_namespace

--- a/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
+++ b/tests/unit/caching/private_api/crawler/private_api_crawler/test_class_methods.py
@@ -4,17 +4,15 @@ from caching.private_api.crawler import PrivateAPICrawler
 class TestPrivateAPICrawlerCreate:
     # Tests for the create class methods
 
-    def test_create_crawler_to_force_write_in_non_reserved_namespace(self):
+    def test_create_crawler_for_default_cache(self):
         """
         Given no pre-existing `InternalAPIClient`
-        When the `create_crawler_to_force_write_in_non_reserved_namespace`
+        When the `create_crawler_for_default_cache`
             class method is called from the `PrivateAPICrawler` class
         Then the correct object is returned
         """
         # Given / When
-        crawler = (
-            PrivateAPICrawler.create_crawler_to_force_write_in_non_reserved_namespace()
-        )
+        crawler = PrivateAPICrawler.create_crawler_for_default_cache()
 
         # Then
         assert not crawler._internal_api_client.reserved_namespace

--- a/tests/unit/caching/private_api/test_handlers.py
+++ b/tests/unit/caching/private_api/test_handlers.py
@@ -211,7 +211,7 @@ class TestForceCacheRefreshForAllPages:
 
 class TestForceCacheRefreshForReservedNamespace:
     @mock.patch.object(
-        PrivateAPICrawler, "create_crawler_to_force_write_in_reserved_staging_namespace"
+        PrivateAPICrawler, "create_crawler_for_reserved_cache"
     )
     @mock.patch(f"{MODULE_PATH}.crawl_all_pages")
     @mock.patch(f"{MODULE_PATH}.AreaSelectorOrchestrator")
@@ -219,7 +219,7 @@ class TestForceCacheRefreshForReservedNamespace:
         self,
         spy_area_selector_orchestrator_class: mock.MagicMock,
         spy_crawl_all_pages: mock.MagicMock,
-        mocked_create_crawler_to_force_write_in_reserved_staging_namespace: mock.MagicMock,
+        mocked_create_crawler_for_reserved_cache: mock.MagicMock,
     ):
         """
         Given no input
@@ -262,7 +262,7 @@ class TestForceCacheRefreshForReservedNamespace:
         expected_calls = [
             mock.call.get_reserved_keys(),
             mock.call.crawl_all_pages(
-                private_api_crawler=mocked_create_crawler_to_force_write_in_reserved_staging_namespace.return_value,
+                private_api_crawler=mocked_create_crawler_for_reserved_cache.return_value,
                 area_selector_orchestrator=spy_area_selector_orchestrator_class.return_value,
             ),
             mock.call.delete_many(keys=expected_original_reserved_keys),

--- a/tests/unit/caching/private_api/test_handlers.py
+++ b/tests/unit/caching/private_api/test_handlers.py
@@ -128,12 +128,10 @@ class TestCrawlAllPages:
 class TestForceCacheRefreshForAllPages:
     @mock.patch(f"{MODULE_PATH}.AreaSelectorOrchestrator")
     @mock.patch(f"{MODULE_PATH}.crawl_all_pages")
-    @mock.patch.object(
-        PrivateAPICrawler, "create_crawler_to_force_write_in_non_reserved_namespace"
-    )
+    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_default_cache")
     def test_delegates_calls_successfully(
         self,
-        spy_create_crawler_to_force_write_in_non_reserved_namespace: mock.MagicMock,
+        spy_create_crawler_for_default_cache: mock.MagicMock,
         spy_crawl_all_pages: mock.MagicMock,
         spy_area_selector_orchestrator_class: mock.MagicMock,
     ):
@@ -143,9 +141,9 @@ class TestForceCacheRefreshForAllPages:
         Then the correct crawler is passed to `crawl_all_pages()`
 
         Patches:
-            `spy_create_crawler_to_force_write_in_non_reserved_namespace`: To assert
+            `spy_create_crawler_for_default_cache`: To assert
                 that the correct crawler is initialized i.e. the one
-                which can be used to forcibly refresh the cache
+                which can be used to crawl the default cache
             `spy_crawl_all_pages`: For the main assertion
             `spy_area_selector_orchestrator_class`: To check the
                 area selector orchestrator is passed to the
@@ -158,18 +156,14 @@ class TestForceCacheRefreshForAllPages:
         force_cache_refresh_for_all_pages(cache_management=mocked_cache_management)
 
         # Then
-        spy_create_crawler_to_force_write_in_non_reserved_namespace.assert_called_once()
-        expected_crawler = (
-            spy_create_crawler_to_force_write_in_non_reserved_namespace.return_value
-        )
+        spy_create_crawler_for_default_cache.assert_called_once()
+        expected_crawler = spy_create_crawler_for_default_cache.return_value
         spy_crawl_all_pages.assert_called_once_with(
             private_api_crawler=expected_crawler,
             area_selector_orchestrator=spy_area_selector_orchestrator_class.return_value,
         )
 
-    @mock.patch.object(
-        PrivateAPICrawler, "create_crawler_to_force_write_in_non_reserved_namespace"
-    )
+    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_default_cache")
     @mock.patch(f"{MODULE_PATH}.crawl_all_pages")
     @mock.patch(f"{MODULE_PATH}.AreaSelectorOrchestrator")
     @mock.patch.object(CacheManagement, "clear_non_reserved_keys")
@@ -178,7 +172,7 @@ class TestForceCacheRefreshForAllPages:
         spy_cache_management_clear_non_reserved_keys: mock.MagicMock,
         spy_area_selector_orchestrator_class: mock.MagicMock,
         spy_crawl_all_pages: mock.MagicMock,
-        mocked_create_crawler_to_force_write_in_non_reserved_namespace: mock.MagicMock,
+        mocked_create_crawler_for_default_cache: mock.MagicMock,
     ):
         """
         Given no input
@@ -205,7 +199,7 @@ class TestForceCacheRefreshForAllPages:
         expected_calls = [
             mock.call.cache_management_clear_non_reserved_keys(),
             mock.call.crawl_all_pages(
-                private_api_crawler=mocked_create_crawler_to_force_write_in_non_reserved_namespace.return_value,
+                private_api_crawler=mocked_create_crawler_for_default_cache.return_value,
                 area_selector_orchestrator=spy_area_selector_orchestrator_class.return_value,
             ),
         ]

--- a/tests/unit/caching/private_api/test_handlers.py
+++ b/tests/unit/caching/private_api/test_handlers.py
@@ -278,12 +278,10 @@ class TestForceCacheRefreshForReservedNamespace:
 
     @mock.patch(f"{MODULE_PATH}.AreaSelectorOrchestrator")
     @mock.patch(f"{MODULE_PATH}.crawl_all_pages")
-    @mock.patch.object(
-        PrivateAPICrawler, "create_crawler_to_force_write_in_reserved_staging_namespace"
-    )
+    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_reserved_cache")
     def test_delegates_calls_successfully(
         self,
-        spy_create_crawler_to_force_write_in_reserved_staging_namespace: mock.MagicMock,
+        spy_create_crawler_for_reserved_cache: mock.MagicMock,
         spy_crawl_all_pages: mock.MagicMock,
         spy_area_selector_orchestrator_class: mock.MagicMock,
     ):
@@ -293,7 +291,7 @@ class TestForceCacheRefreshForReservedNamespace:
         Then the correct crawler is passed to `crawl_all_pages()`
 
         Patches:
-            `spy_create_crawler_to_force_write_in_reserved_staging_namespace`: To assert
+            `spy_create_crawler_for_reserved_cache`: To assert
                 that the correct crawler is initialized i.e. the one
                 which can be used to forcibly refresh the reserved namespace cache
             `spy_crawl_all_pages`: For the main assertion
@@ -310,10 +308,8 @@ class TestForceCacheRefreshForReservedNamespace:
         )
 
         # Then
-        spy_create_crawler_to_force_write_in_reserved_staging_namespace.assert_called_once()
-        expected_crawler = (
-            spy_create_crawler_to_force_write_in_reserved_staging_namespace.return_value
-        )
+        spy_create_crawler_for_reserved_cache.assert_called_once()
+        expected_crawler = spy_create_crawler_for_reserved_cache.return_value
         spy_crawl_all_pages.assert_called_once_with(
             private_api_crawler=expected_crawler,
             area_selector_orchestrator=spy_area_selector_orchestrator_class.return_value,

--- a/tests/unit/caching/private_api/test_handlers.py
+++ b/tests/unit/caching/private_api/test_handlers.py
@@ -210,9 +210,7 @@ class TestForceCacheRefreshForAllPages:
 
 
 class TestForceCacheRefreshForReservedNamespace:
-    @mock.patch.object(
-        PrivateAPICrawler, "create_crawler_for_reserved_cache"
-    )
+    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_reserved_cache")
     @mock.patch(f"{MODULE_PATH}.crawl_all_pages")
     @mock.patch(f"{MODULE_PATH}.AreaSelectorOrchestrator")
     def test_manages_reserved_keys_cache_operations_in_correct_order(


### PR DESCRIPTION
# Description

This is the 2nd PR to implement the dual cache strategy.
See the [1st PR ](https://github.com/UKHSA-Internal/data-dashboard-api/pull/2694) for a brief on the overall solution

This PR includes the following:

- Renames the constructor method `create_crawler_to_force_write_in_non_reserved_namespace()` on the `PrivateAPICrawler` -> `create_crawler_for_default_cache()`
- Renames the constructor method `create_crawler_to_force_write_in_reserved_namespace()` on the `PrivateAPICrawler` -> `create_crawler_for_reserved_cache()`
- The above renaming was done because we will no longer force write requests. They'll be lazy loaded into the cache relying on the fact that the selected cache has been cleared ahead of time.

Fixes #CDD-2839

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
