### PR TITLE
Update actions node runtime [cdd-3229]

### DIFF
--- a/.github/actions/install-cache/action.yml
+++ b/.github/actions/install-cache/action.yml
@@ -6,7 +6,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
     - name: Cache dependencies
       uses: actions/cache@v4
       id: cache

--- a/.github/actions/install-cache/action.yml
+++ b/.github/actions/install-cache/action.yml
@@ -8,7 +8,7 @@ runs:
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
     - name: Cache dependencies
-      uses: actions/cache@v4
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
       id: cache
       # Using the native `setup-python` `cache` interface only caches dependencies
       # as opposed to the build itself.

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -36,7 +36,7 @@ runs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419
 
     - name: Build, tag, and push image to AWS ECR
       env:

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -23,7 +23,7 @@ runs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -20,7 +20,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -26,7 +26,7 @@ runs:
       uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4

--- a/.github/actions/publish-image/action.yml
+++ b/.github/actions/publish-image/action.yml
@@ -29,7 +29,7 @@ runs:
       uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@99214aa6889fcddfa57764031d71add364327e59
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -332,7 +332,7 @@ jobs:
 
       - name: Generate ephemeral deployment token
         id: generate-deployment-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
           app-id: ${{ secrets.DEPLOYMENT_TOKEN_FACTORY_APP_ID }}
           private-key: ${{ secrets.DEPLOYMENT_TOKEN_FACTORY_PRIVATE_KEY }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: ./.github/actions/install-cache
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
 
       - name: Scan dependencies
         run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-22.04-arm
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
@@ -45,7 +45,7 @@ jobs:
     needs: [secret-scan]
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
 
   ###############################################################################
@@ -57,7 +57,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
 
       - name: Install uv
@@ -73,7 +73,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
 
       - name: Scan for vulnerabilities
@@ -90,7 +90,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
 
       - name: Run linters
@@ -107,7 +107,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
 
       - name: Check architectural constraints
@@ -124,7 +124,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
 
       - name: Run unit tests
@@ -141,7 +141,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
 
       - name: Run integration tests
@@ -158,7 +158,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
 
       - name: Run system tests
@@ -175,7 +175,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
 
       - name: Run migration tests
@@ -192,7 +192,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/install-cache
 
       - name: Evaluate test coverage
@@ -209,7 +209,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Build main API Docker image
         run: docker build -t be-main-test -f Dockerfile .
@@ -278,7 +278,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Build and publish docker image
         uses: ./.github/actions/publish-image
         with:
@@ -306,7 +306,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Build and publish docker image
         uses: ./.github/actions/publish-image
         with:
@@ -328,7 +328,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Generate ephemeral deployment token
         id: generate-deployment-token


### PR DESCRIPTION
Upgrade as many action dependencies as we can to remove node 20 deprecation warnings. E.g. https://github.com/UKHSA-Internal/data-dashboard-api/actions/runs/26643002306 which looks like this:

<img width="1473" height="741" alt="image" src="https://github.com/user-attachments/assets/03202323-fb60-4d6f-ab2e-4c04dd080250" />

Git leaks is still lacking node 20 support (e.g. https://github.com/gitleaks/gitleaks-action/issues/209) however it does work when running against node 24 (this has been tested [here](https://github.com/UKHSA-Internal/data-dashboard-api/actions/runs/26645443353). If it becomes an issue in the future, we'll turn it off / look for another way of running it.

Note that every action has been upgraded to the latest version available but we use the sha of the commit that was released for [security reasons](https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions). This is also ensures we pass the sonarqube checks.

Fixes #CDD-3229

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Tech debt item (this is focused solely on addressing any relevant technical debt)
