### PR TITLE
CDD-1699: Replace long-lived PAT with ephemeral token to authenticate cross repo call for CD pipeline

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -245,6 +245,16 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+
+      - name: Generate ephemeral deployment token
+        id: generate-deployment-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{secrets.DEPLOYMENT_TOKEN_FACTORY_APP_ID}}
+          private-key: ${{secrets.DEPLOYMENT_TOKEN_FACTORY_PRIVATE_KEY}}
+          skip-token-revoke: false
+          repositories: "data-dashboard-infra"
+
       - uses: ./.github/actions/trigger-deployments
         with:
-          token: ${{ secrets.DEPLOYMENT_TRIGGER_TOKEN }}
+          token: ${{steps.generate-deployment-token.outputs.token}}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -250,11 +250,13 @@ jobs:
         id: generate-deployment-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{secrets.DEPLOYMENT_TOKEN_FACTORY_APP_ID}}
-          private-key: ${{secrets.DEPLOYMENT_TOKEN_FACTORY_PRIVATE_KEY}}
+          app-id: ${{ secrets.DEPLOYMENT_TOKEN_FACTORY_APP_ID }}
+          private-key: ${{ secrets.DEPLOYMENT_TOKEN_FACTORY_PRIVATE_KEY }}
           skip-token-revoke: false
+          # Although this is the default, this is explicitly set so that
+          # we know the token gets revoked after the job has finished
           repositories: "data-dashboard-infra"
 
       - uses: ./.github/actions/trigger-deployments
         with:
-          token: ${{steps.generate-deployment-token.outputs.token}}
+          token: ${{ steps.generate-deployment-token.outputs.token }}


### PR DESCRIPTION
# Description

This PR includes the following:

- Outside of this we have created a new Github app `data-dashboard-deployments` which has access to the dashboard repos only
- We are now using the `create-github-app-token` action to generate a token from the aforementioned Github app
- This generated token is now being used to authenticate the cross-repo call made from this repo -> infra repo (which runs the deployment workflow to deploy the latest container images)

Fixes #CDD-1699

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
