### PR TITLE
build: update wagtail to fix high cve

### DIFF
--- a/requirements-prod.txt
+++ b/requirements-prod.txt
@@ -84,7 +84,7 @@ typing_extensions==4.15.0
 uritemplate==4.2.0
 urllib3==2.7.0
 virtualenv==21.5.0
-wagtail==7.3.2
+wagtail==7.3.3
 wagtail_trash==3.2.0
 wagtail_modeladmin==2.3.0
 webencodings==0.5.1


### PR DESCRIPTION
We have a wagtail PR upgrade already in the works for 7.4.x but I haven't tested it enough yet to be happy merging it, this is just a patch release upgrade to solve the pipeline being blocked (e.g. https://github.com/UKHSA-Internal/data-dashboard-api/actions/runs/28772026788/job/85307667250?pr=3274).