### PR TITLE
fix: remove dead max_length kwarg from APITimeSeries.metric_value

### DIFF
--- a/metrics/data/models/api_models.py
+++ b/metrics/data/models/api_models.py
@@ -41,7 +41,7 @@ class APITimeSeries(models.Model):
 
     date = models.DateField()
     force_write = models.BooleanField(default=False)
-    metric_value = models.FloatField(max_length=CHAR_COLUMN_MAX_CONSTRAINT)
+    metric_value = models.FloatField()
 
     is_public = models.BooleanField(default=True, null=False)
 

--- a/tests/unit/metrics/data/models/test_api_models.py
+++ b/tests/unit/metrics/data/models/test_api_models.py
@@ -68,7 +68,6 @@ class TestAPITimeSeries:
             ["metric", "COVID-19_deaths_ONSByDay", LARGE_CHAR_COLUMN_MAX_CONSTRAINT],
             ["stratum", "default", CHAR_COLUMN_MAX_CONSTRAINT],
             ["sex", "all", SEX_MAX_CHAR_CONSTRAINT],
-            ["metric_value", 0, CHAR_COLUMN_MAX_CONSTRAINT],
         ),
     )
     def test_correct_max_length_constraints_returned_from_model(


### PR DESCRIPTION
# Description

This PR includes the following:

- Removes a dead `max_length` argument from the `APITimeSeries.metric_value` field.
- Removes the corresponding unit-test parametrize row that locked in and asserted the (non-existent) `max_length` attribute on that field.

`metric_value` was declared as:

```python
metric_value = models.FloatField(max_length=CHAR_COLUMN_MAX_CONSTRAINT)
```

Django's `FloatField` silently ignores `max_length` — the argument is only honoured on character-based fields (`CharField`, `TextField`). At the database layer this column has always been a plain `double precision` (PostgreSQL) / `real` (SQLite) with no length constraint.

Evidence that the argument was cargo-culted rather than intentional can be seen in the historical migrations: the value drifted from `30` to `50` across:

- `metrics/data/migrations/0001_initial.py:34` — `FloatField(max_length=30)`
- `metrics/data/migrations/0003_increase_char_field_max_constraints.py:65` — `FloatField(max_length=50)`

…without triggering any actual schema change for this column on either bump. Removing the dead argument reduces technical debt and prevents future maintainers from being misled into believing the column is length-constrained.

Fixes #CDD-3239

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

*Note: Both items are selected as this change removes a misleading parameter declaration (tech debt) while updating an over-assertive unit test (bug fix).*

---

# Checklist:

- I have commented my code, particularly in hard-to-understand areas (N/A — change is a single-line removal; rationale is captured in this PR description)
- I have made corresponding changes to the documentation (N/A — no behavioural change)
- I have added tests at the right levels to prove my change is effective (the existing parametrize test was the one asserting the dead `max_length`; it has been updated)
- I have added screenshots or screen grabs where appropriate (N/A — no UI change)
- I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) (N/A — no new functions/classes)

## Verification

- **Migrations:** `python manage.py makemigrations --check` reports no changes, confirming no schema migration is required.
- **Unit tests:** All 30 tests in `tests/unit/metrics/data/models/test_api_models.py` pass.
- **Full unit suite:** 2927 tests pass. 17 pre-existing errors in `tests/unit/cms/auth_content/test_wagtail_hooks.py` (13) and `tests/unit/cms/snippets/managers/test_menu.py` (4) were verified to be present on a clean `main` branch (confirmed via `git stash`) and are unrelated to this change.