### PR TITLE
fix: use correct module path for preview middleware

### DIFF
--- a/metrics/api/settings/public_api.py
+++ b/metrics/api/settings/public_api.py
@@ -18,6 +18,6 @@ if AUTH_ENABLED:
         "django.contrib.auth.middleware.AuthenticationMiddleware",
         "django.contrib.messages.middleware.MessageMiddleware",
         "django.middleware.clickjacking.XFrameOptionsMiddleware",
-        "metrics.api.middleware.EmbargoMiddleware",
+        "metrics.api.middleware.preview.EmbargoMiddleware",
         "public_api.middleware.NoIndexNoFollowMiddleware",  # Add noindex, nofollow robots-tag middleware for non-public
     ]


### PR DESCRIPTION
Changes `metrics.api.middleware.EmbargoMiddleware` -> `metrics.api.middleware.preview.EmbargoMiddleware`. Noticed when deploying a local env and the public API containers failed to restart.
