### PR TITLE
build: update gitpython from 3.1.50 -> 3.1.55

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ factory-boy==3.3.3
 freezegun==1.5.5
 Faker==40.19.1
 gitdb==4.0.12
-GitPython==3.1.50
+GitPython==3.1.55
 import-linter==2.11
 isort==8.0.1
 pip-api==0.0.34


### PR DESCRIPTION
This resolves the pipeline breaking for dependency issues. Technically we only need to go to 3.1.52 but might as well get the latest as it looks like a safe release.