### PR TITLE
CDD-3506: streamline sql calls in get pages

### DIFF
--- a/cms/dashboard/viewsets.py
+++ b/cms/dashboard/viewsets.py
@@ -97,21 +97,38 @@ class BaseCMSPagesAPIViewSet(PagesAPIViewSet):
             else:
                 user_permissions = req.user.permission_sets["permission_sets"]
                 pages_to_check = chain(
-                    ((page.id, page.topicpage) for page in queryset.type(TopicPage)),
                     (
-                        (page.id, page.metricsdocumentationchildentry)
-                        for page in queryset.type(MetricsDocumentationChildEntry)
+                        {k.split("__")[-1]: v for k, v in page.items()}
+                        for page in queryset.type(TopicPage).values(
+                            "id",
+                            "topicpage__theme",
+                            "topicpage__sub_theme",
+                            "topicpage__topic",
+                            "topicpage__is_public",
+                        )
+                    ),
+                    (
+                        {k.split("__")[-1]: v for k, v in page.items()}
+                        for page in queryset.type(
+                            MetricsDocumentationChildEntry
+                        ).values(
+                            "id",
+                            "metricsdocumentationchildentry__theme",
+                            "metricsdocumentationchildentry__sub_theme",
+                            "metricsdocumentationchildentry__topic",
+                            "metricsdocumentationchildentry__is_public",
+                        )
                     ),
                 )
                 permitted_page_ids = [
-                    page_id
-                    for page_id, page in pages_to_check
-                    if page.is_public
+                    page["id"]
+                    for page in pages_to_check
+                    if page["is_public"]
                     or check_page_permissions(
                         permission_sets=user_permissions,
-                        theme_id=page.theme,
-                        sub_theme_id=page.sub_theme,
-                        topic_id=page.topic,
+                        theme_id=page["theme"],
+                        sub_theme_id=page["sub_theme"],
+                        topic_id=page["topic"],
                     )
                 ]
 


### PR DESCRIPTION
# Description

This PR includes the following:

- use `.values()` on the queryset to create a list of dicts instead of page objects with just the fields we need. This prevents extra DB calls to populate fields and properties on the page objects that we don't need.
- profiled before and after using Django Silk:
  - Before:  739ms on queries, 276 queries
  - After:  59ms on queries, 40 queries

Fixes #CDD-3506

---

## Type of change

Please select the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
