### PR TITLE
build: upgrade django to 5.2.15

### DIFF
--- a/requirements-prod-ingestion.txt
+++ b/requirements-prod-ingestion.txt
@@ -1,7 +1,7 @@
 asgiref==3.11.1
 boto3==1.34.68
 botocore==1.34.109
-Django==5.2.14
+Django==5.2.15
 psycopg2-binary==2.9.12
 pydantic==2.13.4
 python-dotenv==1.2.2


### PR DESCRIPTION
This PR upgrades Django to 5.2.14 to 5.2.15. This is to solve the pipeline issues sentry has caught which you can see for example [here](https://github.com/UKHSA-Internal/data-dashboard-api/actions/runs/27119695138/job/80033909114?pr=3240).

Also, the fact that the django dependency is specified in the ingestion requirements file is 🤢 but we haven't got to tidying these up yet so we will live with it and just have a little cry instead.