### PR TITLE
Remove redundant bypassing of `ruff` rule `SLF001`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,8 +113,6 @@ target-version = "py312"
 "public_api/views/root_view.py"                               = ["A002"]           # Ignore built-in `format` used in arg to extended
 "public_api/version_02/views/root_view.py"                    = ["A002"]           # Ignore built-in `format` used in arg to extended
                                                                                         # rest framework API view method
-"caching/private_api/client.py"                               = ["SLF001"]         # Ignore access to private member
-                                                                                        # due to low level Redis client being used
 "caching/public_api/crawler.py"                               = ["PERF401"]        # Ignore list comprehension which would reduce readibility
 "caching/common/geographies_crawler.py"                       = ["PLW1641"]        # Ignore requirement of `__hash__` implementation
 "metrics/domain/weather_health_alerts/text_lookups/*"         = ["W291"]           # Ignore trailing whitespace for weather alert text lookups


### PR DESCRIPTION
# Description

This PR includes the following:

- Previously we were explicitly bypassing the ruff rule of `SLF001`, this is now not needed so it can be safely removed

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
