### PR TITLE
chore: load editor pages with sections collapsed

### DIFF
--- a/cms/dynamic_content/access.py
+++ b/cms/dynamic_content/access.py
@@ -13,6 +13,7 @@ ALLOWABLE_BODY_CONTENT = StreamField(
         ("section", sections.Section()),
     ],
     use_json_field=True,
+    collapsed=True,
 )
 
 ALLOWABLE_BODY_CONTENT_SECTION_LINK = StreamField(
@@ -20,6 +21,7 @@ ALLOWABLE_BODY_CONTENT_SECTION_LINK = StreamField(
         ("section", sections.SectionWithLink()),
     ],
     use_json_field=True,
+    collapsed=True,
 )
 
 ALLOWABLE_BODY_CONTENT_TEXT_SECTION = StreamField(
@@ -27,6 +29,7 @@ ALLOWABLE_BODY_CONTENT_TEXT_SECTION = StreamField(
         ("section", sections.TextSection()),
     ],
     use_json_field=True,
+    collapsed=True,
 )
 
 ALLOWABLE_BODY_CONTENT_COMPOSITE = StreamField(
@@ -70,4 +73,5 @@ ALLOWABLE_BODY_CONTENT_COMPOSITE = StreamField(
         ),
     ],
     use_json_field=True,
+    collapsed=True,
 )

--- a/cms/dynamic_content/sections.py
+++ b/cms/dynamic_content/sections.py
@@ -29,6 +29,9 @@ class ContentCards(StreamBlock):
         help_text=help_texts.FILTER_LINKED_TIME_SERIES_CHART_TEMPLATE,
     )
 
+    class Meta:
+        collapsed = True
+
 
 class FooterCardsSectionWithLink(StreamBlock):
     section_link = blocks.SectionFooterLink(max_num=1)
@@ -40,6 +43,9 @@ class ContentCardsSectionWithLink(StreamBlock):
     headline_numbers_row_card = cards.HeadlineNumbersRowCard()
     weather_health_alert_card = cards.WeatherHealthAlertsCard()
     popular_topics_card = cards.PopularTopicsCard()
+
+    class Meta:
+        collapsed = True
 
 
 class Section(StructBlock):


### PR DESCRIPTION
DPD have reported some performance issues in the cms editor pages which seems to be most likely caused by the sheer size of some of the pages (in terms of html components present). This commit sets `collapse=True` on a number of key blocks in order to help the initial page render on slower devices. This applies to pretty much all content on the site and hopefully also makes it easier to manage the pages as they are less overwhelming on load - this needs to be validated though.

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
