### PR TITLE
Add note on how to expand ingestion validation for new geography types

### DIFF
--- a/docs/ingestion_validation.md
+++ b/docs/ingestion_validation.md
@@ -186,3 +186,23 @@ class _RespiratoryTopic(Enum):
 ```
 
 **Note**: These changes need to be made to the codebase before any metrics for `Measles` could be ingested.
+
+## How to add new geography types
+
+Although an individual `Geography` is not validated against any strict enum, 
+the corresponding `GeographyType` will be validated against a strict enum. 
+
+This is declared on the `IncomingBaseDataModel` pydantic model as:
+```python
+class IncomingBaseDataModel(BaseModel):
+    ...
+    geography_type: enums.GeographyType
+```
+Which can be found at `ingestion/data_transfer_models/base.py`.
+
+To add a new `GeographyType` we must:
+
+1. Declare the new geography type on the `GeographyType` enum
+which can be found at `ingestion/utils/enums/geographies_enums.py`.
+2. Expand the `validate_geography_code()` handler at `ingestion/data_transfer_models/validation/geography_code.py`
+to include validation for the `geography_code` associated with the new `GeographyType` which is being added.


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds a note to `docs/ingestion_validation.md` on how to expand the data ingestion validation to incorporate a new geograhy type

Fixes #CDD-2885

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
