### PR TITLE
Task/insert null values for subplots when missing/cdd 2788

### DIFF
--- a/metrics/api/views/tables/subplot_tables/api_view.py
+++ b/metrics/api/views/tables/subplot_tables/api_view.py
@@ -1,5 +1,4 @@
 import logging
-from http import HTTPStatus
 
 from drf_spectacular.utils import OpenApiExample, extend_schema
 from rest_framework.response import Response
@@ -13,10 +12,6 @@ from metrics.api.views.tables.subplot_tables.request_example import (
     REQUEST_PAYLOAD_EXAMPLE,
 )
 from metrics.domain.models.charts.subplot_charts import SubplotChartRequestParameters
-from metrics.interfaces.plots.access import (
-    DataNotFoundForAnyPlotError,
-    InvalidPlotParametersError,
-)
 from metrics.interfaces.tables.subplot_tables import access
 
 logger = logging.getLogger(__name__)
@@ -45,13 +40,8 @@ class TablesSubplotView(APIView):
             request=request
         )
 
-        try:
-            tabular_data: list[dict] = access.generate_subplot_table(
-                subplot_chart_parameters=subplot_chart_parameters
-            )
-        except (InvalidPlotParametersError, DataNotFoundForAnyPlotError) as error:
-            return Response(
-                status=HTTPStatus.BAD_REQUEST, data={"error_message": str(error)}
-            )
+        tabular_data: list[dict] = access.generate_subplot_table(
+            subplot_chart_parameters=subplot_chart_parameters
+        )
 
         return Response(tabular_data)

--- a/metrics/interfaces/tables/subplot_tables/access.py
+++ b/metrics/interfaces/tables/subplot_tables/access.py
@@ -23,8 +23,10 @@ class SubplotTablesInterface:
         result: list[dict] = []
 
         for request_params in request_params_per_group:
-            tabular_data_for_sub_plot = self._generate_complete_tabular_data_for_subplot(
-                request_params=request_params
+            tabular_data_for_sub_plot = (
+                self._generate_complete_tabular_data_for_subplot(
+                    request_params=request_params
+                )
             )
             result += tabular_data_for_sub_plot
 
@@ -33,7 +35,9 @@ class SubplotTablesInterface:
 
         return result
 
-    def _generate_complete_tabular_data_for_subplot(self, *, request_params: ChartRequestParams) -> list[dict]:
+    def _generate_complete_tabular_data_for_subplot(
+        self, *, request_params: ChartRequestParams
+    ) -> list[dict]:
         """Builds the complete tabular data for the subplot associated with the given `request_params` model
 
         Args:

--- a/metrics/interfaces/tables/subplot_tables/access.py
+++ b/metrics/interfaces/tables/subplot_tables/access.py
@@ -1,5 +1,6 @@
 from metrics.domain.models import ChartRequestParams
 from metrics.domain.models.charts.subplot_charts import SubplotChartRequestParameters
+from metrics.domain.tables.generation import IN_REPORTING_DELAY_PERIOD
 from metrics.interfaces.plots.access import (
     DataNotFoundForAnyPlotError,
     InvalidPlotParametersError,
@@ -28,13 +29,77 @@ class SubplotTablesInterface:
                     generate_table_for_full_plots(request_params=request_params)
                 )
             except (InvalidPlotParametersError, DataNotFoundForAnyPlotError):
-                continue
+                tabular_data_for_sub_plot = (
+                    self._get_placeholder_for_sub_plot_with_no_tabular_data(
+                        request_params=request_params
+                    )
+                )
+
+            tabular_data_for_sub_plot = self._inject_null_values_for_any_missing_plots(
+                tabular_data_for_sub_plot=tabular_data_for_sub_plot,
+                request_params=request_params,
+            )
+
             result += tabular_data_for_sub_plot
 
         if not result:
             raise DataNotFoundForAnyPlotError
 
         return result
+
+    @classmethod
+    def _inject_null_values_for_any_missing_plots(
+        cls,
+        *,
+        tabular_data_for_sub_plot: list[dict],
+        request_params: ChartRequestParams,
+    ) -> list[dict]:
+        """Ensure each row contains null value placeholders for any missing plots
+
+        Args:
+            tabular_data_for_sub_plot: A list of tabular row dicts (one per group),
+                each with keys 'reference' and 'values'.
+            request_params: The `ChartRequestParams` model for this group,
+                whose plots define the required order and labels.
+
+        Returns:
+            The same list of rows with 'values' arrays ordered to match plots on the `ChartRequestParams`
+            and with missing entries covered as null case placeholders
+
+        """
+        required_labels: list[str] = [plot.label for plot in request_params.plots]
+
+        current_values = tabular_data_for_sub_plot[0]["values"]
+        label_lookup = {item.get("label"): item for item in current_values}
+
+        complete_values: list[dict] = []
+        for label in required_labels:
+            try:
+                value = label_lookup[label]
+            except KeyError:
+                value = {
+                    "label": label,
+                    "value": None,
+                    IN_REPORTING_DELAY_PERIOD: False,
+                }
+            complete_values.append(value)
+
+        tabular_data_for_sub_plot[0]["values"] = complete_values
+
+        return tabular_data_for_sub_plot
+
+    @classmethod
+    def _get_placeholder_for_sub_plot_with_no_tabular_data(
+        cls, *, request_params: ChartRequestParams
+    ) -> list[dict]:
+        """Create a placeholder row for a subplot group that returned no data at all.
+
+        Returns a list with a single row containing the 'reference' for this group and
+        'values' filled with None placeholders for each expected plot label in order.
+        """
+        x_axis_selector = request_params.x_axis
+        reference = getattr(request_params.plots[0], x_axis_selector)
+        return [{"reference": reference, "values": []}]
 
 
 def generate_subplot_table(

--- a/metrics/interfaces/tables/subplot_tables/access.py
+++ b/metrics/interfaces/tables/subplot_tables/access.py
@@ -30,9 +30,6 @@ class SubplotTablesInterface:
             )
             result += tabular_data_for_sub_plot
 
-        if not result:
-            raise DataNotFoundForAnyPlotError
-
         return result
 
     def _generate_complete_tabular_data_for_subplot(

--- a/metrics/interfaces/tables/subplot_tables/access.py
+++ b/metrics/interfaces/tables/subplot_tables/access.py
@@ -20,32 +20,47 @@ class SubplotTablesInterface:
         request_params_per_group: list[ChartRequestParams] = (
             self.request_params.output_payload_for_tables()
         )
-
         result: list[dict] = []
 
         for request_params in request_params_per_group:
-            try:
-                tabular_data_for_sub_plot: list[dict[str, str]] = (
-                    generate_table_for_full_plots(request_params=request_params)
-                )
-            except (InvalidPlotParametersError, DataNotFoundForAnyPlotError):
-                tabular_data_for_sub_plot = (
-                    self._get_placeholder_for_sub_plot_with_no_tabular_data(
-                        request_params=request_params
-                    )
-                )
-
-            tabular_data_for_sub_plot = self._inject_null_values_for_any_missing_plots(
-                tabular_data_for_sub_plot=tabular_data_for_sub_plot,
-                request_params=request_params,
+            tabular_data_for_sub_plot = self._generate_complete_tabular_data_for_subplot(
+                request_params=request_params
             )
-
             result += tabular_data_for_sub_plot
 
         if not result:
             raise DataNotFoundForAnyPlotError
 
         return result
+
+    def _generate_complete_tabular_data_for_subplot(self, *, request_params: ChartRequestParams) -> list[dict]:
+        """Builds the complete tabular data for the subplot associated with the given `request_params` model
+
+        Args:
+            request_params: The `ChartRequestParams` model for this group,
+                whose plots define the required order and labels.
+
+        Returns:
+            List of 1 dict, which represents the tabular data output
+            as to be returned from the API layer for this subplot group.
+            Missing entries are covered as null case placeholders
+
+        """
+        try:
+            tabular_data_for_sub_plot: list[dict[str, str]] = (
+                generate_table_for_full_plots(request_params=request_params)
+            )
+        except (InvalidPlotParametersError, DataNotFoundForAnyPlotError):
+            tabular_data_for_sub_plot = (
+                self._get_placeholder_for_sub_plot_with_no_tabular_data(
+                    request_params=request_params
+                )
+            )
+
+        return self._inject_null_values_for_any_missing_plots(
+            tabular_data_for_sub_plot=tabular_data_for_sub_plot,
+            request_params=request_params,
+        )
 
     @classmethod
     def _inject_null_values_for_any_missing_plots(

--- a/tests/integration/metrics/api/views/tables/test_subplot_tables.py
+++ b/tests/integration/metrics/api/views/tables/test_subplot_tables.py
@@ -18,7 +18,7 @@ class TestTablesSubplotView:
             theme_name="immunisation",
             sub_theme_name="childhood-vaccines",
             topic_name="6-in-1",
-            metric_name=f"6-in-1_coverage_coverageByYear",
+            metric_name="6-in-1_coverage_coverageByYear",
             stratum_name="12m",
             date="2021-03-31",
             geography_name="Darlington",
@@ -29,7 +29,7 @@ class TestTablesSubplotView:
             theme_name="immunisation",
             sub_theme_name="childhood-vaccines",
             topic_name="6-in-1",
-            metric_name=f"6-in-1_coverage_coverageByYear",
+            metric_name="6-in-1_coverage_coverageByYear",
             stratum_name="12m",
             date="2021-03-31",
             geography_name="North East",
@@ -40,7 +40,7 @@ class TestTablesSubplotView:
             theme_name="immunisation",
             sub_theme_name="childhood-vaccines",
             topic_name="6-in-1",
-            metric_name=f"6-in-1_coverage_coverageByYear",
+            metric_name="6-in-1_coverage_coverageByYear",
             stratum_name="12m",
             date="2021-03-31",
             geography_name="England",
@@ -52,7 +52,7 @@ class TestTablesSubplotView:
             theme_name="immunisation",
             sub_theme_name="childhood-vaccines",
             topic_name="6-in-1",
-            metric_name=f"6-in-1_coverage_coverageByYear",
+            metric_name="6-in-1_coverage_coverageByYear",
             stratum_name="24m",
             date="2021-03-31",
             geography_name="Darlington",
@@ -63,7 +63,7 @@ class TestTablesSubplotView:
             theme_name="immunisation",
             sub_theme_name="childhood-vaccines",
             topic_name="6-in-1",
-            metric_name=f"6-in-1_coverage_coverageByYear",
+            metric_name="6-in-1_coverage_coverageByYear",
             stratum_name="24m",
             date="2021-03-31",
             geography_name="North East",
@@ -74,7 +74,7 @@ class TestTablesSubplotView:
             theme_name="immunisation",
             sub_theme_name="childhood-vaccines",
             topic_name="6-in-1",
-            metric_name=f"6-in-1_coverage_coverageByYear",
+            metric_name="6-in-1_coverage_coverageByYear",
             stratum_name="24m",
             date="2021-03-31",
             geography_name="England",
@@ -145,6 +145,11 @@ class TestTablesSubplotView:
                         "in_reporting_delay_period": False,
                         "label": "6-in-1 (24 months)",
                         "value": "78.0000",
+                    },
+                    {
+                        "in_reporting_delay_period": False,
+                        "label": "MMR1 (24 months)",
+                        "value": None,
                     },
                     # Since there is no England / MMR1 / 24m record then
                     # nothing is returned in its place
@@ -224,7 +229,28 @@ class TestTablesSubplotView:
         # which in this case is `geography`
         expected_response_data = [
             # Since all the `England` record were under the `metric_value` of 90
-            # then they `England` gets excluded entirely
+            # then they are all returned as null values
+            {
+                "reference": "North East",
+                "values": [
+                    {
+                        "in_reporting_delay_period": False,
+                        "label": "6-in-1 (12 months)",
+                        "value": None,
+                    },
+                    {
+                        "in_reporting_delay_period": False,
+                        "label": "6-in-1 (24 months)",
+                        "value": None,
+                    },
+                    {
+                        "in_reporting_delay_period": False,
+                        "label": "MMR1 (24 months)",
+                        "value": None,
+                    },
+                    # The North East only had the 1 record with a high enough `metric_value
+                ],
+            },
             {
                 "reference": "North East",
                 "values": [
@@ -232,6 +258,16 @@ class TestTablesSubplotView:
                         "in_reporting_delay_period": False,
                         "label": "6-in-1 (12 months)",
                         "value": "97.0000",
+                    },
+                    {
+                        "in_reporting_delay_period": False,
+                        "label": "6-in-1 (24 months)",
+                        "value": None,
+                    },
+                    {
+                        "in_reporting_delay_period": False,
+                        "label": "MMR1 (24 months)",
+                        "value": None,
                     },
                     # The North East only had the 1 record with a high enough `metric_value
                 ],
@@ -244,7 +280,12 @@ class TestTablesSubplotView:
                         "label": "6-in-1 (12 months)",
                         "value": "90.0000",
                     },
-                    # Darlington will be given back excluding 1 of its records
+                    {
+                        "in_reporting_delay_period": False,
+                        "label": "6-in-1 (24 months)",
+                        "value": None,
+                    },
+                    # Darlington will be given back with null for 1 of its records
                     # since that fell outside the permissible `metric_value_ranges`
                     {
                         "in_reporting_delay_period": False,

--- a/tests/integration/metrics/api/views/tables/test_subplot_tables.py
+++ b/tests/integration/metrics/api/views/tables/test_subplot_tables.py
@@ -105,6 +105,7 @@ class TestTablesSubplotView:
             metric_value=84,
         )
         # There is intentionally no corresponding record for England / MMR1 / 24m
+        # There are also no records at all for MMR1 / 5 years across any of the geographies
 
     @property
     def path(self) -> str:


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds `null` case placeholders for any plots with missing data so that the frontend can consume the API response and consistently add `-` placeholders for those rows with missing data

Fixes #CDD-2788

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [x] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
