### PR TITLE
CDD-3433 Fix: Add permission set urls to CMS_ADMIN

### DIFF
--- a/metrics/api/urls_construction.py
+++ b/metrics/api/urls_construction.py
@@ -138,7 +138,7 @@ heat_alert_detail = HeatAlertViewSet.as_view({"get": "retrieve"})
 cold_alert_list = ColdAlertViewSet.as_view({"get": "list"})
 cold_alert_detail = ColdAlertViewSet.as_view({"get": "retrieve"})
 
-permission_set_urlpatterns = [
+generic_permission_set_urlpatterns = [
     path(
         f"{API_PREFIX}data-hierarchy/subthemes/<str:theme_id>",
         SubThemesByThemeView.as_view(),
@@ -159,6 +159,8 @@ permission_set_urlpatterns = [
         GeographiesByGeographyTypeView.as_view(),
         name="get_geographies",
     ),
+]
+permission_set_urlpatterns = [
     path(
         f"{API_PREFIX}user/<str:user_id>/permissions",
         UserPermissionSetsByUserIdView.as_view(),
@@ -313,7 +315,7 @@ def construct_urlpatterns(
             constructed_url_patterns += construct_cms_admin_urlpatterns(
                 app_mode=app_mode
             )
-            constructed_url_patterns += permission_set_urlpatterns
+            constructed_url_patterns += generic_permission_set_urlpatterns
             constructed_url_patterns += audit_api_urlpatterns
         case enums.AppMode.PUBLIC_API.value:
             constructed_url_patterns += construct_public_api_urlpatterns(
@@ -321,6 +323,7 @@ def construct_urlpatterns(
             )
         case enums.AppMode.PRIVATE_API.value:
             constructed_url_patterns += private_api_urlpatterns
+            constructed_url_patterns += generic_permission_set_urlpatterns
             constructed_url_patterns += permission_set_urlpatterns
         case enums.AppMode.FEEDBACK_API.value:
             constructed_url_patterns += feedback_urlpatterns

--- a/metrics/api/urls_construction.py
+++ b/metrics/api/urls_construction.py
@@ -342,5 +342,6 @@ def construct_urlpatterns(
             constructed_url_patterns += feedback_urlpatterns
             constructed_url_patterns += audit_api_urlpatterns
             constructed_url_patterns += permission_set_urlpatterns
+            constructed_url_patterns += generic_permission_set_urlpatterns
 
     return constructed_url_patterns

--- a/metrics/api/urls_construction.py
+++ b/metrics/api/urls_construction.py
@@ -313,6 +313,7 @@ def construct_urlpatterns(
             constructed_url_patterns += construct_cms_admin_urlpatterns(
                 app_mode=app_mode
             )
+            constructed_url_patterns += permission_set_urlpatterns
             constructed_url_patterns += audit_api_urlpatterns
         case enums.AppMode.PUBLIC_API.value:
             constructed_url_patterns += construct_public_api_urlpatterns(

--- a/tests/unit/metrics/api/test_urls_construction.py
+++ b/tests/unit/metrics/api/test_urls_construction.py
@@ -57,6 +57,18 @@ VERSIONED_APP_NAMES = [
     "public_api",
 ]
 
+PERMISSION_SET_PATHS = [
+    "api/user/<str:user_id>/permissions",
+    "api/user/<str:user_id>/permissions/hierarchy",
+]
+
+GENERIC_PERMISSION_SET_PATHS = [
+    "api/data-hierarchy/subthemes/<str:theme_id>",
+    "api/data-hierarchy/topics/<str:sub_theme_id>",
+    "api/data-hierarchy/metrics/<str:topic_id>",
+    "api/data-hierarchy/geographies/<str:geography_type_id>",
+]
+
 
 def _flatten_urls(*, urlpatterns: list[URLPattern | URLResolver]) -> list[URLPattern]:
     """Takes a list of URLPatterns and URLResolvers and returns
@@ -183,7 +195,9 @@ class TestConstructUrlpatterns:
 
     @pytest.mark.parametrize(
         "private_api_endpoint_path",
-        PRIVATE_API_ENDPOINT_PATHS,
+        PRIVATE_API_ENDPOINT_PATHS
+        + PERMISSION_SET_PATHS
+        + GENERIC_PERMISSION_SET_PATHS,
     )
     def test_private_api_mode_returns_private_api_urls(
         self, private_api_endpoint_path: str
@@ -369,7 +383,7 @@ class TestConstructUrlpatterns:
 
     @pytest.mark.parametrize(
         "included_endpoint_path",
-        AUDIT_API_ENDPOINT_PATHS,
+        AUDIT_API_ENDPOINT_PATHS + GENERIC_PERMISSION_SET_PATHS,
     )
     def test_cms_admin_mode_returns_all_expected_urls(
         self, included_endpoint_path: str
@@ -392,7 +406,8 @@ class TestConstructUrlpatterns:
         "excluded_endpoint_path",
         PRIVATE_API_ENDPOINT_PATHS
         + PUBLIC_API_ENDPOINT_PATHS
-        + FEEDBACK_API_ENDPOINT_PATHS,
+        + FEEDBACK_API_ENDPOINT_PATHS
+        + PERMISSION_SET_PATHS,
     )
     def test_cms_admin_mode_does_not_return_other_urls(
         self, excluded_endpoint_path: str


### PR DESCRIPTION
# Description

- This PR splits the permission set url construction into two, one for generic information, and one for user specific data. This allows the CMS admin to have access to the themes endpoints, but not user specific information. 

- This fixes CDD-3433
---

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
