### PR TITLE
CDD-2839: Implement dual redis cache strategy - Part 3

### DIFF
--- a/caching/private_api/handlers.py
+++ b/caching/private_api/handlers.py
@@ -166,5 +166,5 @@ def get_all_downloads(*, file_format: str = "csv") -> list[dict[str, str]]:
 
     """
     pages = collect_all_pages()
-    crawler = PrivateAPICrawler.create_crawler_for_lazy_loading()
+    crawler = PrivateAPICrawler.create_crawler_for_default_cache()
     return crawler.get_all_downloads(pages=pages, file_format=file_format)

--- a/tests/unit/caching/private_api/test_handlers.py
+++ b/tests/unit/caching/private_api/test_handlers.py
@@ -313,10 +313,10 @@ class TestForceCacheRefreshForReservedNamespace:
 
 class TestGetAllDownloads:
     @mock.patch(f"{MODULE_PATH}.collect_all_pages")
-    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_lazy_loading")
+    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_default_cache")
     def test_delegates_calls_correctly(
         self,
-        spy_create_crawler_for_lazy_loading: mock.MagicMock,
+        spy_create_crawler_for_default_cache: mock.MagicMock,
         spy_collect_all_pages: mock.MagicMock,
     ):
         """
@@ -326,7 +326,7 @@ class TestGetAllDownloads:
             crawler_get_all_downloads() methods.
         """
         # Given
-        crawler = spy_create_crawler_for_lazy_loading.return_value
+        crawler = spy_create_crawler_for_default_cache.return_value
         fake_file_format = "csv"
 
         # When
@@ -335,16 +335,16 @@ class TestGetAllDownloads:
         # Then
         spy_collect_all_pages.assert_called_once()
         expected_pages = spy_collect_all_pages.return_value
-        spy_create_crawler_for_lazy_loading.assert_called_once()
+        spy_create_crawler_for_default_cache.assert_called_once()
         crawler.get_all_downloads.assert_called_once_with(
             pages=expected_pages, file_format=fake_file_format
         )
 
     @mock.patch(f"{MODULE_PATH}.collect_all_pages")
-    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_lazy_loading")
+    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_default_cache")
     def test_default_file_format_can_be_changed_to_json(
         self,
-        spy_create_crawler_for_lazy_loading: mock.MagicMock,
+        spy_create_crawler_for_default_cache: mock.MagicMock,
         spy_collect_all_pages,
     ):
         """
@@ -354,7 +354,7 @@ class TestGetAllDownloads:
         Then The file_format parameter set to json.
         """
         # Given
-        crawler = spy_create_crawler_for_lazy_loading.return_value
+        crawler = spy_create_crawler_for_default_cache.return_value
         file_format = "json"
 
         # Then
@@ -367,10 +367,10 @@ class TestGetAllDownloads:
         )
 
     @mock.patch(f"{MODULE_PATH}.collect_all_pages")
-    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_lazy_loading")
+    @mock.patch.object(PrivateAPICrawler, "create_crawler_for_default_cache")
     def test_default_file_format_is_csv(
         self,
-        spy_create_crawler_for_lazy_loading: mock.MagicMock,
+        spy_create_crawler_for_default_cache: mock.MagicMock,
         spy_collect_all_pages,
     ):
         """
@@ -379,7 +379,7 @@ class TestGetAllDownloads:
         Then The default file_format parameter is set to csv.
         """
         # Given
-        crawler = spy_create_crawler_for_lazy_loading.return_value
+        crawler = spy_create_crawler_for_default_cache.return_value
 
         # When
         get_all_downloads()


### PR DESCRIPTION
# Description

This is the 3rd PR to implement the dual cache strategy.
See the [1st PR ](https://github.com/UKHSA-Internal/data-dashboard-api/pull/2694) for a brief on the overall solution

This PR includes the following:

- When processing bulk downloads we will now re-use the same cache crawler as the cache crawler which we use to warm the default cache as this is simple lazy loading of requests

Fixes #CDD-2839

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
