### PR TITLE
fix: resolve circular import from common using ingestion metrics interface

### DIFF
--- a/common/auth/permissions.py
+++ b/common/auth/permissions.py
@@ -1,6 +1,6 @@
 from typing import TypedDict
 
-from ingestion.metrics_interface.interface import MetricsAPIInterface
+from common.metrics_interface.interface import MetricsAPIInterface
 
 WILDCARD_ID_VALUE = "-1"
 

--- a/common/metrics_interface/interface.py
+++ b/common/metrics_interface/interface.py
@@ -1,0 +1,19 @@
+from metrics.data.models import core_models
+
+
+class MetricsAPIInterface:
+    @staticmethod
+    def get_topic_manager():
+        return core_models.Topic.objects
+
+    @staticmethod
+    def get_metric_manager():
+        return core_models.Metric.objects
+
+    @staticmethod
+    def get_geography_type_manager():
+        return core_models.GeographyType.objects
+
+    @staticmethod
+    def get_geography_manager():
+        return core_models.Geography.objects


### PR DESCRIPTION
The ingestion process is broken on a circular import which I believe originates because the common permissions module is using the ingestion metrics interface when it should have its own one.

The error is:
```
[ERROR] Runtime.ImportModuleError: Unable to import module 'ingestion.operations.lambda_entrypoint': cannot import name 'MetricsAPIInterface' from partially initialized module 'ingestion.metrics_interface.interface' (most likely due to a circular import) (/var/task/ingestion/metrics_interface/interface.py)
```

which I think is because of this chain of imports.