### PR TITLE
CDD-2839: Implement dual redis cache strategy - Part 5

### DIFF
--- a/caching/private_api/handlers.py
+++ b/caching/private_api/handlers.py
@@ -87,6 +87,9 @@ def force_cache_refresh_for_all_pages(
     cache_management = cache_management or CacheManagement(in_memory=False)
     logger.info("Clearing all non reserved keys")
     cache_management.clear_non_reserved_keys()
+    cache_management = cache_management or CacheManagement(
+        in_memory=False, is_reserved_namespace=False
+    )
 
     private_api_crawler = (
         private_api_crawler or PrivateAPICrawler.create_crawler_for_default_cache()
@@ -133,6 +136,9 @@ def force_cache_refresh_for_reserved_namespace(
 
     """
     cache_management = cache_management or CacheManagement(in_memory=False)
+    cache_management = cache_management or CacheManagement(
+        in_memory=False, is_reserved_namespace=True
+    )
     private_api_crawler = (
         private_api_crawler or PrivateAPICrawler.create_crawler_for_reserved_cache()
     )

--- a/caching/private_api/management.py
+++ b/caching/private_api/management.py
@@ -74,6 +74,7 @@ class CacheManagement:
         self,
         *,
         in_memory: bool,
+        is_reserved_namespace: bool = True,
         client: CacheClient | None = None,
         reserved_namespace_key_prefix: str = RESERVED_NAMESPACE_KEY_PREFIX,
     ):

--- a/tests/unit/caching/private_api/management/test_cache_management_init.py
+++ b/tests/unit/caching/private_api/management/test_cache_management_init.py
@@ -47,6 +47,16 @@ class TestCacheManagementInit:
             cache_management._reserved_namespace_key_prefix
             == reserved_namespace_key_prefix
         )
+
+    @pytest.mark.parametrize(
+        "in_memory, is_reserved_namespace",
+        (
+            [True, True],
+            [True, False],
+            [False, True],
+            [False, False],
+        ),
+    )
     @mock.patch.object(CacheManagement, "_create_cache_client")
     def test_create_cache_client_is_delegated_to_during_init_when_client_not_provided(
         self,

--- a/tests/unit/caching/private_api/management/test_cache_management_init.py
+++ b/tests/unit/caching/private_api/management/test_cache_management_init.py
@@ -47,11 +47,12 @@ class TestCacheManagementInit:
             cache_management._reserved_namespace_key_prefix
             == reserved_namespace_key_prefix
         )
-
-    @pytest.mark.parametrize("in_memory", [True, False])
     @mock.patch.object(CacheManagement, "_create_cache_client")
     def test_create_cache_client_is_delegated_to_during_init_when_client_not_provided(
-        self, spy_create_cache_client: mock.MagicMock, in_memory: bool
+        self,
+        spy_create_cache_client: mock.MagicMock,
+        in_memory: bool,
+        is_reserved_namespace: bool,
     ):
         """
         Given no pre-existing cache client
@@ -59,7 +60,9 @@ class TestCacheManagementInit:
         Then the call is delegated to the `_create_cache_client()` method
         """
         # Given / When
-        cache_management = CacheManagement(in_memory=in_memory)
+        cache_management = CacheManagement(
+            in_memory=in_memory, is_reserved_namespace=is_reserved_namespace
+        )
 
         # Then
         assert cache_management._client == spy_create_cache_client.return_value


### PR DESCRIPTION
# Description

This is the 5th PR to implement the dual cache strategy.
See the [1st PR ](https://github.com/UKHSA-Internal/data-dashboard-api/pull/2694) for a brief on the overall solution

This PR includes the following:

- Passes the `is_reserved_namespace` to the `CacheManagement` class. There are 2 modes of operation here. 1 is where we tell the `CacheManagement` ahead of time which `namespace` to look at and the other is where we give it a cache and basically say he you figure out which cache to put this key in. The 1st mode where we tell it ahead of time which cache to look at is gonna be used when we want to flush the cache, since we won't have a specific cache key to hand for it to figure that out, we'll have to tell it ahead of time

Fixes #CDD-2839

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
