### PR TITLE
Fix failing tests when auth_enabled is set

### DIFF
--- a/tests/unit/metrics/interfaces/headlines/test_access.py
+++ b/tests/unit/metrics/interfaces/headlines/test_access.py
@@ -47,7 +47,7 @@ class TestHeadlinesInterface:
         # Then
         assert headlines_interface.core_headline_manager == CoreHeadline.objects
 
-    def test_get_metric_value_calls_core_time_series_manager_with_correct_args(
+    def test_get_metric_value_calls_core_headline_manager_with_correct_args(
         self, example_headline_args: dict[str, str]
     ):
         """

--- a/tests/unit/public_api/test_urls.py
+++ b/tests/unit/public_api/test_urls.py
@@ -1,13 +1,33 @@
 import pytest
+from unittest import mock
 
 from public_api import construct_url_patterns_for_public_api
+from public_api.metrics_interface.interface import MetricsPublicAPIInterface
 
 
 class TestConstructUrlPatternsForPublicAPI:
     @pytest.mark.parametrize(
-        "prefix", ["api/example/prefix/", "api/example/", "api/public/"]
+        ("prefix", "auth_enabled"),
+        [
+            pytest.param("api/example/prefix/", False, id="api/example/prefix/"),
+            pytest.param("api/example/", False, id="api/example/"),
+            pytest.param("api/public/", False, id="api/public/"),
+            pytest.param("api/example/prefix/v2", False, id="api/example/prefix/v2"),
+            pytest.param("api/example/v1", False, id="api/example/v1"),
+            pytest.param("api/public/v2", False, id="api/public/v2"),
+            pytest.param(
+                "api/example/prefix/", True, id="api/example/prefix/-auth_enabled"
+            ),
+            pytest.param("api/example/", True, id="api/example/-auth_enabled"),
+            pytest.param("api/public/", True, id="api/public/-auth_enabled"),
+            pytest.param(
+                "api/example/prefix/v2", True, id="api/example/prefix/v2-auth_enabled"
+            ),
+            pytest.param("api/example/v1", True, id="api/example/v1-auth_enabled"),
+            pytest.param("api/public/v2", True, id="api/public/v2-auth_enabled"),
+        ],
     )
-    def test_sets_prefix_on_urls(self, prefix: str):
+    def test_sets_prefix_on_urls(self, prefix: str, auth_enabled: bool):
         """
         Given a prefix to prepend to the constructed urlpatterns
         When `construct_urlpatterns_for_public_api()` is called
@@ -17,27 +37,19 @@ class TestConstructUrlPatternsForPublicAPI:
         api_prefix = prefix
 
         # When
-        urlpatterns = construct_url_patterns_for_public_api(prefix=api_prefix)
+        with mock.patch.object(
+            MetricsPublicAPIInterface,
+            "is_auth_enabled",
+            return_value=auth_enabled,
+        ):
+            urlpatterns = construct_url_patterns_for_public_api(prefix=api_prefix)
 
-        # Then
-        assert all(
-            prefix in urlpattern.pattern.regex.pattern for urlpattern in urlpatterns
-        )
-
-    @pytest.mark.parametrize(
-        "prefix", ["api/example/prefix/v2", "api/example/v1", "api/public/v2"]
-    )
-    def test_sets_prefix_on_urls(self, prefix: str):
-        """
-        Given a prefix to prepend to the constructed urlpatterns
-        When `construct_urlpatterns_for_public_api()` is called
-        Then the prefix is added to the returned urlpatterns
-        """
-        # Given
-        api_prefix = prefix
-
-        # When
-        urlpatterns = construct_url_patterns_for_public_api(prefix=api_prefix)
+        if auth_enabled:
+            urlpatterns = [
+                urlpattern
+                for urlpattern in urlpatterns
+                if "robots.txt" not in urlpattern.pattern.describe()
+            ]
 
         # Then
         assert all(


### PR DESCRIPTION
# Description

This PR includes the following:

rename timeseries test that tests headlines
Combine 2 tests with duplicate names (so one has been being silently ignored)
Parametrize auth_enabled flag.