### PR TITLE
refactor: rename app-id to client-id as per warning

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -334,7 +334,7 @@ jobs:
         id: generate-deployment-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
-          app-id: ${{ secrets.DEPLOYMENT_TOKEN_FACTORY_APP_ID }}
+          client-id: ${{ secrets.DEPLOYMENT_TOKEN_FACTORY_APP_ID }}
           private-key: ${{ secrets.DEPLOYMENT_TOKEN_FACTORY_PRIVATE_KEY }}
           skip-token-revoke: false
           # Although this is the default, this is explicitly set so that


### PR DESCRIPTION
As per:

<img width="608" height="310" alt="image" src="https://github.com/user-attachments/assets/0d0e8516-758d-4194-aba8-85af0469d572" />