### PR TITLE
CDD-2813: Add optional `about` field to filter linked map CMS component

### DIFF
--- a/cms/dashboard/templates/cms_starting_pages/childhood_vaccinations.json
+++ b/cms/dashboard/templates/cms_starting_pages/childhood_vaccinations.json
@@ -672,7 +672,8 @@
                     {
                         "type": "filter_linked_map",
                         "value": {
-                            "title_prefix": "Vaccination coverage statistics"
+                            "title_prefix": "Vaccination coverage statistics",
+                            "about": ""
                         },
                         "id": "c5720a34-4f6e-4132-b82b-c8982b9f4551"
                     }

--- a/cms/dynamic_content/global_filter/components/map.py
+++ b/cms/dynamic_content/global_filter/components/map.py
@@ -1,6 +1,18 @@
+from wagtail import blocks
+
+from cms.dashboard.models import AVAILABLE_RICH_TEXT_FEATURES
+from cms.dynamic_content import help_texts
+
 from .common import FilterLinkedComponent
 
 
 class FilterLinkedMap(FilterLinkedComponent):
+    about = blocks.RichTextBlock(
+        required=False,
+        default="",
+        features=AVAILABLE_RICH_TEXT_FEATURES,
+        help_text=help_texts.OPTIONAL_MAP_ABOUT_FIELD,
+    )
+
     class Meta:
         icon = "site"

--- a/cms/dynamic_content/help_texts.py
+++ b/cms/dynamic_content/help_texts.py
@@ -190,6 +190,10 @@ OPTIONAL_CHART_ABOUT_FIELD: str = """
 An optional body of text to accompany this block. This text will be displayed in the about content of the chart.
 """
 
+OPTIONAL_MAP_ABOUT_FIELD: str = """
+An optional body of text to accompany this block. This text will be displayed in the about content for this map.
+"""
+
 OPTIONAL_BODY_FIELD: str = """
 An optional body of text to accompany this block. This text will be displayed below the chart title.
 """


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds an optional `about` field for filter linked maps CMS components

Fixes #CDD-2813

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
