### PR TITLE
Fix for flakey test in test_api_time_series_request_serializer

### DIFF
--- a/tests/unit/public_api/serializers/test_api_time_series_request_serializer.py
+++ b/tests/unit/public_api/serializers/test_api_time_series_request_serializer.py
@@ -112,11 +112,7 @@ class TestAPITimeSeriesRequestSerializer:
         value_dynamically_set_on_dto = getattr(api_timeseries_dto, lookup_field)
         assert value_dynamically_set_on_dto == value_returned_from_query
 
-    @mock.patch.object(APITimeSeries.objects, "get_distinct_column_values_with_filters")
-    def test_get_queryset_delegates_call_to_the_api_timeseries_model_manager(
-        self,
-        spy_get_distinct_column_values_with_filters: mock.MagicMock,
-    ):
+    def test_get_queryset_delegates_call_to_the_api_timeseries_model_manager(self):
         """
         Given a request which contains kwargs from the URL parameters
         And a `lookup_field` also provided in the context of the serializer
@@ -127,20 +123,28 @@ class TestAPITimeSeriesRequestSerializer:
         fake_request_kwargs = {"theme": "infectious_disease"}
         fake_lookup_field = "theme"
         mocked_request = mock.Mock(parser_context={"kwargs": fake_request_kwargs})
+        api_time_series_manager_spy = mock.Mock()
         serializer = APITimeSeriesRequestSerializer(
-            context={"request": mocked_request, "lookup_field": fake_lookup_field}
+            context={
+                "request": mocked_request,
+                "lookup_field": fake_lookup_field,
+                "api_time_series_manager": api_time_series_manager_spy,
+            }
         )
 
         # When
         queryset = serializer.get_queryset()
 
         # Then
-        spy_get_distinct_column_values_with_filters.assert_called_once_with(
+        api_time_series_manager_spy.get_distinct_column_values_with_filters.assert_called_once_with(
             lookup_field=fake_lookup_field,
             restrict_to_public=True,
             **fake_request_kwargs,
         )
-        assert queryset == spy_get_distinct_column_values_with_filters.return_value
+        assert (
+            queryset
+            == api_time_series_manager_spy.get_distinct_column_values_with_filters.return_value
+        )
 
     def test_get_timeseries_dto_slice_returns_list_of_dto_objects_for_theme_lookup(
         self,


### PR DESCRIPTION
Change the mock usage change for test_get_queryset_delegates_call_to_the_api_timeseries_model_manager - original implementation sometimes called through to the concrete implementation to be used instead of the mock

# Description

This PR includes the following:

-

Fixes #CDD-<ISSUE_ID>

---

## Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Tech debt item (this is focused solely on addressing any relevant technical debt)

---

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests at the right levels to prove my change is effective
- [ ] I have added screenshots or screen grabs where appropriate
- [ ] I have added docstrings in the correct style [(google)](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
