### PR TITLE
Add note on need for expanding CMS objects with `theme` and `sub_theme` fields

### DIFF
--- a/docs/handover/key_tech_debt_items.md
+++ b/docs/handover/key_tech_debt_items.md
@@ -31,3 +31,23 @@ It is recommended that you extract the validation functionality from the `ingest
 its own 1st class module. 
 This way you can then share that module with both data ingestion and the `cms/` so that you can bolt on 
 CMS input validation for free.
+
+### Specifying complete parameters in CMS inputs
+
+In the CMS, we have a number of components such as charts & headline numbers.
+Generally, they ask for the following parameters:
+
+- `topic`
+- `metric`
+- `geography`
+- `geography_type`
+- `sex`
+- `age`
+- `stratum`
+
+However, `topic` **names are not unique** as we can now have the same `topic` appear under multiple `sub_themes`.
+At the time of writing (September 2025) this is only the case with the `topic` of `"E-Coli"`, 
+which appears under the `sub_themes` of `"bloodstream_infection"` and `"antimicrobial_resistance""`.
+
+As such, you will need to enforce `theme` and `sub_theme` to be provided by the CMS content author.
+With those 2 additional fields, the parameters as a whole become entirely explicit and granular.


### PR DESCRIPTION
# Description

This PR includes the following:

- Adds a note to the handover docs explaining the need for expanding dynamic content blocks in the CMS with `theme` and `sub_theme` fields

Fixes #CDD-2885

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
