### PR TITLE
CDD-2839: Implement dual redis cache strategy - Part 10

### DIFF
--- a/caching/private_api/handlers.py
+++ b/caching/private_api/handlers.py
@@ -53,12 +53,12 @@ def crawl_all_pages(
     logger.info("Finished refreshing of cache in %s seconds", round(duration, 2))
 
 
-def force_cache_refresh_for_all_pages(
+def refresh_default_cache(
     *,
     cache_management: CacheManagement | None = None,
     private_api_crawler: PrivateAPICrawler | None = None,
 ) -> None:
-    """Forcibly refresh the cache for all pages
+    """Refresh the default cache for all live pages
 
     Args:
         `cache_management`: A `CacheManagement` object

--- a/caching/private_api/handlers.py
+++ b/caching/private_api/handlers.py
@@ -105,12 +105,12 @@ def refresh_default_cache(
     )
 
 
-def force_cache_refresh_for_reserved_namespace(
+def refresh_reserved_cache(
     *,
     cache_management: CacheManagement | None = None,
     private_api_crawler: PrivateAPICrawler | None = None,
 ) -> None:
-    """Forcibly refresh the cache for the reserved namespace only.
+    """Refresh the reserved cache for all live pages
 
     Args:
         `cache_management`: A `CacheManagement` object

--- a/metrics/interfaces/management/commands/hydrate_private_api_cache.py
+++ b/metrics/interfaces/management/commands/hydrate_private_api_cache.py
@@ -1,9 +1,9 @@
 from django.core.management.base import BaseCommand
 
-from caching.private_api.handlers import force_cache_refresh_for_all_pages
+from caching.private_api.handlers import refresh_default_cache
 
 
 class Command(BaseCommand):
     @classmethod
     def handle(cls, *args, **options) -> None:
-        force_cache_refresh_for_all_pages()
+        refresh_default_cache()

--- a/metrics/interfaces/management/commands/hydrate_private_api_cache_reserved_namespace.py
+++ b/metrics/interfaces/management/commands/hydrate_private_api_cache_reserved_namespace.py
@@ -1,9 +1,9 @@
 from django.core.management.base import BaseCommand
 
-from caching.private_api.handlers import force_cache_refresh_for_reserved_namespace
+from caching.private_api.handlers import refresh_reserved_cache
 
 
 class Command(BaseCommand):
     @classmethod
     def handle(cls, *args, **options) -> None:
-        force_cache_refresh_for_reserved_namespace()
+        refresh_reserved_cache()

--- a/tests/unit/caching/private_api/test_handlers.py
+++ b/tests/unit/caching/private_api/test_handlers.py
@@ -2,11 +2,10 @@ from unittest import mock
 
 from _pytest.logging import LogCaptureFixture
 
-from caching.private_api.client import RESERVED_NAMESPACE_KEY_PREFIX
 from caching.private_api.crawler import PrivateAPICrawler
 from caching.private_api.handlers import (
     crawl_all_pages,
-    force_cache_refresh_for_all_pages,
+    refresh_default_cache,
     get_all_downloads,
     force_cache_refresh_for_reserved_namespace,
 )
@@ -125,7 +124,7 @@ class TestCrawlAllPages:
         assert "Finished refreshing of cache" in caplog.text
 
 
-class TestForceCacheRefreshForAllPages:
+class TestRefreshDefaultCache:
     @mock.patch(f"{MODULE_PATH}.AreaSelectorOrchestrator")
     @mock.patch(f"{MODULE_PATH}.crawl_all_pages")
     @mock.patch.object(PrivateAPICrawler, "create_crawler_for_default_cache")
@@ -137,7 +136,7 @@ class TestForceCacheRefreshForAllPages:
     ):
         """
         Given no input
-        When `force_cache_refresh_for_all_pages()` is called
+        When `refresh_default_cache()` is called
         Then the correct crawler is passed to `crawl_all_pages()`
 
         Patches:
@@ -153,7 +152,7 @@ class TestForceCacheRefreshForAllPages:
         mocked_cache_management = mock.Mock()
 
         # When
-        force_cache_refresh_for_all_pages(cache_management=mocked_cache_management)
+        refresh_default_cache(cache_management=mocked_cache_management)
 
         # Then
         spy_create_crawler_for_default_cache.assert_called_once()
@@ -176,7 +175,7 @@ class TestForceCacheRefreshForAllPages:
     ):
         """
         Given no input
-        When `force_cache_refresh_for_all_pages()` is called
+        When `refresh_default_cache()` is called
         Then `clear()` is called from a `CacheManagement` object
             before the call is made to `crawl_all_pages()`
         """
@@ -189,7 +188,7 @@ class TestForceCacheRefreshForAllPages:
         spy_manager.attach_mock(spy_crawl_all_pages, "crawl_all_pages")
 
         # When
-        force_cache_refresh_for_all_pages()
+        refresh_default_cache()
 
         # Then
         # `clear()` should only have been called once from the CacheManagement object

--- a/tests/unit/caching/private_api/test_handlers.py
+++ b/tests/unit/caching/private_api/test_handlers.py
@@ -7,7 +7,7 @@ from caching.private_api.handlers import (
     crawl_all_pages,
     refresh_default_cache,
     get_all_downloads,
-    force_cache_refresh_for_reserved_namespace,
+    refresh_reserved_cache,
 )
 from caching.private_api.management import (
     CacheManagement,
@@ -208,7 +208,7 @@ class TestRefreshDefaultCache:
         spy_crawl_all_pages.assert_called_once()
 
 
-class TestForceCacheRefreshForReservedNamespace:
+class TestRefreshReservedCache:
     @mock.patch(f"{MODULE_PATH}.AreaSelectorOrchestrator")
     @mock.patch(f"{MODULE_PATH}.crawl_all_pages")
     @mock.patch.object(PrivateAPICrawler, "create_crawler_for_reserved_cache")
@@ -220,7 +220,7 @@ class TestForceCacheRefreshForReservedNamespace:
     ):
         """
         Given no input
-        When `force_cache_refresh_for_reserved_namespace()` is called
+        When `refresh_reserved_cache()` is called
         Then the correct crawler is passed to `crawl_all_pages()`
 
         Patches:
@@ -236,9 +236,7 @@ class TestForceCacheRefreshForReservedNamespace:
         mocked_cache_management = mock.Mock()
 
         # When
-        force_cache_refresh_for_reserved_namespace(
-            cache_management=mocked_cache_management
-        )
+        refresh_reserved_cache(cache_management=mocked_cache_management)
 
         # Then
         spy_create_crawler_for_reserved_cache.assert_called_once()
@@ -264,7 +262,7 @@ class TestForceCacheRefreshForReservedNamespace:
     ):
         """
         Given no input
-        When `force_cache_refresh_for_reserved_namespace()` is called
+        When `refresh_reserved_cache()` is called
         Then `clear()` is called from a `CacheManagement` object
             before the call is made to `crawl_all_pages()`
         """
@@ -277,7 +275,7 @@ class TestForceCacheRefreshForReservedNamespace:
         spy_manager.attach_mock(spy_crawl_all_pages, "crawl_all_pages")
 
         # When
-        force_cache_refresh_for_reserved_namespace()
+        refresh_reserved_cache()
 
         # Then
         # `clear()` should only have been called once from the CacheManagement object

--- a/tests/unit/metrics/interfaces/management/test_hydrate_private_api_cache.py
+++ b/tests/unit/metrics/interfaces/management/test_hydrate_private_api_cache.py
@@ -6,20 +6,20 @@ MODULE_PATH = "metrics.interfaces.management.commands.hydrate_private_api_cache"
 
 
 class TestHydratePrivateAPICommand:
-    @mock.patch(f"{MODULE_PATH}.force_cache_refresh_for_all_pages")
+    @mock.patch(f"{MODULE_PATH}.refresh_default_cache")
     def test_delegates_call_successfully(
-        self, spy_force_cache_refresh_for_all_pages: mock.MagicMock
+        self, spy_refresh_default_cache: mock.MagicMock
     ):
         """
         Given an instance of the app
         When a call is made to the custom management command `hydrate_private_api_cache`
-        Then the call is delegated to the `force_cache_refresh_for_all_pages()` function
+        Then the call is delegated to the `refresh_default_cache()` function
 
         Patches:
-            `spy_force_cache_refresh_for_all_pages`: For the main assertion
+            `spy_refresh_default_cache`: For the main assertion
         """
         # Given / When
         call_command("hydrate_private_api_cache")
 
         # Then
-        spy_force_cache_refresh_for_all_pages.assert_called_once()
+        spy_refresh_default_cache.assert_called_once()

--- a/tests/unit/metrics/interfaces/management/test_hydrate_private_api_cache_reserved_namespace.py
+++ b/tests/unit/metrics/interfaces/management/test_hydrate_private_api_cache_reserved_namespace.py
@@ -6,20 +6,20 @@ MODULE_PATH = "metrics.interfaces.management.commands.hydrate_private_api_cache_
 
 
 class TestHydratePrivateAPIReservedNamespaceCommand:
-    @mock.patch(f"{MODULE_PATH}.force_cache_refresh_for_reserved_namespace")
+    @mock.patch(f"{MODULE_PATH}.refresh_reserved_cache")
     def test_delegates_call_successfully(
-        self, spy_force_cache_refresh_for_reserved_namespace: mock.MagicMock
+        self, spy_refresh_reserved_cache: mock.MagicMock
     ):
         """
         Given an instance of the app
         When a call is made to the custom management command `hydrate_private_api_cache`
-        Then the call is delegated to the `force_cache_refresh_for_reserved_namespace()` function
+        Then the call is delegated to the `refresh_reserved_cache()` function
 
         Patches:
-            `spy_force_cache_refresh_for_reserved_namespace`: For the main assertion
+            `spy_refresh_reserved_cache`: For the main assertion
         """
         # Given / When
         call_command("hydrate_private_api_cache_reserved_namespace")
 
         # Then
-        spy_force_cache_refresh_for_reserved_namespace.assert_called_once()
+        spy_refresh_reserved_cache.assert_called_once()


### PR DESCRIPTION
# Description

This is the 10th PR to implement the dual cache strategy. This PR contains **no functional changes**.
See the [1st PR ](https://github.com/UKHSA-Internal/data-dashboard-api/pull/2694) for a brief on the overall solution

This PR includes the following:

- Renaming `force_cache_refresh_for_all_pages()` -> `refresh_default_cache()`
- Renaming `force_cache_refresh_for_reserved_namespace()` -> `refresh_reserved_cache()`



Fixes #CDD-2839


---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
