### PR TITLE
Allow tests to run without needing a .env file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,9 @@ exclude = '''
 # This is needed to point pytest at the settings.py file for the django app
 DJANGO_SETTINGS_MODULE = "metrics.api.settings"
 addopts = "--random-order"
+env = [
+	 "APIENV=LOCAL",
+]
 
 ########################################################################################################################
 # Test coverage configuration

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ pylint-django==2.7.0
 pytest==9.0.3
 pytest-cov==7.1.0
 pytest-django==4.12.0
+pytest-env==1.7.0
 pytest-random-order==1.2.0
 pytest-responses==0.6.0
 ruff==0.15.20


### PR DESCRIPTION
# Description

Allows tests to run in a freshly checkout out repo without needing to create a `.env` file.