### PR TITLE
build: remove simplejson dependency

### DIFF
--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -74,7 +74,6 @@ ruamel.yaml.clib==0.2.15
 SQLAlchemy==2.0.49
 scour==0.38.2
 setuptools==82.0.1
-simplejson==3.20.2
 six==1.17.0
 sortedcontainers==2.4.0
 soupsieve==2.8.3


### PR DESCRIPTION
Saw a dependabot update for this package and in investigating if it was safe to update realised we're not actually using it...
