### PR TITLE
chore: stop the build from being dependant on a successfuly secrets scan

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -42,7 +42,6 @@ jobs:
 
   build:
     name: Build
-    needs: [secret-scan]
     runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd


### PR DESCRIPTION
With this in place, nothing runs unless the secret scan works. Can't really see a reason why this would be necessary tbh. Noted when running a PR from an external which means the gitleaks step fails (can't use the secret) but all the other steps are just skipped: https://github.com/UKHSA-Internal/data-dashboard-api/actions/runs/27132966145.