### PR TITLE
Task/CDD-3284 make permission sets readonly

### DIFF
--- a/auth_content/models/permission_sets.py
+++ b/auth_content/models/permission_sets.py
@@ -126,7 +126,7 @@ class PermissionSet(models.Model):
     geography = models.CharField(max_length=255, blank=False, default="")
 
     base_form_class = PermissionSetForm
-    
+
     @property
     def permission_set_details(self):
         parts = [part.strip() for part in self.name.split("|")]

--- a/auth_content/models/permission_sets.py
+++ b/auth_content/models/permission_sets.py
@@ -5,7 +5,7 @@ from django import forms
 from django.core.exceptions import ValidationError
 from django.db import models
 from wagtail.admin.forms import WagtailAdminModelForm
-from wagtail.admin.panels import FieldPanel
+from wagtail.admin.panels import FieldPanel, mark_safe
 
 from auth_content.constants import PERMISSION_SET_FIELDS, WILDCARD_ID_VALUE
 from cms.metrics_interface.field_choices_callables import (
@@ -126,6 +126,11 @@ class PermissionSet(models.Model):
     geography = models.CharField(max_length=255, blank=False, default="")
 
     base_form_class = PermissionSetForm
+    
+    @property
+    def permission_set_details(self):
+        parts = [part.strip() for part in self.name.split("|")]
+        return mark_safe("<br>".join(parts))
 
     panels = [
         FieldPanel("theme"),

--- a/auth_content/wagtail_hooks.py
+++ b/auth_content/wagtail_hooks.py
@@ -1,16 +1,31 @@
 from django.templatetags.static import static
 from django.utils.html import format_html
 from wagtail import hooks
-from wagtail.admin.viewsets.model import ModelViewSet, ModelViewSetGroup
+from wagtail.admin.viewsets.model import ModelPermissionPolicy, ModelViewSet, ModelViewSetGroup
 
 from auth_content.models.permission_sets import PermissionSet
 from auth_content.models.users import User
+
+
+class NoEditPermissionPolicy(ModelPermissionPolicy):
+    def user_has_permission(self, user, action):
+        if action == "change":
+            return False
+        return super().user_has_permission(user, action)
+
+    def user_has_permission_for_instance(self, user, action, instance):
+        if action == "change":
+            return False
+        return super().user_has_permission_for_instance(user, action, instance)
 
 
 class PermissionSetViewSet(ModelViewSet):
     model = PermissionSet
     menu_label = "Permission Sets"
     icon = "key"
+    permission_policy = NoEditPermissionPolicy(PermissionSet)
+    inspect_view_enabled = True
+    inspect_view_fields = ["permission_set_details"]
 
 
 class UserViewSet(ModelViewSet):

--- a/auth_content/wagtail_hooks.py
+++ b/auth_content/wagtail_hooks.py
@@ -1,7 +1,11 @@
 from django.templatetags.static import static
 from django.utils.html import format_html
 from wagtail import hooks
-from wagtail.admin.viewsets.model import ModelPermissionPolicy, ModelViewSet, ModelViewSetGroup
+from wagtail.admin.viewsets.model import (
+    ModelPermissionPolicy,
+    ModelViewSet,
+    ModelViewSetGroup,
+)
 
 from auth_content.models.permission_sets import PermissionSet
 from auth_content.models.users import User

--- a/tests/unit/auth_content/test_wagtail_hooks.py
+++ b/tests/unit/auth_content/test_wagtail_hooks.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 from django.test import TestCase
 from django.utils.safestring import SafeData
 
-from auth_content.models import PermissionSet
+from auth_content.models.permission_sets import PermissionSet
 from auth_content.wagtail_hooks import NoEditPermissionPolicy, PermissionSetViewSet
 
 

--- a/tests/unit/auth_content/test_wagtail_hooks.py
+++ b/tests/unit/auth_content/test_wagtail_hooks.py
@@ -1,0 +1,60 @@
+from unittest.mock import MagicMock
+from django.test import TestCase
+from django.utils.safestring import SafeData
+
+from auth_content.models import PermissionSet
+from auth_content.wagtail_hooks import NoEditPermissionPolicy, PermissionSetViewSet
+
+
+
+class TestPermissionSetDetailsProperty(TestCase):
+
+    def test_single_value_no_pipe(self):
+        permission_set = PermissionSet(name="test 1")
+        self.assertEqual(permission_set.permission_set_details, "test 1")
+
+    def test_pipe_separated_values_split_to_newlines(self):
+        permission_set = PermissionSet(name="Name One|Name Two|Name Three")
+        self.assertEqual(permission_set.permission_set_details, "Name One<br>Name Two<br>Name Three")
+
+    def test_whitespace_around_pipes_is_stripped(self):
+        permission_set = PermissionSet(name="Name One | Name Two")
+        self.assertEqual(permission_set.permission_set_details, "Name One<br>Name Two")
+
+    def test_empty_string(self):
+        permission_set = PermissionSet(name="")
+        self.assertEqual(permission_set.permission_set_details, "")
+
+    def test_output_is_marked_safe(self):
+        permission_set = PermissionSet(name="Name One|Name Two")
+        self.assertIsInstance(permission_set.permission_set_details, SafeData)
+        
+class TestNoEditPermissionPolicy(TestCase):
+
+    def setUp(self):
+        self.policy = NoEditPermissionPolicy(PermissionSet)
+        self.user = MagicMock()
+        self.instance = PermissionSet(name="Test")
+
+    def test_change_permission_denied(self):
+        self.assertFalse(self.policy.user_has_permission(self.user, "change"))
+
+    def test_change_permission_denied_for_instance(self):
+        self.assertFalse(
+            self.policy.user_has_permission_for_instance(self.user, "change", self.instance)
+        )
+        
+class TestPermissionSetViewSet(TestCase):
+
+    def setUp(self):
+        self.viewset = PermissionSetViewSet()
+
+    def test_inspect_view_fields_contains_permission_set_details(self):
+        self.assertIn("permission_set_details", self.viewset.inspect_view_fields)
+
+    def test_permission_policy_is_no_edit_policy(self):
+        self.assertIsInstance(self.viewset.permission_policy, NoEditPermissionPolicy)
+
+    def test_change_permission_denied_via_viewset_policy(self):
+        user = MagicMock()
+        self.assertFalse(self.viewset.permission_policy.user_has_permission(user, "change"))

--- a/tests/unit/auth_content/test_wagtail_hooks.py
+++ b/tests/unit/auth_content/test_wagtail_hooks.py
@@ -6,7 +6,6 @@ from auth_content.models import PermissionSet
 from auth_content.wagtail_hooks import NoEditPermissionPolicy, PermissionSetViewSet
 
 
-
 class TestPermissionSetDetailsProperty(TestCase):
 
     def test_single_value_no_pipe(self):
@@ -15,7 +14,9 @@ class TestPermissionSetDetailsProperty(TestCase):
 
     def test_pipe_separated_values_split_to_newlines(self):
         permission_set = PermissionSet(name="Name One|Name Two|Name Three")
-        self.assertEqual(permission_set.permission_set_details, "Name One<br>Name Two<br>Name Three")
+        self.assertEqual(
+            permission_set.permission_set_details, "Name One<br>Name Two<br>Name Three"
+        )
 
     def test_whitespace_around_pipes_is_stripped(self):
         permission_set = PermissionSet(name="Name One | Name Two")
@@ -28,7 +29,8 @@ class TestPermissionSetDetailsProperty(TestCase):
     def test_output_is_marked_safe(self):
         permission_set = PermissionSet(name="Name One|Name Two")
         self.assertIsInstance(permission_set.permission_set_details, SafeData)
-        
+
+
 class TestNoEditPermissionPolicy(TestCase):
 
     def setUp(self):
@@ -41,9 +43,12 @@ class TestNoEditPermissionPolicy(TestCase):
 
     def test_change_permission_denied_for_instance(self):
         self.assertFalse(
-            self.policy.user_has_permission_for_instance(self.user, "change", self.instance)
+            self.policy.user_has_permission_for_instance(
+                self.user, "change", self.instance
+            )
         )
-        
+
+
 class TestPermissionSetViewSet(TestCase):
 
     def setUp(self):
@@ -57,4 +62,6 @@ class TestPermissionSetViewSet(TestCase):
 
     def test_change_permission_denied_via_viewset_policy(self):
         user = MagicMock()
-        self.assertFalse(self.viewset.permission_policy.user_has_permission(user, "change"))
+        self.assertFalse(
+            self.viewset.permission_policy.user_has_permission(user, "change")
+        )


### PR DESCRIPTION
# Description

This PR includes the following:

- Make permission sets read only after creation
- Ensure users can still delete permission sets
- Ensure users can still be assigned permission sets
- Ensure users can still click on a permission set to see details

Fixes #CDD-3284 

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
