### PR TITLE
  CDD-2839: Implement dual redis cache strategy - Part 6

### DIFF
--- a/caching/private_api/decorators.py
+++ b/caching/private_api/decorators.py
@@ -115,7 +115,6 @@ def _retrieve_response_from_cache_or_calculate(
         # when all the keys are ready
         cache_entry_key: str = cache_management.build_cache_entry_key_for_request(
             request=request,
-            is_reserved_staging_namespace=is_reserved_namespace,
             is_reserved_namespace=False,
         )
         return _calculate_response_and_save_in_cache(
@@ -126,7 +125,6 @@ def _retrieve_response_from_cache_or_calculate(
     # So we want to fetch the key associated with the non-reserved or reserved namespaces only.
     cache_entry_key: str = cache_management.build_cache_entry_key_for_request(
         request=request,
-        is_reserved_staging_namespace=False,
         is_reserved_namespace=is_reserved_namespace,
     )
 

--- a/caching/private_api/management.py
+++ b/caching/private_api/management.py
@@ -256,15 +256,12 @@ class CacheManagement:
         self,
         *,
         request: Request,
-        is_reserved_staging_namespace: bool,
         is_reserved_namespace: bool,
     ) -> str:
         """Builds a hashed cache entry key for a request
 
         Args:
             request: The incoming request which is to be hashed
-            is_reserved_staging_namespace: Boolean switch to store the data
-                in the reserved / long-lived staging namespace within the cache.
             is_reserved_namespace: Boolean switch to store the data
                 directly in the reserved / long-lived namespace within the cache.
 
@@ -281,9 +278,6 @@ class CacheManagement:
 
         """
         cache_key: str = self._build_standalone_key_for_request(request=request)
-        if is_reserved_staging_namespace:
-            return f"{RESERVED_NAMESPACE_STAGING_KEY_PREFIX}-{cache_key}"
-
         if is_reserved_namespace:
             return f"{RESERVED_NAMESPACE_KEY_PREFIX}-{cache_key}"
 

--- a/tests/unit/caching/private_api/management/test_build_cache_key_entry_for_request.py
+++ b/tests/unit/caching/private_api/management/test_build_cache_key_entry_for_request.py
@@ -88,7 +88,6 @@ class TestCacheManagementBuildCacheKeyEntryForRequest:
         cache_management_with_in_memory_cache.build_cache_entry_key_for_request(
             request=mocked_request,
             is_reserved_namespace=False,
-            is_reserved_staging_namespace=False,
         )
 
         # Then
@@ -117,7 +116,6 @@ class TestCacheManagementBuildCacheKeyEntryForRequest:
         cache_management_with_in_memory_cache.build_cache_entry_key_for_request(
             request=mocked_request,
             is_reserved_namespace=False,
-            is_reserved_staging_namespace=False,
         )
 
         # Then
@@ -146,40 +144,11 @@ class TestCacheManagementBuildCacheKeyEntryForRequest:
             cache_management_with_in_memory_cache.build_cache_entry_key_for_request(
                 request=mocked_request,
                 is_reserved_namespace=True,
-                is_reserved_staging_namespace=False,
             )
         )
 
         # Then
         assert cache_key == f"{RESERVED_NAMESPACE_KEY_PREFIX}-some-key"
-
-    @mock.patch.object(CacheManagement, "_build_standalone_key_for_request")
-    def test_build_cache_entry_key_for_reserved_staging_namespace_entry(
-        self,
-        mocked_build_standalone_key_for_request: mock.MagicMock,
-        cache_management_with_in_memory_cache: CacheManagement,
-    ):
-        """
-        Given a mocked POST request in the reserved staging namespace
-        When `build_cache_entry_key_for_request()` is called
-            from an instance of `CacheManagement`
-        Then cache key is returned with the reserved staging namespace prefix
-        """
-        # Given
-        mocked_build_standalone_key_for_request.return_value = "some-key"
-        mocked_request = mock.Mock(method="POST")
-
-        # When
-        cache_key: str = (
-            cache_management_with_in_memory_cache.build_cache_entry_key_for_request(
-                request=mocked_request,
-                is_reserved_namespace=False,
-                is_reserved_staging_namespace=True,
-            )
-        )
-
-        # Then
-        assert cache_key == f"{RESERVED_NAMESPACE_STAGING_KEY_PREFIX}-some-key"
 
     @pytest.mark.parametrize(
         "invalid_http_method",
@@ -210,5 +179,4 @@ class TestCacheManagementBuildCacheKeyEntryForRequest:
             cache_management_with_in_memory_cache.build_cache_entry_key_for_request(
                 request=mocked_request,
                 is_reserved_namespace=False,
-                is_reserved_staging_namespace=False,
             )


### PR DESCRIPTION
# Description

This is the 6th PR to implement the dual cache strategy.
See the [1st PR ](https://github.com/UKHSA-Internal/data-dashboard-api/pull/2694) for a brief on the overall solution

This PR includes the following:

- Removes support for creating reserved staging keys. Since we'll now just write directly to the staging cache on a key by key basis
- When we estabilish cache keys, we'll just decide whether they are default cache keys or reserved cache keys only

Fixes #CDD-2839

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
