### PR TITLE
Update dependencies with security issues blocking pipeline

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ factory-boy==3.3.3
 freezegun==1.5.5
 Faker==40.15.0
 gitdb==4.0.12
-GitPython==3.1.49
+GitPython==3.1.50
 import-linter==2.11
 isort==8.0.1
 pip-api==0.0.34

--- a/requirements-prod-ingestion.txt
+++ b/requirements-prod-ingestion.txt
@@ -1,7 +1,7 @@
 asgiref==3.11.1
 boto3==1.34.68
 botocore==1.34.109
-Django==5.2.13
+Django==5.2.14
 psycopg2-binary==2.9.12
 pydantic==2.13.3
 python-dotenv==1.2.2

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -48,7 +48,6 @@ mdurl==0.1.2
 msgpack==1.1.2
 mypy-extensions==1.1.0
 nodeenv==1.10.0
-openapi-codec==1.3.2
 openpyxl==3.1.5
 orjson==3.11.8
 packageurl-python==0.17.6

--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -85,7 +85,7 @@ typing_extensions==4.15.0
 uritemplate==4.2.0
 urllib3==2.6.3
 virtualenv==21.3.0
-wagtail==7.3.1
+wagtail==7.3.2
 wagtail_trash==3.2.0
 wagtail_modeladmin==2.2.0
 webencodings==0.5.1


### PR DESCRIPTION
# Description

This PR includes the following:

- Update django 5.2.13 -> 5.2.14
- Update wagtail 7.3.1 -> 7.3.2
- Update gitpython 3.1.49 -> 3.1.50
- Remove unused `openapi-codec` dependency

The first 3 have security issues causing the dependency check in the pipeline to fail, while the last one was an warning on the sentry check but didn't actually fail the build (we're not using it anywhere and the lib is 7 years out of date having been archived in 2019).

Because each of these is failing the dependency check in the pipeline and dependabot opens one PR for each, they all fail waiting for the others to be merged so this PR just brings them all together so that the pipeline is happy and we can merge without having override our safety mechanisms.

---

Covers:
- https://github.com/UKHSA-Internal/data-dashboard-api/pull/3182
- https://github.com/UKHSA-Internal/data-dashboard-api/pull/3181
- https://github.com/UKHSA-Internal/data-dashboard-api/pull/3180